### PR TITLE
Vue-dot: rename field type 'string' to 'text'

### DIFF
--- a/packages/vue-dot/playground/examples/FormFieldEx.vue
+++ b/packages/vue-dot/playground/examples/FormFieldEx.vue
@@ -13,7 +13,7 @@
 	@Component
 	export default class FormFieldEx extends Vue {
 		field: Field = {
-			type: 'string',
+			type: 'text',
 			value: null,
 			metadata: {
 				label: 'Votre nom'

--- a/packages/vue-dot/src/functions/getFormValues/tests/data/forms.ts
+++ b/packages/vue-dot/src/functions/getFormValues/tests/data/forms.ts
@@ -6,7 +6,7 @@ export const formNull = {
 		value: null,
 		mask: '#####',
 		metadata: {
-			type: 'string',
+			type: 'text',
 			label: 'Numéro de voie'
 		}
 	},
@@ -23,7 +23,7 @@ export const formNull = {
 		}
 	},
 	streetLabel: {
-		type: 'string',
+		type: 'text',
 		value: null,
 		metadata: {
 			label: 'Libellé de la voie'
@@ -47,7 +47,7 @@ export const formNotNull = {
 		]
 	},
 	streetLabel: {
-		type: 'string',
+		type: 'text',
 		value: 'streetLabel'
 	}
 } as Form;

--- a/packages/vue-dot/src/functions/setFormErrors/tests/__snapshots__/setFormErrors.spec.ts.snap
+++ b/packages/vue-dot/src/functions/setFormErrors/tests/__snapshots__/setFormErrors.spec.ts.snap
@@ -11,7 +11,7 @@ Object {
     "type": "period",
   },
   "questionString": Object {
-    "type": "string",
+    "type": "text",
   },
 }
 `;
@@ -42,7 +42,7 @@ Object {
         "error string 2",
       ],
     },
-    "type": "string",
+    "type": "text",
   },
 }
 `;

--- a/packages/vue-dot/src/functions/setFormErrors/tests/data/formErrors.ts
+++ b/packages/vue-dot/src/functions/setFormErrors/tests/data/formErrors.ts
@@ -32,7 +32,7 @@ export const questionErrors = {
 
 export const form = {
 	questionString: {
-		type: 'string'
+		type: 'text'
 	},
 	questionPeriod: {
 		type: 'period'

--- a/packages/vue-dot/src/patterns/FormBuilder/mixins/tests/formBuilderCore.spec.ts
+++ b/packages/vue-dot/src/patterns/FormBuilder/mixins/tests/formBuilderCore.spec.ts
@@ -16,7 +16,7 @@ import {
 import { Layouts } from 'src/patterns/FormLayout/layoutsEnum';
 
 const testField: Field = {
-	type: 'string',
+	type: 'text',
 	value: null,
 	metadata: {
 		label: 'Test'

--- a/packages/vue-dot/src/patterns/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`FormBuilder renders correctly 1`] = `
     <div class="v-input vd-form-field theme--light v-text-field">
       <div class="v-input__control">
         <div class="v-input__slot">
-          <div class="v-text-field__slot"><label for="input-7" class="v-label theme--light" style="left: 0px; position: absolute;">Numéro de voie</label><input id="input-7" type="string"></div>
+          <div class="v-text-field__slot"><label for="input-7" class="v-label theme--light" style="left: 0px; position: absolute;">Numéro de voie</label><input id="input-7" type="text"></div>
         </div>
         <div class="v-text-field__details">
           <div class="v-messages theme--light">

--- a/packages/vue-dot/src/patterns/FormBuilder/tests/data/addressForm.ts
+++ b/packages/vue-dot/src/patterns/FormBuilder/tests/data/addressForm.ts
@@ -6,7 +6,7 @@ export default {
 		value: null,
 		mask: '#####',
 		metadata: {
-			type: 'string',
+			type: 'text',
 			label: 'Numéro de voie'
 		}
 	},
@@ -36,14 +36,14 @@ export default {
 		}
 	},
 	streetLabel: {
-		type: 'string',
+		type: 'text',
 		value: null,
 		metadata: {
 			label: 'Libellé de la voie'
 		}
 	},
 	streetComplement: {
-		type: 'string',
+		type: 'text',
 		value: null,
 		metadata: {
 			label: 'Complément d\'adresse'
@@ -58,7 +58,7 @@ export default {
 		}
 	},
 	city: {
-		type: 'string',
+		type: 'text',
 		value: null,
 		metadata: {
 			label: 'Ville'

--- a/packages/vue-dot/src/patterns/FormBuilder/tests/data/questionForm.ts
+++ b/packages/vue-dot/src/patterns/FormBuilder/tests/data/questionForm.ts
@@ -17,7 +17,7 @@ const defaultItems = [
 
 export default {
 	questionString: {
-		type: 'string',
+		type: 'text',
 		title: 'Question ?',
 		description: 'Informations supplémentaires',
 		tooltip: 'Texte d\'aide',

--- a/packages/vue-dot/src/patterns/FormField/mixins/fieldMap.ts
+++ b/packages/vue-dot/src/patterns/FormField/mixins/fieldMap.ts
@@ -41,7 +41,7 @@ export default class FieldMap extends Vue {
 		period: 'PeriodField',
 		select: 'SelectField',
 		choiceSlider: 'ChoiceSliderField',
-		string: 'TextField',
+		text: 'TextField',
 		textarea: 'TextareaField'
 	};
 

--- a/packages/vue-dot/src/patterns/FormField/mixins/tests/__snapshots__/fieldMap.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FormField/mixins/tests/__snapshots__/fieldMap.spec.ts.snap
@@ -9,7 +9,7 @@ Object {
   "password": "PasswordField",
   "period": "PeriodField",
   "select": "SelectField",
-  "string": "TextField",
+  "text": "TextField",
   "textarea": "TextareaField",
 }
 `;

--- a/packages/vue-dot/src/patterns/FormField/mixins/tests/fieldComponent.spec.ts
+++ b/packages/vue-dot/src/patterns/FormField/mixins/tests/fieldComponent.spec.ts
@@ -6,7 +6,7 @@ import { Field } from '../../types';
 import fieldComponent from '../fieldComponent';
 
 const testField = {
-	type: 'string',
+	type: 'text',
 	value: null,
 	metadata: {
 		label: 'Field',

--- a/packages/vue-dot/src/patterns/FormField/mixins/tests/fieldMap.spec.ts
+++ b/packages/vue-dot/src/patterns/FormField/mixins/tests/fieldMap.spec.ts
@@ -26,6 +26,6 @@ describe('fieldMap', () => {
 	it('gets a field component', () => {
 		const wrapper = createWrapper();
 
-		expect(typeof wrapper.vm.getField('string')).toBe('string');
+		expect(typeof wrapper.vm.getField('text')).toBe('string');
 	});
 });

--- a/packages/vue-dot/src/patterns/FormField/tests/FormField.spec.ts
+++ b/packages/vue-dot/src/patterns/FormField/tests/FormField.spec.ts
@@ -9,7 +9,7 @@ import FormField from '../FormField.vue';
 let wrapper: Wrapper<Vue>;
 
 const testField = {
-	type: 'string',
+	type: 'text',
 	value: null,
 	metadata: {
 		label: 'Classic field',

--- a/packages/vue-dot/src/patterns/FormLayout/mixins/tests/layoutComponent.spec.ts
+++ b/packages/vue-dot/src/patterns/FormLayout/mixins/tests/layoutComponent.spec.ts
@@ -6,7 +6,7 @@ import { Field } from '../../../FormField/types';
 import layoutComponent from '../layoutComponent';
 
 const testFieldString = {
-	type: 'string',
+	type: 'text',
 	value: null
 };
 

--- a/packages/vue-dot/src/patterns/FormLayout/tests/FormLayout.spec.ts
+++ b/packages/vue-dot/src/patterns/FormLayout/tests/FormLayout.spec.ts
@@ -12,7 +12,7 @@ import FormLayout from '../FormLayout.vue';
 let wrapper: Wrapper<Vue>;
 
 const testField: ComputedField = {
-	type: 'string',
+	type: 'text',
 	value: null,
 	name: 'field1'
 };


### PR DESCRIPTION
QUE 83
rename field type  'string' to 'text'