### PR TITLE
♻️ vue-dot: Refactor CopyBtn

### DIFF
--- a/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
+++ b/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
@@ -1,32 +1,29 @@
 <template>
 	<div>
-		<VBtn
-			v-bind="options.btn"
-			:aria-label="label"
-			@click="copy"
-		>
-			<slot name="icon">
-				<VIcon>
-					{{ copyIcon }}
-				</VIcon>
-			</slot>
-		</VBtn>
-
-		<!--
-			The tooltip
-			We don't use the activator slot
-			because of problem with events
-		-->
-		<VTooltip
-			v-if="showTooltip"
+		<VMenu
 			v-model="tooltip"
-			v-bind="options.tooltip"
-			activator=".copy-tooltip-activator"
+			v-bind="options.menu"
+			:disabled="!showTooltip"
 		>
+			<template #activator="{ on }">
+				<VBtn
+					v-bind="options.btn"
+					:aria-label="label"
+					v-on="on"
+					@click="copy"
+				>
+					<slot name="icon">
+						<VIcon>
+							{{ copyIcon }}
+						</VIcon>
+					</slot>
+				</VBtn>
+			</template>
+
 			<slot name="tooltip">
 				{{ locales.tooltip }}
 			</slot>
-		</VTooltip>
+		</VMenu>
 	</div>
 </template>
 
@@ -82,7 +79,7 @@
 			customizable(config)
 		]
 	})
-	export default class Copy extends Props {
+	export default class CopyBtn extends Props {
 		// Mixin computed data
 		options!: Options;
 
@@ -95,26 +92,16 @@
 		/** Tooltip v-model */
 		tooltip = false;
 
-		/**
-		 * Show the tooltip then hide it after
-		 * tooltipDuration delay
-		 */
-		activateTooltip() {
-			this.tooltip = true;
-
-			setTimeout(() => {
-				this.tooltip = false;
-			}, this.tooltipDuration);
-		}
-
 		/** When the copy button is clicked */
 		copy() {
 			// Copy the text to the clipboard
 			copyToClipboard(this.textToCopy);
 
-			// Activate the tooltip if wanted
 			if (this.showTooltip) {
-				this.activateTooltip();
+				// Hide tooltip after tooltipDuration delay
+				setTimeout(() => {
+					this.tooltip = false;
+				}, this.tooltipDuration);
 			}
 		}
 	}

--- a/packages/vue-dot/src/elements/CopyBtn/config.ts
+++ b/packages/vue-dot/src/elements/CopyBtn/config.ts
@@ -1,13 +1,12 @@
 export default {
+	menu: {
+		offsetX: true,
+		zIndex: 8,
+		retainFocusOnClick: true,
+		contentClass: 'vd-copy-tooltip-menu white--text body-2 ml-2'
+	},
 	btn: {
 		icon: true,
-		class: 'grey--text text--darken-3 copy-tooltip-activator'
-	},
-	tooltip: {
-		/** By default, the tooltip is placed on the right */
-		right: true,
-		openOnClick: true,
-		openOnHover: false,
-		closeDelay: 2500
+		class: 'grey--text text--darken-3'
 	}
 };

--- a/packages/vue-dot/src/elements/CopyBtn/tests/__snapshots__/CopyBtn.spec.ts.snap
+++ b/packages/vue-dot/src/elements/CopyBtn/tests/__snapshots__/CopyBtn.spec.ts.snap
@@ -2,13 +2,8 @@
 
 exports[`CopyBtn renders correctly 1`] = `
 <div>
-  <vbtn-stub tag="button" activeclass="" icon="true" type="button" aria-label="test" class="grey--text text--darken-3 copy-tooltip-activator">
-    <vicon-stub>
-      M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z
-    </vicon-stub>
-  </vbtn-stub>
-  <vtooltip-stub opendelay="0" closedelay="2500" contentclass="" fixed="true" right="true" activator=".copy-tooltip-activator" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" tag="span">
+  <vmenu-stub opendelay="0" closedelay="0" contentclass="vd-copy-tooltip-menu white--text body-2 ml-2" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" zindex="8" closeonclick="true" closeoncontentclick="true" maxheight="auto" offsetx="true" origin="top left" transition="v-menu-transition" retainfocusonclick="true">
     Texte copié !
-  </vtooltip-stub>
+  </vmenu-stub>
 </div>
 `;

--- a/packages/vue-dot/src/styles/global.scss
+++ b/packages/vue-dot/src/styles/global.scss
@@ -2,13 +2,21 @@
 
 @import '../tokens';
 
-// Change the main color when a warning is present
 .v-application {
+	// Change the main color when a warning is present
 	.vd-warning-rules {
 		&.success--text,
 		.success--text {
 			color: $vd-warning !important;
 			caret-color: $vd-warning !important;
 		}
+	}
+
+	// Make the tooltip menu look like a tooltip
+	.vd-copy-tooltip-menu {
+		padding: 6px 16px;
+		box-shadow: none;
+		margin-top: 2px;
+		background: rgba(97, 97, 97, .9);
 	}
 }


### PR DESCRIPTION
Refactor CopyBtn by using a menu instead of a tooltip. This fits better our need because the tooltip is designed to display information on hover, but we need to display it on click.

This change fixes the hide/show bug, the component is now more stable and we finally can make have multiple instances on one page.