### PR TITLE
♻️ vue-dot: Use sync modifier for options props in PaginatedTable

### DIFF
--- a/packages/vue-dot/playground/examples/PaginatedTableEx.vue
+++ b/packages/vue-dot/playground/examples/PaginatedTableEx.vue
@@ -11,11 +11,11 @@
 		<PaginatedTable
 			:headers="headers"
 			:items="desserts"
-			:options="options"
+			:options.sync="options"
 			:server-items-length="totalDesserts"
 			:loading="loading"
 			class="vd-table elevation-1"
-			@pagination:updated="options = $event; fetchData()"
+			@update:options="fetchData"
 		>
 			<template #items="props">
 				<td>{{ props.item.name }}</td>

--- a/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
+++ b/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
@@ -101,7 +101,7 @@
 				this.localOptions = {};
 			}
 
-			this.$emit('pagination:updated', value);
+			this.$emit('update:options', value);
 		}
 
 		/** Local storage id */


### PR DESCRIPTION
Use sync modifier to avoid typing `options = $event` and rename the event `pagination:updated` to `update:options`.