### PR TITLE
🏷️ vue-dot: Make prop types stronger

### DIFF
--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -55,14 +55,16 @@
 </template>
 
 <script lang="ts">
-	import Vue from 'vue';
+	import Vue, { PropType } from 'vue';
 	import Component from 'vue-class-component';
+
+	import { ListItem } from './types';
 
 	const Props = Vue.extend({
 		props: {
 			/** The list to display */
 			list: {
-				type: [Array, Object],
+				type: Array as PropType<ListItem[]>,
 				required: true
 			},
 			// Title options

--- a/packages/vue-dot/src/elements/DataList/types.d.ts
+++ b/packages/vue-dot/src/elements/DataList/types.d.ts
@@ -1,0 +1,4 @@
+export interface ListItem {
+	key: string;
+	value?: string;
+}

--- a/packages/vue-dot/src/mixins/warningRules/index.ts
+++ b/packages/vue-dot/src/mixins/warningRules/index.ts
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
 import Component from 'vue-class-component';
 
 import { ValidationRule } from '../../rules/types';
@@ -7,7 +7,7 @@ const Props = Vue.extend({
 	props: {
 		/** An array of rules (same syntax as Vuetify ones) */
 		warningRules: {
-			type: [Array, Object],
+			type: Array as PropType<ValidationRule[]>,
 			default: () => []
 		}
 	}
@@ -19,8 +19,6 @@ const Props = Vue.extend({
  */
 @Component
 export default class WarningRules extends Props {
-	warningRules!: ValidationRule[];
-
 	/**
 	 * The messages from warningRules.
 	 * Not used if already passed as a prop*

--- a/packages/vue-dot/src/patterns/FileList/FileList.vue
+++ b/packages/vue-dot/src/patterns/FileList/FileList.vue
@@ -92,7 +92,7 @@
 </template>
 
 <script lang="ts">
-	import Vue from 'vue';
+	import Vue, { PropType } from 'vue';
 	import Component from 'vue-class-component';
 
 	import config from './config';
@@ -118,7 +118,7 @@
 			},
 			/** The list of files to display */
 			files: {
-				type: [Array, Object],
+				type: Array as PropType<FileItem[]>,
 				required: true
 			},
 			hideListDivider: {
@@ -138,9 +138,6 @@
 	export default class FileList extends Props {
 		// Mixin computed data
 		options!: Options;
-
-		// Stronger types
-		files!: FileItem[];
 
 		// Icons
 		refreshIcon = mdiRefresh;

--- a/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
+++ b/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script lang="ts">
-	import Vue from 'vue';
+	import Vue, { PropType } from 'vue';
 	import Component from 'vue-class-component';
 
 	import locales from './locales';
@@ -148,7 +148,7 @@
 			},
 			/** The size units used in the template for i18n */
 			fileSizeUnits: {
-				type: [Array, Object],
+				type: Array as PropType<string[]>,
 				default: () => [
 					'o',
 					'Ko',
@@ -159,7 +159,7 @@
 			},
 			/** The allowed file extensions */
 			allowedExtensions: {
-				type: [Array, Object],
+				type: Array as PropType<string[]>,
 				default: () => [
 					'pdf',
 					'jpg',

--- a/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
+++ b/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
@@ -71,12 +71,12 @@
 </template>
 
 <script lang="ts">
-	import Vue from 'vue';
+	import Vue, { PropType } from 'vue';
 	import Component from 'vue-class-component';
 
 	import config from './config';
 	import locales from './locales';
-	import { Languages } from './types';
+	import { Languages, AllLanguagesChar } from './types';
 
 	// ISO 639-1 language database in a JSON object
 	import languages from 'languages';
@@ -92,7 +92,7 @@
 			 * by default it's all (*)
 			 */
 			availableLanguages: {
-				type: [Array, Object, String],
+				type: [Array, String] as PropType<string[] | AllLanguagesChar>,
 				default: '*'
 			},
 			/** Show the down arrow inside the activator button */

--- a/packages/vue-dot/src/patterns/LangBtn/types.d.ts
+++ b/packages/vue-dot/src/patterns/LangBtn/types.d.ts
@@ -8,3 +8,5 @@ export interface Languages {
 	// 'key' is the code of the language
 	[key: string]: Language;
 }
+
+export type AllLanguagesChar = '*';

--- a/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
+++ b/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-	import Vue from 'vue';
+	import Vue, { PropType } from 'vue';
 	import Component from 'vue-class-component';
 
 	import { Options } from './types';
@@ -38,7 +38,7 @@
 		props: {
 			// Props from Vuetify
 			options: {
-				type: [Array, Object],
+				type: Object as PropType<Options>,
 				required: true
 			},
 			serverItemsLength: {

--- a/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
@@ -73,7 +73,7 @@
 </template>
 
 <script lang="ts">
-	import Vue from 'vue';
+	import Vue, { PropType } from 'vue';
 	import Component from 'vue-class-component';
 
 	import config from './config';
@@ -93,7 +93,7 @@
 		props: {
 			/** The v-model value (the list of files) */
 			value: {
-				type: [Array, Object],
+				type: Array as PropType<FileListItem[]>,
 				required: true
 			},
 			/** The main title */
@@ -148,9 +148,6 @@
 	export default class UploadWorkflow extends Props {
 		// Mixin computed data
 		options!: Options;
-
-		// Stronger types
-		value!: FileListItem[];
 
 		// Extend $refs
 		$refs!: Refs<{


### PR DESCRIPTION
Use [tip from vue-typescript-cookbook](https://github.com/ffxsam/vue-typescript-cookbook#when-i-use-an-array-prop-type-my-components-properties-data-computed-properties-etc-are-shown-as-type-errors) to make prop types stronger