### PR TITLE
⬆️ vue-dot: Upgrade vue-test-utils

### DIFF
--- a/packages/vue-dot/package.json
+++ b/packages/vue-dot/package.json
@@ -54,7 +54,7 @@
 		"@vue/cli-plugin-typescript": "^4.1.1",
 		"@vue/cli-plugin-unit-jest": "^4.1.1",
 		"@vue/cli-service": "^4.1.1",
-		"@vue/test-utils": "1.0.0-beta.29",
+		"@vue/test-utils": "1.0.0-beta.30",
 		"babel-core": "7.0.0-bridge.0",
 		"core-js": "^3.4.8",
 		"json-to-scss": "^1.4.0",

--- a/packages/vue-dot/src/patterns/DatePicker/tests/__snapshots__/DatePicker.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/__snapshots__/DatePicker.spec.ts.snap
@@ -9,7 +9,11 @@ exports[`DatePicker renders correctly 1`] = `
         <div class="v-text-field__slot"><label for="input-4" class="v-label theme--light" style="left: 0px; position: absolute;">Date</label><input id="input-4" type="text"></div>
       </div>
       <div class="v-text-field__details">
-        <div class="v-messages theme--light"><span name="message-transition" tag="div" class="v-messages__wrapper"><div class="v-messages__message">Format JJ/MM/AAAA</div></span></div>
+        <div class="v-messages theme--light">
+          <div class="v-messages__wrapper">
+            <div class="v-messages__message">Format JJ/MM/AAAA</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/vue-dot/src/patterns/DatePicker/tests/birthdate.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/birthdate.spec.ts
@@ -91,7 +91,9 @@ describe('birthdate', () => {
 
 		wrapper.vm.menu = true;
 
-		expect(spy).toHaveBeenCalled();
+		wrapper.vm.$nextTick(() => {
+			expect(spy).toHaveBeenCalled();
+		});
 	});
 
 	it('calls setActivePicker in watch when menu goes from true to false', () => {
@@ -100,7 +102,9 @@ describe('birthdate', () => {
 
 		wrapper.vm.menu = false;
 
-		expect(spy).toHaveBeenCalled();
+		wrapper.vm.$nextTick(() => {
+			expect(spy).toHaveBeenCalled();
+		});
 	});
 
 	it('updates the active picker when setActivePicker is called', () => {

--- a/packages/vue-dot/src/patterns/DatePicker/tests/dateLogic.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/dateLogic.spec.ts
@@ -223,7 +223,9 @@ describe('dateLogic', () => {
 
 		wrapper.vm.$refs.input.hasError = true;
 
-		expect(wrapper.emitted('error')).toBeTruthy();
+		wrapper.vm.$nextTick(() => {
+			expect(wrapper.emitted('error')).toBeTruthy();
+		});
 	});
 
 	// dateFormatted

--- a/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
@@ -33,8 +33,7 @@ describe('UploadWorkflow', () => {
 			},
 			propsData: {
 				value: files
-			},
-			sync: false
+			}
 		});
 
 		expect(html(wrapper)).toMatchSnapshot();
@@ -49,8 +48,7 @@ describe('UploadWorkflow', () => {
 			},
 			propsData: {
 				value: [files[0]]
-			},
-			sync: false
+			}
 		});
 
 		expect(html(wrapper)).toMatchSnapshot();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,13 +2272,14 @@
   resolved "https://registry.yarnpkg.com/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.1.tgz#18723530d304f443021da2292d6ec9502826104a"
   integrity sha512-8VCoJeeH8tCkzhkpfOkt+abALQkS11OIHhte5MBzYaKMTqK0A3ZAKEUVAffsOklhEv7t0yrQt696Opnu9oAx+w==
 
-"@vue/test-utils@1.0.0-beta.29":
-  version "1.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.29.tgz#c942cf25e891cf081b6a03332b4ae1ef430726f0"
-  integrity sha512-yX4sxEIHh4M9yAbLA/ikpEnGKMNBCnoX98xE1RwxfhQVcn0MaXNSj1Qmac+ZydTj6VBSEVukchBogXBTwc+9iA==
+"@vue/test-utils@1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.30.tgz#d5f26d1e2411fdb7fa7fdedb61b4b4ea4194c49d"
+  integrity sha512-Wyvcha9fNk8+kzTDwb3xWGjPkCPzHSYSwKP6MplrPTG/auhqoad7JqUEceZLc6u7AU4km2pPQ8/m9s0RgCZ0NA==
   dependencies:
     dom-event-types "^1.0.0"
-    lodash "^4.17.4"
+    lodash "^4.17.15"
+    pretty "^2.0.0"
 
 "@vue/web-component-wrapper@^1.2.0":
   version "1.2.0"
@@ -10496,7 +10497,7 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty@2.0.0:
+pretty@2.0.0, pretty@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
   integrity sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=


### PR DESCRIPTION
Vue test utils version 1.0.0-bata.30 introduced [breaking changes](https://github.com/vuejs/vue-test-utils/blob/dev/CHANGELOG.md#100-beta30-2019-11-28) so we needed to update our tests!