### PR TITLE
♻️ vue-dot: Refactor mixins declaration

### DIFF
--- a/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
+++ b/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
@@ -29,12 +29,12 @@
 
 <script lang="ts">
 	import Vue from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import config from './config';
 	import locales from './locales';
 
-	import customizable, { Options } from '../../mixins/customizable';
+	import customizable from '../../mixins/customizable';
 
 	import copyToClipboard from '../../functions/copyToClipboard';
 
@@ -69,25 +69,19 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props, customizable(config));
+
 	/**
 	 * CopyBtn is a component that copy text to the clipboard and
 	 * shows a tooltip
 	 */
-	@Component({
-		mixins: [
-			// Default configuration
-			customizable(config)
-		]
-	})
-	export default class CopyBtn extends Props {
-		// Mixin computed data
-		options!: Options;
+	@Component
+	export default class Copy extends MixinsDeclaration {
+		// Locales
+		locales = locales;
 
 		// Icon
 		copyIcon = mdiContentCopy;
-
-		// Locales
-		locales = locales;
 
 		/** Tooltip v-model */
 		tooltip = false;

--- a/packages/vue-dot/src/elements/CustomIcon/CustomIcon.vue
+++ b/packages/vue-dot/src/elements/CustomIcon/CustomIcon.vue
@@ -36,7 +36,7 @@
 
 <script lang="ts">
 	import Vue from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import { Icons, VueDotOptions } from '../../../types';
 
@@ -78,12 +78,14 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props);
+
 	/**
 	 * CustomIcon is a component that displays an SVG Icon
 	 * defined in the theme that is passed as an option of the plugin
 	 */
 	@Component
-	export default class CustomIcon extends Props {
+	export default class CustomIcon extends MixinsDeclaration {
 		get themeIcon(): string | undefined {
 			// If there are icons in the theme
 			if (this.$vd && this.$vd.theme && this.$vd.theme.icons) {

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -56,7 +56,7 @@
 
 <script lang="ts">
 	import Vue, { PropType } from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import locales from './locales';
 
@@ -112,12 +112,14 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props);
+
 	/**
 	 * DataList is a component that displays an array of
 	 * objects containing key/value
 	 */
 	@Component
-	export default class DataList extends Props {}
+	export default class DataList extends MixinsDeclaration {}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/vue-dot/src/mixins/eventable/index.ts
+++ b/packages/vue-dot/src/mixins/eventable/index.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Component from 'vue-class-component';
+import Component, { mixins } from 'vue-class-component';
 
 import { Options } from '../customizable';
 
@@ -21,9 +21,11 @@ const Props = Vue.extend({
 	}
 });
 
+const MixinsDeclaration = mixins(Props);
+
 /** Add event handling: week-ends and ranges */
 @Component
-export default class Eventable extends Props {
+export default class Eventable extends MixinsDeclaration {
 	// Mixin computed data
 	options!: Options;
 	/** DatePicker.date */

--- a/packages/vue-dot/src/mixins/warningRules/index.ts
+++ b/packages/vue-dot/src/mixins/warningRules/index.ts
@@ -1,5 +1,5 @@
 import Vue, { PropType } from 'vue';
-import Component from 'vue-class-component';
+import Component, { mixins } from 'vue-class-component';
 
 import { ValidationRule } from '../../rules/types';
 
@@ -13,12 +13,14 @@ const Props = Vue.extend({
 	}
 });
 
+const MixinsDeclaration = mixins(Props);
+
 /**
  * Add warning rules: same as Vuetify rules,
  * but that does not block validation
  */
 @Component
-export default class WarningRules extends Props {
+export default class WarningRules extends MixinsDeclaration {
 	/**
 	 * The messages from warningRules.
 	 * Not used if already passed as a prop*

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/birthdate.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/birthdate.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Component from 'vue-class-component';
+import Component, { mixins } from 'vue-class-component';
 
 import { Refs } from '../../../types';
 
@@ -13,6 +13,8 @@ const Props = Vue.extend({
 	}
 });
 
+const MixinsDeclaration = mixins(Props);
+
 /** Add birthdate prop: select year, month then day */
 @Component<Birthdate>({
 	watch: {
@@ -24,7 +26,7 @@ const Props = Vue.extend({
 		}
 	}
 })
-export default class Birthdate extends Props {
+export default class Birthdate extends MixinsDeclaration {
 	// Extend $refs
 	$refs!: Refs<{
 		picker: {

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Component from 'vue-class-component';
+import Component, { mixins } from 'vue-class-component';
 
 import dayjs from 'dayjs';
 
@@ -32,6 +32,8 @@ const Props = Vue.extend({
 		}
 	}
 });
+
+const MixinsDeclaration = mixins(Props);
 
 /** Handle main logic of the DatePicker */
 @Component<DateLogic>({
@@ -71,7 +73,7 @@ const Props = Vue.extend({
 		}
 	}
 })
-export default class DateLogic extends Props {
+export default class DateLogic extends MixinsDeclaration {
 	// Extend $refs
 	$refs!: Refs<{
 		/** VMenu */

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/errorProp.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/errorProp.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Component from 'vue-class-component';
+import Component, { mixins } from 'vue-class-component';
 
 const Props = Vue.extend({
 	props: {
@@ -11,9 +11,11 @@ const Props = Vue.extend({
 	}
 });
 
+const MixinsDeclaration = mixins(Props);
+
 /** Add error prop from Vuetify and bind it with .sync modifier */
 @Component
-export default class ErrorProp extends Props {
+export default class ErrorProp extends MixinsDeclaration {
 	/**
 	 * Use an internal model
 	 * so we don't modify the prop

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/maskValue.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/maskValue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Component from 'vue-class-component';
+import Component, { mixins } from 'vue-class-component';
 
 const Props = Vue.extend({
 	props: {
@@ -16,14 +16,16 @@ const Props = Vue.extend({
 	}
 });
 
-/** */
+const MixinsDeclaration = mixins(Props);
+
+/** Provides computed date format mask value */
 @Component
-export default class MaskValue extends Props {
+export default class MaskValue extends MixinsDeclaration {
 	/** DatePicker.dateFormat */
 	dateFormat!: string;
 
 	/**
-	 * Return the mask to apply to the TextField
+	 * The mask to apply to the TextField
 	 *
 	 * @example
 	 * '##/##/####' for default dateFormat

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/pickerDate.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/pickerDate.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Component from 'vue-class-component';
+import Component, { mixins } from 'vue-class-component';
 
 const Props = Vue.extend({
 	props: {
@@ -11,9 +11,11 @@ const Props = Vue.extend({
 	}
 });
 
+const MixinsDeclaration = mixins(Props);
+
 /** Add picker-date prop from Vuetify and bind it with .sync modifier */
 @Component
-export default class PickerDate extends Props {
+export default class PickerDate extends MixinsDeclaration {
 	/**
 	 * Use an internal model
 	 * so we don't modify the prop

--- a/packages/vue-dot/src/patterns/FileList/FileList.vue
+++ b/packages/vue-dot/src/patterns/FileList/FileList.vue
@@ -93,7 +93,7 @@
 
 <script lang="ts">
 	import Vue, { PropType } from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import config from './config';
 	import { FileItem } from './types';
@@ -128,17 +128,11 @@
 		}
 	});
 
-	/** FileList is a component that displays a list of files */
-	@Component({
-		mixins: [
-			// Default configuration
-			customizable(config)
-		]
-	})
-	export default class FileList extends Props {
-		// Mixin computed data
-		options!: Options;
+	const MixinsDeclaration = mixins(Props, customizable(config));
 
+	/** FileList is a component that displays a list of files */
+	@Component
+	export default class FileList extends MixinsDeclaration {
 		// Icons
 		refreshIcon = mdiRefresh;
 		eyeIcon = mdiEye;

--- a/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
+++ b/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
@@ -98,7 +98,7 @@
 
 <script lang="ts">
 	import Vue, { PropType } from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import locales from './locales';
 
@@ -175,6 +175,8 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props);
+
 	/**
 	 * FileUpload is a component that enhance the default HTML
 	 * file input element
@@ -185,7 +187,7 @@
 			event: 'change'
 		}
 	})
-	export default class FileUpload extends Props {
+	export default class FileUpload extends MixinsDeclaration {
 		$refs!: Refs<{
 			vdInputEl: HTMLInputElement;
 		}>;

--- a/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
+++ b/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
@@ -72,16 +72,17 @@
 
 <script lang="ts">
 	import Vue, { PropType } from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import config from './config';
 	import locales from './locales';
+
 	import { Languages, AllLanguagesChar } from './types';
 
 	// ISO 639-1 language database in a JSON object
 	import languages from 'languages';
 
-	import customizable, { Options } from '../../mixins/customizable';
+	import customizable from '../../mixins/customizable';
 
 	import { mdiChevronDown } from '@mdi/js';
 
@@ -131,24 +132,19 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props, customizable(config));
+
 	/**
 	 * LangBtn is a component that displays a list of languages
 	 * to choose from when clicking a button
 	 */
 	@Component({
-		mixins: [
-			// Default configuration
-			customizable(config)
-		],
 		model: {
 			prop: 'value',
 			event: 'change'
 		}
 	})
-	export default class LangBtn extends Props {
-		// Mixin computed data
-		options!: Options;
-
+	export default class LangBtn extends MixinsDeclaration {
 		// Icon
 		downArrowIcon = mdiChevronDown;
 

--- a/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
+++ b/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 	import Vue from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import config from './config';
 	import locales from './locales';
@@ -41,7 +41,7 @@
 	import { mapActions, mapState } from 'vuex';
 	import { NotificationObj } from '../../modules/notification';
 
-	import customizable, { Options } from '../../mixins/customizable';
+	import customizable from '../../mixins/customizable';
 
 	const Props = Vue.extend({
 		props: {
@@ -53,6 +53,8 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props, customizable(config));
+
 	/**
 	 * NotificationBar is a component that displays a notification using a Snackbar
 	 */
@@ -63,16 +65,9 @@
 		]),
 		methods: mapActions('notification', [
 			'rmNotif'
-		]),
-		mixins: [
-			// Default configuration
-			customizable(config)
-		]
+		])
 	})
-	export default class NotificationBar extends Props {
-		// Mixin computed data
-		options!: Options;
-
+	export default class NotificationBar extends MixinsDeclaration {
 		// Vuex bindings type declaration
 		notification!: NotificationObj;
 		rmNotif!: () => void;

--- a/packages/vue-dot/src/patterns/PageCard/PageCard.vue
+++ b/packages/vue-dot/src/patterns/PageCard/PageCard.vue
@@ -16,11 +16,11 @@
 
 <script lang="ts">
 	import Vue from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import config from './config';
 
-	import customizable, { Options } from '../../mixins/customizable';
+	import customizable from '../../mixins/customizable';
 
 	const Props = Vue.extend({
 		props: {
@@ -58,22 +58,17 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props, customizable(config));
+
 	/**
 	 * PageCard is a component that displays a
 	 * VCard with specific parameters
 	 */
 	@Component({
 		// Disable attributes inheritance since we bind them to the VCard
-		inheritAttrs: false,
-		mixins: [
-			// Default configuration
-			customizable(config)
-		]
+		inheritAttrs: false
 	})
-	export default class PageCard extends Props {
-		// Mixin computed data
-		options!: Options;
-
+	export default class PageCard extends MixinsDeclaration {
 		/** The CSS classes to apply to the VCard */
 		get computedClass() {
 			return [

--- a/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
+++ b/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
@@ -30,7 +30,7 @@
 
 <script lang="ts">
 	import Vue, { PropType } from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import { Options } from './types';
 
@@ -57,6 +57,8 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props);
+
 	/**
 	 * PaginatedTable is a wrapper component for the VDataTable
 	 * that stores the pagination in local storage
@@ -71,7 +73,7 @@
 			}
 		}
 	})
-	export default class PaginatedTable extends Props {
+	export default class PaginatedTable extends MixinsDeclaration {
 		localStorageUtility = this.newLocalStorageInstance();
 
 		/**

--- a/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
@@ -74,7 +74,7 @@
 
 <script lang="ts">
 	import Vue, { PropType } from 'vue';
-	import Component from 'vue-class-component';
+	import Component, { mixins } from 'vue-class-component';
 
 	import config from './config';
 	import locales from './locales';
@@ -84,7 +84,7 @@
 
 	import required from '../../rules/required';
 
-	import customizable, { Options } from '../../mixins/customizable';
+	import customizable from '../../mixins/customizable';
 
 	import FileUpload from '../FileUpload';
 	import { ErrorEvent } from '../FileUpload/types';
@@ -108,15 +108,13 @@
 		}
 	});
 
+	const MixinsDeclaration = mixins(Props, customizable(config));
+
 	/**
 	 * UploadWorkflow is a component that let the user select files
 	 * and define a type for them in a pre-defined list
 	 */
 	@Component<UploadWorkflow>({
-		mixins: [
-			// Default configuration
-			customizable(config)
-		],
 		model: {
 			prop: 'value',
 			event: 'change'
@@ -145,10 +143,7 @@
 			}
 		}
 	})
-	export default class UploadWorkflow extends Props {
-		// Mixin computed data
-		options!: Options;
-
+	export default class UploadWorkflow extends MixinsDeclaration {
 		// Extend $refs
 		$refs!: Refs<{
 			fileUpload: FileUpload;


### PR DESCRIPTION
Refactor mixins declaration by introducing a new way to declare their usage using [vue-class-component mixin helper](https://github.com/vuejs/vue-class-component#using-mixins).

It looks like this:
```ts
import Vue from 'vue';
import Component, { mixins } from 'vue-class-component';

import MixinA from '...';
import MixinA from '...';

const Props = Vue.extend({});

const MixinsDeclaration = mixins(Props, MixinA, MixinB);

class MyComponent extends MixinsDeclaration {}
```

### Questions

- Should we apply this also when we're just using one mixin (eg. components that `extends Props`)?
This will be more standard and make it easier to create a component, but this requires more boilerplate -> Yes
- Is the name `MixinsDeclaration` right? We're not really declarating them, we're using them -> If we find something better we'll see, meantime we use this name

### Todo

I still need to figure out how to handle cases were we have more than 5 mixins (eg. `DatePicker`), but we can see this later.