### PR TITLE
♻️ vue-dot: Refactor PaginatedTable to use LocalStorageUtility

### DIFF
--- a/packages/vue-dot/playground/Playground.vue
+++ b/packages/vue-dot/playground/Playground.vue
@@ -76,10 +76,11 @@
 
 	import { version } from '../package.json';
 
-	const DARK_THEME_KEY = 'pg-dark';
-	const STORAGE_VERSION = 1;
+	import { LOCAL_STORAGE_CONTROL } from './plugins/vue-dot';
 
 	import LocalStorageUtility from '../src/helpers/localStorageUtility';
+
+	const DARK_THEME_KEY = 'pg-dark';
 
 	/**
 	 * Playground is a component that contains examples
@@ -89,7 +90,7 @@
 	export default class Playground extends Vue {
 		version = version;
 
-		localStorageUtility = new LocalStorageUtility(STORAGE_VERSION);
+		localStorageUtility = new LocalStorageUtility(LOCAL_STORAGE_CONTROL.version);
 
 		updateTheme() {
 			this.$vuetify.theme.dark = !this.$vuetify.theme.dark;

--- a/packages/vue-dot/playground/plugins/vue-dot.ts
+++ b/packages/vue-dot/playground/plugins/vue-dot.ts
@@ -15,8 +15,13 @@ import '../theme/theme.scss';
 import VueTheMask from 'vue-the-mask';
 Vue.use(VueTheMask);
 
+export const LOCAL_STORAGE_CONTROL = {
+	version: 1
+};
+
 Vue.use(VueDot, {
 	theme: {
 		icons
-	}
+	},
+	localStorageControl: LOCAL_STORAGE_CONTROL
 });

--- a/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
+++ b/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
@@ -34,6 +34,8 @@
 
 	import { Options } from './types';
 
+	import LocalStorageUtility from '../../helpers/localStorageUtility';
+
 	const Props = Vue.extend({
 		props: {
 			// Props from Vuetify
@@ -45,10 +47,10 @@
 				type: Number,
 				required: true
 			},
-			// The prefix is used to store different pagination objects
+			// The suffix is used to store different pagination objects
 			// If the user has two tables but isn't using this prop,
 			// the tables will share the same saved pagination object
-			prefix: {
+			suffix: {
 				type: String,
 				default: ''
 			}
@@ -65,21 +67,37 @@
 			/** When the options object is updated */
 			options() {
 				// Save it to local storage
-				localStorage.setItem(
-					'vd-pagination' + this.id,
-					// Local storage only accepts strings,
-					// so we must use JSON.stringify
-					JSON.stringify(this.options)
-				);
+				this.localStorageUtility.setItem(this.storageKey, this.options);
 			}
 		}
 	})
 	export default class PaginatedTable extends Props {
+		localStorageUtility = this.newLocalStorageInstance();
+
 		/**
 		 * Local pagination
 		 * This is the pagination from local storage
 		 */
 		localOptions: Options | {} = {};
+
+		/**
+		 * Create a LocalStorageUtility instance
+		 * with version, expiration & prefix
+		 * from Vue Dot options
+		 *
+		 * @returns {LocalStorageUtility} New instance
+		 */
+		newLocalStorageInstance() {
+			if (!this.$vd || !this.$vd.localStorageControl) {
+				return new LocalStorageUtility();
+			}
+
+			return new LocalStorageUtility(
+				this.$vd.localStorageControl.version,
+				this.$vd.localStorageControl.expiration,
+				this.$vd.localStorageControl.prefix
+			);
+		}
 
 		/**
 		 * Returns either the local storage options,
@@ -104,25 +122,24 @@
 			this.$emit('update:options', value);
 		}
 
-		/** Local storage id */
-		get id() {
-			// If there is a prefix
-			if (this.prefix) {
-				// Add a dash before it, to make the key
+		/** Local storage key */
+		get storageKey() {
+			const prefix = 'pagination';
+
+			// If there is a suffix
+			if (this.suffix) {
+				// Add a dash before it to make the key
 				// more readable in local storage
-				return '-' + this.prefix;
+				return `${prefix}-${this.suffix}`;
 			}
 
-			// else, return an empty string
-			return '';
+			// else, return only the prefix
+			return prefix;
 		}
 
 		/** Retrieve the options from local storage */
 		created() {
-			this.localOptions = JSON.parse(
-				// Default to empty object
-				localStorage.getItem('vd-pagination' + this.id) || '{}'
-			);
+			this.localOptions = this.localStorageUtility.getItem(this.storageKey) || {};
 		}
 	}
 </script>

--- a/packages/vue-dot/types/index.d.ts
+++ b/packages/vue-dot/types/index.d.ts
@@ -11,8 +11,15 @@ export interface Theme {
 	icons: Icons;
 }
 
+export interface LocalStorageControl {
+	version?: number;
+	expiration?: number;
+	prefix?: string;
+}
+
 export interface VueDotOptions {
 	theme?: Theme;
+	localStorageControl: LocalStorageControl;
 }
 
 export interface VueDotPlugin {


### PR DESCRIPTION
Use LocalStorageUtility in PaginatedTable to have proper cache management.

### API Changes

- The `prefix` property on `PaginatedTable` was renamed to `suffix`

### Configuring the LocalStorageUtility instance

To configure the instance, pass the object `localStorageControl` in Vue Dot options as following:

```ts
export const LOCAL_STORAGE_CONTROL = {
	version: 1
};

Vue.use(VueDot, {
	localStorageControl: LOCAL_STORAGE_CONTROL
});
```

All parameters of `LocalStorageUtility` are supported (`version`, `expiration` and `prefix`).