### PR TITLE
♻️ Remove default exports

### DIFF
--- a/packages/cli-helpers/README.md
+++ b/packages/cli-helpers/README.md
@@ -25,8 +25,8 @@ import { log, done, getPath } from '@cnamts/cli-helpers';
 Or you can import them using their files, like so:
 
 ```ts
-import log, { done } from '@cnamts/cli-helpers/src/logger';
-import getPath from '@cnamts/cli-helpers/src/getPath';
+import { log, done } from '@cnamts/cli-helpers/src/logger';
+import { getPath } from '@cnamts/cli-helpers/src/getPath';
 ```
 
 ## Helpers

--- a/packages/cli-helpers/src/colors.ts
+++ b/packages/cli-helpers/src/colors.ts
@@ -1,5 +1,5 @@
 /** Theme */
-export default {
+export const colors = {
 	primary: '#01579b',
 	lightGrey: '#909090'
 };

--- a/packages/cli-helpers/src/getPath.ts
+++ b/packages/cli-helpers/src/getPath.ts
@@ -6,6 +6,6 @@ import * as path from 'path';
  * @param {string} value The path to join
  * @returns {string} The normalized path
  */
-export default function getPath(value: string): string {
+export function getPath(value: string): string {
 	return path.join(process.cwd(), value);
 }

--- a/packages/cli-helpers/src/index.ts
+++ b/packages/cli-helpers/src/index.ts
@@ -1,6 +1,6 @@
 export * from './logger';
 
-export { default as colors } from './colors';
-export { default as getPath } from './getPath';
-export { default as renderHeader } from './renderHeader';
-export { default as traceLine } from './traceLine';
+export { colors } from './colors';
+export { getPath } from './getPath';
+export { renderHeader } from './renderHeader';
+export { traceLine } from './traceLine';

--- a/packages/cli-helpers/src/logger.ts
+++ b/packages/cli-helpers/src/logger.ts
@@ -3,7 +3,7 @@
 
 import chalk from 'chalk';
 
-import colors from './colors';
+import { colors } from './colors';
 
 /** Wrapper for console.log to avoid lint errors */
 export const log = console.log;
@@ -70,5 +70,3 @@ export function verbose(text: string): void {
 export function event(text: string): void {
 	console.log(chalk.bold.white(text));
 }
-
-export default log;

--- a/packages/cli-helpers/src/renderHeader.ts
+++ b/packages/cli-helpers/src/renderHeader.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
 import figlet from 'figlet';
 
-import log from './logger';
-import traceLine from './traceLine';
-import colors from './colors';
+import { log } from './logger';
+import { traceLine } from './traceLine';
+import { colors } from './colors';
 
 /**
  * Display header with 'Georgia11' font and 'primary' color
@@ -12,7 +12,7 @@ import colors from './colors';
  * @param {string} [author] Package author
  * @param {string} [version] Package version
  */
-export default function renderHeader(text: string, author?: string, version?: string): void {
+export function renderHeader(text: string, author?: string, version?: string): void {
 	const txt = figlet.textSync(text, {
 		font: 'Georgia11',
 		horizontalLayout: 'default',

--- a/packages/cli-helpers/src/traceLine.ts
+++ b/packages/cli-helpers/src/traceLine.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import colors from './colors';
+import { colors } from './colors';
 
 /** Unicode Box-drawing character, see https://en.wikipedia.org/wiki/Box-drawing_character */
 const LINE_CHARACTER = '─';
@@ -10,7 +10,7 @@ const LINE_CHARACTER = '─';
  *
  * @param {string} [lineColor=colors.primary] The color of the line
  */
-export default function traceLine(lineColor = colors.primary): void {
+export function traceLine(lineColor = colors.primary): void {
 	const cols = process.stdout.columns || 0;
 
 	// For each column, display `─` in primary color

--- a/packages/cli-helpers/tests/colors.spec.ts
+++ b/packages/cli-helpers/tests/colors.spec.ts
@@ -1,4 +1,4 @@
-import colors from '@/colors';
+import { colors } from '@/colors';
 
 describe('colors object', () => {
 	it('should contains all colors', () => {

--- a/packages/cli-helpers/tests/getPath.spec.ts
+++ b/packages/cli-helpers/tests/getPath.spec.ts
@@ -1,4 +1,4 @@
-import getPath from '@/getPath';
+import { getPath } from '@/getPath';
 
 describe('getPath', () => {
 	beforeAll(() => {

--- a/packages/cli-helpers/tests/integration/__snapshots__/lib.spec.ts.snap
+++ b/packages/cli-helpers/tests/integration/__snapshots__/lib.spec.ts.snap
@@ -7,7 +7,6 @@ Object {
     "lightGrey": "#909090",
     "primary": "#01579b",
   },
-  "default": [Function],
   "done": [Function],
   "error": [Function],
   "event": [Function],

--- a/packages/cli-helpers/tests/renderHeader.spec.ts
+++ b/packages/cli-helpers/tests/renderHeader.spec.ts
@@ -1,6 +1,6 @@
 import { mockConsoleLog } from 'jest-mock-process';
 
-import renderHeader from '@/renderHeader';
+import { renderHeader } from '@/renderHeader';
 
 describe('renderHeader', () => {
 	let mockLog: jest.SpyInstance;

--- a/packages/cli-helpers/tests/traceLine.spec.ts
+++ b/packages/cli-helpers/tests/traceLine.spec.ts
@@ -1,6 +1,6 @@
 import { mockProcessStdout } from 'jest-mock-process';
 
-import traceLine from '@/traceLine';
+import { traceLine } from '@/traceLine';
 
 describe('traceLine', () => {
 	let mockStdout: jest.SpyInstance;

--- a/packages/vue-dot/playground/Playground.vue
+++ b/packages/vue-dot/playground/Playground.vue
@@ -78,7 +78,7 @@
 
 	import { LOCAL_STORAGE_CONTROL } from './plugins/vue-dot';
 
-	import LocalStorageUtility from '../src/helpers/localStorageUtility';
+	import { LocalStorageUtility } from '../src/helpers/localStorageUtility';
 
 	const DARK_THEME_KEY = 'pg-dark';
 

--- a/packages/vue-dot/playground/examples/DatePickerEx.vue
+++ b/packages/vue-dot/playground/examples/DatePickerEx.vue
@@ -125,9 +125,9 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	import required from '../../src/rules/required';
-	import isDateValid from '../../src/rules/isDateValid';
-	import notAfterToday from '../../src/rules/notAfterToday';
+	import { required } from '../../src/rules/required';
+	import { isDateValid } from '../../src/rules/isDateValid';
+	import { notAfterToday } from '../../src/rules/notAfterToday';
 
 	import { mdiCakeVariant } from '@mdi/js';
 

--- a/packages/vue-dot/playground/examples/RulesEx.vue
+++ b/packages/vue-dot/playground/examples/RulesEx.vue
@@ -47,22 +47,22 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	import defaultRequired, { required } from '../../src/rules/required';
-	import maxLength from '../../src/rules/maxLength';
-	import minLength from '../../src/rules/minLength';
+	import { required, requiredFn } from '../../src/rules/required';
+	import { maxLength } from '../../src/rules/maxLength';
+	import { minLength } from '../../src/rules/minLength';
 
 	import { ValidationRule } from '../../src/rules/types';
 
 	@Component
 	export default class RulesEx extends Vue {
 		textFieldRules = [
-			required({
+			requiredFn({
 				default: 'Field is required.'
 			})
 		];
 
 		textareaRules: ValidationRule[] = [
-			defaultRequired,
+			required,
 			minLength(10) // Default error messages
 		];
 
@@ -78,7 +78,7 @@
 		];
 
 		selectRules = [
-			defaultRequired
+			required
 		];
 
 		selected = [];

--- a/packages/vue-dot/playground/main.ts
+++ b/packages/vue-dot/playground/main.ts
@@ -5,13 +5,13 @@ import Vue from 'vue';
 // Register globally all examples
 import './examples';
 
-import store from './store/';
+import { store } from './store/';
 
 // Disable console tooltip
 Vue.config.productionTip = false;
 
 // Import plugins
-import vuetify from './plugins/vuetify';
+import { vuetify } from './plugins/vuetify';
 import './plugins/vue-dot';
 
 // Globally register DocSection component

--- a/packages/vue-dot/playground/plugins/vue-dot.ts
+++ b/packages/vue-dot/playground/plugins/vue-dot.ts
@@ -7,7 +7,7 @@ import 'dayjs/locale/fr';
 import VueDot from '../../src/';
 
 // Import the theme
-import icons from '../theme/icons';
+import { icons } from '../theme/icons';
 
 // Import the theme styles
 import '../theme/theme.scss';

--- a/packages/vue-dot/playground/plugins/vuetify.ts
+++ b/packages/vue-dot/playground/plugins/vuetify.ts
@@ -4,11 +4,11 @@ import Vue from 'vue';
 import Vuetify from 'vuetify/lib';
 
 // Import theme colors
-import colors from '../theme/colors';
+import { colors } from '../theme/colors';
 
 Vue.use(Vuetify);
 
-export default new Vuetify({
+export const vuetify = new Vuetify({
 	theme: {
 		// Destructure colors object in theme
 		themes: {

--- a/packages/vue-dot/playground/store/index.ts
+++ b/packages/vue-dot/playground/store/index.ts
@@ -2,12 +2,12 @@ import Vue from 'vue';
 import Vuex, { StoreOptions } from 'vuex';
 import { RootState } from './types';
 
-import notification from '../../src/modules/notification';
+import { notification } from '../../src/modules/notification';
 
 Vue.use(Vuex);
 
 /** See https://vuex.vuejs.org/fr/getting-started.html for help */
-const store: StoreOptions<RootState> = {
+const storeOptions: StoreOptions<RootState> = {
 	strict: true,
 	state: {},
 	// See https://vuex.vuejs.org/guide/modules.html for more info on modules
@@ -16,4 +16,4 @@ const store: StoreOptions<RootState> = {
 	}
 };
 
-export default new Vuex.Store<RootState>(store);
+export const store = new Vuex.Store<RootState>(storeOptions);

--- a/packages/vue-dot/playground/theme/colors.ts
+++ b/packages/vue-dot/playground/theme/colors.ts
@@ -1,8 +1,8 @@
 // Import Vuetify theme from Design Tokens
-import vuetifyTheme from '../../src/tokens/vuetifyTheme';
+import { vuetifyTheme } from '../../src/tokens/vuetifyTheme';
 
 /** Custom Vuetify color theme */
-export default {
+export const colors = {
 	light: {
 		...vuetifyTheme
 	},

--- a/packages/vue-dot/playground/theme/icons.ts
+++ b/packages/vue-dot/playground/theme/icons.ts
@@ -1,3 +1,3 @@
-export default {
+export const icons = {
 	vuejs: '<svg width="24" height="24" viewBox="0 0 400 400"><path fill="#4dba87" d="M237.42 86.66L207.19 139l-30.22-52.35H76.3l130.9 226.69L338.07 86.66z"/><path fill="#435466" d="M237.42 86.66L207.19 139l-30.22-52.35h-48.3l78.52 136 78.53-136z"/></svg>'
 };

--- a/packages/vue-dot/scripts/generateTokens.ts
+++ b/packages/vue-dot/scripts/generateTokens.ts
@@ -6,11 +6,13 @@ import { execOpts, writeToBeginning } from './utils';
 
 import { execSync } from 'child_process';
 
-import tokensObj from '../src/tokens';
+import { default as tokensObj } from '../src/tokens';
 
 interface Tokens {
 	[key: string]: string | Tokens;
 }
+
+const tokens = tokensObj as Tokens;
 
 const tokensFolder = getPath('src/tokens');
 
@@ -20,7 +22,6 @@ const tokenList = {
 	scss: `${tokensFolder}/index.scss`
 };
 
-const tokens = tokensObj as Tokens;
 delete tokens._jsonToScss; // Remove package config
 
 info('Generating Design Tokens');

--- a/packages/vue-dot/src/directives/debounce/index.ts
+++ b/packages/vue-dot/src/directives/debounce/index.ts
@@ -1,8 +1,9 @@
 import { DirectiveOptions } from 'vue';
-import debounceFn from '../../functions/debounce';
+
+import { debounce as debounceFn } from '../../functions/debounce';
 
 /** v-debounce directive */
-const debounce: DirectiveOptions = {
+export const debounce: DirectiveOptions = {
 	bind(el, binding) {
 		// If the tag the directive is binded to
 		// isn't an input, find one in his children elements
@@ -40,5 +41,3 @@ const debounce: DirectiveOptions = {
 		}, parseInt(value, 10));
 	}
 };
-
-export default debounce;

--- a/packages/vue-dot/src/directives/debounce/tests/debounce.spec.ts
+++ b/packages/vue-dot/src/directives/debounce/tests/debounce.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
-import debounce from '../';
+import { debounce } from '../';
 
 interface TestComponent extends Vue {
 	value: string;

--- a/packages/vue-dot/src/directives/index.ts
+++ b/packages/vue-dot/src/directives/index.ts
@@ -1,4 +1,4 @@
-import debounce from './debounce';
+import { debounce } from './debounce';
 
 import { VueConstructor, DirectiveOptions } from 'vue';
 

--- a/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
+++ b/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
@@ -31,12 +31,12 @@
 	import Vue from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import config from './config';
-	import locales from './locales';
+	import { config } from './config';
+	import { locales } from './locales';
 
-	import customizable from '../../mixins/customizable';
+	import { customizable } from '../../mixins/customizable';
 
-	import copyToClipboard from '../../functions/copyToClipboard';
+	import { copyToClipboard } from '../../functions/copyToClipboard';
 
 	import { mdiContentCopy } from '@mdi/js';
 

--- a/packages/vue-dot/src/elements/CopyBtn/config.ts
+++ b/packages/vue-dot/src/elements/CopyBtn/config.ts
@@ -1,4 +1,4 @@
-export default {
+export const config = {
 	menu: {
 		offsetX: true,
 		zIndex: 8,

--- a/packages/vue-dot/src/elements/CopyBtn/locales.ts
+++ b/packages/vue-dot/src/elements/CopyBtn/locales.ts
@@ -1,3 +1,3 @@
-export default {
+export const locales = {
 	tooltip: 'Texte copié !'
 };

--- a/packages/vue-dot/src/elements/CopyBtn/tests/CopyBtn.spec.ts
+++ b/packages/vue-dot/src/elements/CopyBtn/tests/CopyBtn.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import CopyBtn from '../';
 

--- a/packages/vue-dot/src/elements/CustomIcon/tests/CustomIcon.spec.ts
+++ b/packages/vue-dot/src/elements/CustomIcon/tests/CustomIcon.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import CustomIcon from '../';
 

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -58,7 +58,7 @@
 	import Vue, { PropType } from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import locales from './locales';
+	import { locales } from './locales';
 
 	import { ListItem } from './types';
 

--- a/packages/vue-dot/src/elements/DataList/locales.ts
+++ b/packages/vue-dot/src/elements/DataList/locales.ts
@@ -1,3 +1,3 @@
-export default {
+export const locales = {
 	placeholder: '…'
 };

--- a/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import DataList from '../';
 

--- a/packages/vue-dot/src/elements/index.ts
+++ b/packages/vue-dot/src/elements/index.ts
@@ -2,7 +2,7 @@ import CopyBtn from './CopyBtn';
 import CustomIcon from './CustomIcon';
 import DataList from './DataList';
 
-export default {
+export const elements = {
 	CopyBtn,
 	CustomIcon,
 	DataList

--- a/packages/vue-dot/src/functions/calcHumanFileSize/index.ts
+++ b/packages/vue-dot/src/functions/calcHumanFileSize/index.ts
@@ -1,5 +1,5 @@
 /** Takes a size in bytes and outputs a human readable value */
-export default function calcHumanFileSize(size: number, fileSizeUnits: string[], separator = ' '): string {
+export function calcHumanFileSize(size: number, fileSizeUnits: string[], separator = ' '): string {
 	// Calc index
 	const index = Math.floor(Math.log(size) / Math.log(1024));
 

--- a/packages/vue-dot/src/functions/calcHumanFileSize/tests/calcHumanFileSize.spec.ts
+++ b/packages/vue-dot/src/functions/calcHumanFileSize/tests/calcHumanFileSize.spec.ts
@@ -1,4 +1,4 @@
-import calcHumanFileSize from '../';
+import { calcHumanFileSize } from '../';
 
 const sizeMax = 4096 * 1024; // Default 4MB
 

--- a/packages/vue-dot/src/functions/copyToClipboard/index.ts
+++ b/packages/vue-dot/src/functions/copyToClipboard/index.ts
@@ -4,7 +4,7 @@
  *
  * @param {string} textToCopy The text to copy
  */
-export default function copyToClipboard(textToCopy: string) {
+export function copyToClipboard(textToCopy: string) {
 	/** Use a text area, so we can use execCommand */
 	const el = document.createElement('textarea');
 

--- a/packages/vue-dot/src/functions/copyToClipboard/tests/copyToClipboard.spec.ts
+++ b/packages/vue-dot/src/functions/copyToClipboard/tests/copyToClipboard.spec.ts
@@ -1,4 +1,4 @@
-import copyToClipboard from '../';
+import { copyToClipboard } from '../';
 
 interface TSelection {
 	rangeCount?: number;

--- a/packages/vue-dot/src/functions/debounce/index.ts
+++ b/packages/vue-dot/src/functions/debounce/index.ts
@@ -4,7 +4,7 @@
  * @param {Function} callback The function called after debounce
  * @param {number} [time=500] The interval of the debounce in milliseconds
  */
-export default function debounce(callback: (args: IArguments) => void, time: number = 500): () => void {
+export function debounce(callback: (args: IArguments) => void, time: number = 500): () => void {
 	let interval: NodeJS.Timeout | null;
 
 	return () => {

--- a/packages/vue-dot/src/functions/debounce/tests/debounce.spec.ts
+++ b/packages/vue-dot/src/functions/debounce/tests/debounce.spec.ts
@@ -1,4 +1,4 @@
-import debounce from '../';
+import { debounce } from '../';
 
 // Tell jest to mock all timeout functions
 jest.useFakeTimers();

--- a/packages/vue-dot/src/functions/getFileExtension/index.ts
+++ b/packages/vue-dot/src/functions/getFileExtension/index.ts
@@ -3,7 +3,7 @@
  *
  * @param {string} fileName The name of the file (with extension)
  */
-export default function getFileExtension(fileName: string): string {
+export function getFileExtension(fileName: string): string {
 	// lastIndexOf returns '.xxx', add 1 to slice the dot
 	return fileName.slice(fileName.lastIndexOf('.') + 1);
 }

--- a/packages/vue-dot/src/functions/getFileExtension/tests/getFileExtension.spec.ts
+++ b/packages/vue-dot/src/functions/getFileExtension/tests/getFileExtension.spec.ts
@@ -1,4 +1,4 @@
-import getFileExtension from '../';
+import { getFileExtension } from '../';
 
 // Tests
 describe('getFileExtension', () => {

--- a/packages/vue-dot/src/functions/isDateInRange/index.ts
+++ b/packages/vue-dot/src/functions/isDateInRange/index.ts
@@ -12,7 +12,7 @@ dayjs.extend(isBetween);
  * @param {string} [interval] The interval for the isBetween function
  * '[' indicates inclusion, '(' indicates exclusion
  */
-export default function isDateInRange(
+export function isDateInRange(
 	date: string,
 	startDate: string,
 	endDate: string,

--- a/packages/vue-dot/src/functions/isDateInRange/tests/isDateInRange.spec.ts
+++ b/packages/vue-dot/src/functions/isDateInRange/tests/isDateInRange.spec.ts
@@ -1,4 +1,4 @@
-import isDateInRange from '../';
+import { isDateInRange } from '../';
 
 const start = '2019-10-21';
 const end = '2019-10-27';

--- a/packages/vue-dot/src/functions/isWeekEnd/index.ts
+++ b/packages/vue-dot/src/functions/isWeekEnd/index.ts
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
  *
  * @param {string} date The date to check (must be a valid dayjs format)
  */
-export default function isWeekEnd(date: string) {
+export function isWeekEnd(date: string) {
 	/* The name of the day of the week */
 	const day = dayjs(date).format('dddd');
 

--- a/packages/vue-dot/src/functions/isWeekEnd/tests/isWeekEnd.spec.ts
+++ b/packages/vue-dot/src/functions/isWeekEnd/tests/isWeekEnd.spec.ts
@@ -1,4 +1,4 @@
-import isWeekEnd from '../';
+import { isWeekEnd } from '../';
 
 // Tests
 describe('isWeekEnd', () => {

--- a/packages/vue-dot/src/helpers/deepCopy/index.ts
+++ b/packages/vue-dot/src/helpers/deepCopy/index.ts
@@ -4,7 +4,7 @@
  * @param {any} o The value to copy
  * @returns {any} The copied value (can be typed if needed)
  */
-export default function deepCopy<T = any>(o: any): T {
+export function deepCopy<T = any>(o: any): T {
 	let copy = o;
 	let k;
 

--- a/packages/vue-dot/src/helpers/deepCopy/tests/deepCopy.spec.ts
+++ b/packages/vue-dot/src/helpers/deepCopy/tests/deepCopy.spec.ts
@@ -1,4 +1,4 @@
-import deepCopy from '../';
+import { deepCopy } from '../';
 
 // Tests
 describe('deepCopy', () => {

--- a/packages/vue-dot/src/helpers/localStorageUtility/index.ts
+++ b/packages/vue-dot/src/helpers/localStorageUtility/index.ts
@@ -6,7 +6,7 @@ interface ControlItem {
 	expiresAt?: number;
 }
 
-export default class LocalStorageUtility {
+export class LocalStorageUtility {
 	readonly localStorageSupported: boolean;
 
 	/** Integer number */

--- a/packages/vue-dot/src/helpers/localStorageUtility/tests/localStorageUtility.spec.ts
+++ b/packages/vue-dot/src/helpers/localStorageUtility/tests/localStorageUtility.spec.ts
@@ -3,7 +3,7 @@
 
 // tslint:disable: no-unused-expression
 
-import LocalStorageUtility from '../';
+import { LocalStorageUtility } from '../';
 
 /** Get the controlItem (not parsed) in localStorage */
 function getControlItem() {

--- a/packages/vue-dot/src/helpers/parseDate/index.ts
+++ b/packages/vue-dot/src/helpers/parseDate/index.ts
@@ -5,8 +5,6 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 dayjs.extend(customParseFormat);
 
 /** Parse custom format with dayjs */
-function parseDate(value: string, format = 'DD/MM/YYYY') {
+export function parseDate(value: string, format = 'DD/MM/YYYY') {
 	return dayjs(value, format);
 }
-
-export default parseDate;

--- a/packages/vue-dot/src/helpers/parseDate/tests/parseDate.spec.ts
+++ b/packages/vue-dot/src/helpers/parseDate/tests/parseDate.spec.ts
@@ -1,6 +1,6 @@
-import parseDate from '../';
-
 import dayjs from 'dayjs';
+
+import { parseDate } from '../';
 
 const RESULT_DATE_FORMAT = 'YYYY-MM-DD';
 

--- a/packages/vue-dot/src/helpers/registerComponents/index.ts
+++ b/packages/vue-dot/src/helpers/registerComponents/index.ts
@@ -10,7 +10,7 @@ export interface Components {
  * @param {VueConstructor} Vue The global Vue instance
  * @param {object} componentList The list of components to register
  */
-export default function registerComponents(Vue: VueConstructor, componentList: Components) {
+export function registerComponents(Vue: VueConstructor, componentList: Components) {
 	Object.keys(componentList).forEach((name: string) => {
 		Vue.component(name, componentList[name]);
 	});

--- a/packages/vue-dot/src/helpers/registerComponents/tests/registerComponents.spec.ts
+++ b/packages/vue-dot/src/helpers/registerComponents/tests/registerComponents.spec.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 
-import registerComponents, { Components } from '../';
+import { registerComponents, Components } from '../';
 
 import { getComponents } from '@/tests/integration/utils';
 

--- a/packages/vue-dot/src/helpers/ruleMessage/index.ts
+++ b/packages/vue-dot/src/helpers/ruleMessage/index.ts
@@ -4,7 +4,7 @@ import { ErrorMessages, GenericFnOpt } from '../../rules/types';
  * Generic error messages function
  * Executes a function that returns a string, or returns a string
  */
-export default function ruleMessage<T>(
+export function ruleMessage<T>(
 	errorMessages: ErrorMessages<T>,
 	key: string,
 	args?: T[]

--- a/packages/vue-dot/src/helpers/ruleMessage/tests/ruleMessages.spec.ts
+++ b/packages/vue-dot/src/helpers/ruleMessage/tests/ruleMessages.spec.ts
@@ -1,4 +1,4 @@
-import ruleMessage from '../';
+import { ruleMessage } from '../';
 
 // Tests
 describe('ruleMessage', () => {

--- a/packages/vue-dot/src/index.ts
+++ b/packages/vue-dot/src/index.ts
@@ -1,6 +1,6 @@
 import directives from './directives';
 
-import registerAllComponents from './registerAllComponents';
+import { registerAllComponents } from './registerAllComponents';
 
 // Import global styles
 import './styles/global.scss';

--- a/packages/vue-dot/src/mixins/customizable/index.ts
+++ b/packages/vue-dot/src/mixins/customizable/index.ts
@@ -16,7 +16,7 @@ import merge from 'deepmerge';
  * // Final API
  * <MyComponent :vuetify-options="{ btn: { color: 'white' } }" />
  */
-export default function customizable(defaultOptions: Options) {
+export function customizable(defaultOptions: Options) {
 	return Vue.extend({
 		props: {
 			/** User options */

--- a/packages/vue-dot/src/mixins/customizable/tests/customizable.spec.ts
+++ b/packages/vue-dot/src/mixins/customizable/tests/customizable.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
-import customizable, { Options } from '../';
+import { customizable, Options } from '../';
 import deepmerge from 'deepmerge';
 
 interface TestComponent extends Vue {

--- a/packages/vue-dot/src/mixins/eventable/index.ts
+++ b/packages/vue-dot/src/mixins/eventable/index.ts
@@ -3,8 +3,8 @@ import Component, { mixins } from 'vue-class-component';
 
 import { Options } from '../customizable';
 
-import isWeekEnd from '../../functions/isWeekEnd';
-import isDateInRange from '../../functions/isDateInRange';
+import { isWeekEnd } from '../../functions/isWeekEnd';
+import { isDateInRange } from '../../functions/isDateInRange';
 
 const Props = Vue.extend({
 	props: {
@@ -25,7 +25,7 @@ const MixinsDeclaration = mixins(Props);
 
 /** Add event handling: week-ends and ranges */
 @Component
-export default class Eventable extends MixinsDeclaration {
+export class Eventable extends MixinsDeclaration {
 	// Mixin computed data
 	options!: Options;
 	/** DatePicker.date */

--- a/packages/vue-dot/src/mixins/eventable/tests/eventable.spec.ts
+++ b/packages/vue-dot/src/mixins/eventable/tests/eventable.spec.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
-import eventable from '../';
-import customizable, { Options } from '../../customizable';
+import { Eventable } from '../';
+import { customizable, Options } from '../../customizable';
 
 const DATE = '2019-10-25';
 const DATE_WEEK_END = '2019-10-26';
@@ -16,7 +16,7 @@ interface TestComponent extends Vue {
 function createTestComponent(mixinData = {}) {
 	return Vue.component('test', {
 		mixins: [
-			eventable,
+			Eventable,
 			customizable(mixinData) // Needed because used in eventable
 		],
 		template: '<div />'
@@ -24,7 +24,7 @@ function createTestComponent(mixinData = {}) {
 }
 
 // Tests
-describe('customizable', () => {
+describe('Eventable', () => {
 	it('does nothing when no options are defined', () => {
 		const testComponent = createTestComponent();
 

--- a/packages/vue-dot/src/mixins/warningRules/index.ts
+++ b/packages/vue-dot/src/mixins/warningRules/index.ts
@@ -20,7 +20,7 @@ const MixinsDeclaration = mixins(Props);
  * but that does not block validation
  */
 @Component
-export default class WarningRules extends MixinsDeclaration {
+export class WarningRules extends MixinsDeclaration {
 	/**
 	 * The messages from warningRules.
 	 * Not used if already passed as a prop*

--- a/packages/vue-dot/src/mixins/warningRules/tests/warningRules.spec.ts
+++ b/packages/vue-dot/src/mixins/warningRules/tests/warningRules.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
-import warningRules from '../';
+import { WarningRules } from '../';
 
 interface TestComponent extends Vue {
 	validate: (value: string) => void;
@@ -12,7 +12,7 @@ interface TestComponent extends Vue {
 function createWrapper() {
 	const component = Vue.component('test', {
 		mixins: [
-			warningRules
+			WarningRules
 		],
 		template: '<div />'
 	});
@@ -28,7 +28,7 @@ function createWrapper() {
 }
 
 // Tests
-describe('warningRules', () => {
+describe('WarningRules', () => {
 	it('validates the value correctly on error', () => {
 		const wrapper = createWrapper();
 

--- a/packages/vue-dot/src/modules/notification/index.ts
+++ b/packages/vue-dot/src/modules/notification/index.ts
@@ -39,12 +39,10 @@ export const mutations: MutationTree<NotificationState> = {
 export const getters: GetterTree<NotificationState, RootState> = {};
 
 /** The notification module */
-const notification: Module<NotificationState, RootState> = {
+export const notification: Module<NotificationState, RootState> = {
 	namespaced: true,
 	state,
 	actions,
 	mutations,
 	getters
 };
-
-export default notification;

--- a/packages/vue-dot/src/modules/notification/tests/notification.spec.ts
+++ b/packages/vue-dot/src/modules/notification/tests/notification.spec.ts
@@ -1,5 +1,5 @@
-import { createLocalVue } from '@vue/test-utils';
 import Vuex, { ActionTree } from 'vuex';
+import { createLocalVue } from '@vue/test-utils';
 
 import { NotificationState, actions as moduleActions, mutations } from '../';
 

--- a/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
@@ -74,18 +74,18 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	import config from './config';
+	import { config } from './config';
 
-	import customizable, { Options } from '../../mixins/customizable';
-	import eventable from '../../mixins/eventable';
-	import warningRules from '../../mixins/warningRules';
+	import { customizable, Options } from '../../mixins/customizable';
+	import { Eventable } from '../../mixins/eventable';
+	import { WarningRules } from '../../mixins/warningRules';
 	import { ValidationRule } from '../../rules/types';
 
-	import dateLogic from './mixins/dateLogic';
-	import maskValue from './mixins/maskValue';
-	import birthdate from './mixins/birthdate';
-	import pickerDate from './mixins/pickerDate';
-	import errorProp from './mixins/errorProp';
+	import { DateLogic } from './mixins/dateLogic';
+	import { MaskValue } from './mixins/maskValue';
+	import { Birthdate } from './mixins/birthdate';
+	import { PickerDate } from './mixins/pickerDate';
+	import { ErrorProp } from './mixins/errorProp';
 
 	import { mdiCalendar } from '@mdi/js';
 
@@ -122,13 +122,13 @@
 		mixins: [
 			// Default configuration
 			customizable(config),
-			eventable,
-			warningRules,
-			dateLogic,
-			maskValue,
-			birthdate,
-			pickerDate,
-			errorProp
+			Eventable,
+			WarningRules,
+			DateLogic,
+			MaskValue,
+			Birthdate,
+			PickerDate,
+			ErrorProp
 		],
 		model: {
 			prop: 'value',

--- a/packages/vue-dot/src/patterns/DatePicker/config.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/config.ts
@@ -1,4 +1,4 @@
-export default {
+export const config = {
 	textField: {
 		hint: 'Format JJ/MM/AAAA',
 		label: 'Date',

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/birthdate.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/birthdate.ts
@@ -26,7 +26,7 @@ const MixinsDeclaration = mixins(Props);
 		}
 	}
 })
-export default class Birthdate extends MixinsDeclaration {
+export class Birthdate extends MixinsDeclaration {
 	// Extend $refs
 	$refs!: Refs<{
 		picker: {

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
@@ -3,7 +3,7 @@ import Component, { mixins } from 'vue-class-component';
 
 import dayjs from 'dayjs';
 
-import parseDate from '../../../helpers/parseDate';
+import { parseDate } from '../../../helpers/parseDate';
 import { DATE_FORMAT_REGEX } from '../../../rules/isDateValid/checkIfDateValid';
 
 import { Options } from '../../../mixins/customizable';
@@ -73,7 +73,7 @@ const MixinsDeclaration = mixins(Props);
 		}
 	}
 })
-export default class DateLogic extends MixinsDeclaration {
+export class DateLogic extends MixinsDeclaration {
 	// Extend $refs
 	$refs!: Refs<{
 		/** VMenu */

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/errorProp.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/errorProp.ts
@@ -15,7 +15,7 @@ const MixinsDeclaration = mixins(Props);
 
 /** Add error prop from Vuetify and bind it with .sync modifier */
 @Component
-export default class ErrorProp extends MixinsDeclaration {
+export class ErrorProp extends MixinsDeclaration {
 	/**
 	 * Use an internal model
 	 * so we don't modify the prop

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/maskValue.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/maskValue.ts
@@ -20,7 +20,7 @@ const MixinsDeclaration = mixins(Props);
 
 /** Provides computed date format mask value */
 @Component
-export default class MaskValue extends MixinsDeclaration {
+export class MaskValue extends MixinsDeclaration {
 	/** DatePicker.dateFormat */
 	dateFormat!: string;
 

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/pickerDate.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/pickerDate.ts
@@ -15,7 +15,7 @@ const MixinsDeclaration = mixins(Props);
 
 /** Add picker-date prop from Vuetify and bind it with .sync modifier */
 @Component
-export default class PickerDate extends MixinsDeclaration {
+export class PickerDate extends MixinsDeclaration {
 	/**
 	 * Use an internal model
 	 * so we don't modify the prop

--- a/packages/vue-dot/src/patterns/DatePicker/tests/DatePicker.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/DatePicker.spec.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
-import localVue, { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { localVue, mountComponent } from '@/tests';
+import { html } from '@/tests/html';
 
 import VueTheMask from 'vue-the-mask';
 localVue.use(VueTheMask);

--- a/packages/vue-dot/src/patterns/DatePicker/tests/birthdate.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/birthdate.spec.ts
@@ -1,11 +1,11 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
+import dayjs from 'dayjs';
+
 import { Refs } from '../../../types';
 
-import birthdate from '../mixins/birthdate';
-
-import dayjs from 'dayjs';
+import { Birthdate } from '../mixins/birthdate';
 
 // Tell jest to mock all timeout functions
 jest.useFakeTimers();
@@ -41,7 +41,7 @@ function createDatePicker() {
 function createWrapper(birthdateValue: boolean, spy?: jest.Mock, menu = true) {
 	const component = Vue.component('test', {
 		mixins: [
-			birthdate
+			Birthdate
 		],
 		watch: {
 			menu: spy ? spy : () => null
@@ -65,7 +65,7 @@ function createWrapper(birthdateValue: boolean, spy?: jest.Mock, menu = true) {
 }
 
 // Tests
-describe('birthdate', () => {
+describe('Birthdate', () => {
 	it('doesn\'t set max & min values when birthdate is false', () => {
 		const wrapper = createWrapper(false);
 

--- a/packages/vue-dot/src/patterns/DatePicker/tests/dateLogic.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/dateLogic.spec.ts
@@ -3,9 +3,9 @@ import { mount, Wrapper } from '@vue/test-utils';
 
 import { Refs } from '../../../types';
 
-import customizable, { Options } from '../../../mixins/customizable';
+import { customizable, Options } from '../../../mixins/customizable';
 
-import dateLogic from '../mixins/dateLogic';
+import { DateLogic } from '../mixins/dateLogic';
 
 interface VueInstance extends VueConstructor {
 	options: {
@@ -70,7 +70,7 @@ function createTextField(disableHasFocused: boolean) {
 function createWrapper(propsData?: object, mixinData = {}, disableHasFocused: boolean = false) {
 	const component = Vue.component('test', {
 		mixins: [
-			dateLogic,
+			DateLogic,
 			customizable(mixinData)
 		],
 		template: '<div><v-menu ref="menu" /><v-text-field ref="input" /></div>'
@@ -89,7 +89,7 @@ function createWrapper(propsData?: object, mixinData = {}, disableHasFocused: bo
 }
 
 // Tests
-describe('dateLogic', () => {
+describe('DateLogic', () => {
 	// We need to unregister VTextField between each test
 	// because it may change
 	afterEach(() => {

--- a/packages/vue-dot/src/patterns/DatePicker/tests/errorProp.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/errorProp.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
-import errorProp from '../mixins/errorProp';
+import { ErrorProp } from '../mixins/errorProp';
 
 interface TestComponent extends Vue {
 	error: boolean;
@@ -12,7 +12,7 @@ interface TestComponent extends Vue {
 function createWrapper(error: boolean) {
 	const component = Vue.component('test', {
 		mixins: [
-			errorProp
+			ErrorProp
 		],
 		template: '<div />'
 	});
@@ -25,7 +25,7 @@ function createWrapper(error: boolean) {
 }
 
 // Tests
-describe('errorProp', () => {
+describe('ErrorProp', () => {
 	it('receives the value correctly from the prop', () => {
 		const wrapper = createWrapper(false);
 

--- a/packages/vue-dot/src/patterns/DatePicker/tests/maskValue.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/maskValue.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
-import maskValue from '../mixins/maskValue';
+import { MaskValue } from '../mixins/maskValue';
 
 interface TestComponent extends Vue {
 	mask: string | boolean;
@@ -13,7 +13,7 @@ interface TestComponent extends Vue {
 function createWrapper(mask?: string | boolean, dateFormat?: string) {
 	const component = Vue.component('test', {
 		mixins: [
-			maskValue
+			MaskValue
 		],
 		template: '<div />'
 	});
@@ -29,7 +29,7 @@ function createWrapper(mask?: string | boolean, dateFormat?: string) {
 }
 
 // Tests
-describe('maskValue', () => {
+describe('MaskValue', () => {
 	it('computes a mask from dateFormat if mask prop is empty', () => {
 		const wrapper = createWrapper(undefined, 'YYYY-DD-MM');
 

--- a/packages/vue-dot/src/patterns/DatePicker/tests/pickerDate.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/pickerDate.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 
-import pickerDate from '../mixins/pickerDate';
+import { PickerDate } from '../mixins/pickerDate';
 
 interface TestComponent extends Vue {
 	pickerDate: string;
@@ -12,7 +12,7 @@ interface TestComponent extends Vue {
 function createWrapper() {
 	const component = Vue.component('test', {
 		mixins: [
-			pickerDate
+			PickerDate
 		],
 		template: '<div />'
 	});
@@ -25,7 +25,7 @@ function createWrapper() {
 }
 
 // Tests
-describe('pickerDate', () => {
+describe('PickerDate', () => {
 	it('receives the value correctly from the prop', () => {
 		const wrapper = createWrapper();
 

--- a/packages/vue-dot/src/patterns/FileList/FileList.vue
+++ b/packages/vue-dot/src/patterns/FileList/FileList.vue
@@ -95,10 +95,10 @@
 	import Vue, { PropType } from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import config from './config';
+	import { config } from './config';
 	import { FileItem } from './types';
 
-	import customizable, { Options } from '../../mixins/customizable';
+	import { customizable, Options } from '../../mixins/customizable';
 
 	import {
 		mdiRefresh,

--- a/packages/vue-dot/src/patterns/FileList/config.ts
+++ b/packages/vue-dot/src/patterns/FileList/config.ts
@@ -1,4 +1,4 @@
-export default {
+export const config = {
 	listItemAvatarIcon: {
 		size: 24
 	},

--- a/packages/vue-dot/src/patterns/FileList/tests/FileList.spec.ts
+++ b/packages/vue-dot/src/patterns/FileList/tests/FileList.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import FileList from '../';
 

--- a/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
+++ b/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
@@ -100,10 +100,10 @@
 	import Vue, { PropType } from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import locales from './locales';
+	import { locales } from './locales';
 
-	import getFileExtension from '../../functions/getFileExtension';
-	import calcHumanFileSize from '../../functions/calcHumanFileSize';
+	import { getFileExtension } from '../../functions/getFileExtension';
+	import { calcHumanFileSize } from '../../functions/calcHumanFileSize';
 
 	import { mdiCloudUpload } from '@mdi/js';
 

--- a/packages/vue-dot/src/patterns/FileUpload/locales.ts
+++ b/packages/vue-dot/src/patterns/FileUpload/locales.ts
@@ -1,4 +1,4 @@
-export default {
+export const locales = {
 	or: 'Ou',
 	chooseFile: 'Choisir un fichier',
 	infoText: (max: string, ext: string) => `Taille max. : ${max}. Formats acceptés : ${ext}`,

--- a/packages/vue-dot/src/patterns/FileUpload/tests/FileUpload.spec.ts
+++ b/packages/vue-dot/src/patterns/FileUpload/tests/FileUpload.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import FileUpload from '../';
 

--- a/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
+++ b/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
@@ -74,15 +74,15 @@
 	import Vue, { PropType } from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import config from './config';
-	import locales from './locales';
+	import { config } from './config';
+	import { locales } from './locales';
 
 	import { Languages, AllLanguagesChar } from './types';
 
 	// ISO 639-1 language database in a JSON object
 	import languages from 'languages';
 
-	import customizable from '../../mixins/customizable';
+	import { customizable } from '../../mixins/customizable';
 
 	import { mdiChevronDown } from '@mdi/js';
 

--- a/packages/vue-dot/src/patterns/LangBtn/config.ts
+++ b/packages/vue-dot/src/patterns/LangBtn/config.ts
@@ -1,4 +1,4 @@
-export default {
+export const config = {
 	menu: {
 		offsetY: true
 	},

--- a/packages/vue-dot/src/patterns/LangBtn/locales.ts
+++ b/packages/vue-dot/src/patterns/LangBtn/locales.ts
@@ -1,3 +1,3 @@
-export default {
+export const locales = {
 	ariaLabel: 'Choix de la langue. Actuellement :'
 };

--- a/packages/vue-dot/src/patterns/LangBtn/tests/LangBtn.spec.ts
+++ b/packages/vue-dot/src/patterns/LangBtn/tests/LangBtn.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import LangBtn from '../';
 

--- a/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
+++ b/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
@@ -35,13 +35,13 @@
 	import Vue from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import config from './config';
-	import locales from './locales';
+	import { config } from './config';
+	import { locales } from './locales';
 
 	import { mapActions, mapState } from 'vuex';
 	import { NotificationObj } from '../../modules/notification';
 
-	import customizable from '../../mixins/customizable';
+	import { customizable } from '../../mixins/customizable';
 
 	const Props = Vue.extend({
 		props: {

--- a/packages/vue-dot/src/patterns/NotificationBar/config.ts
+++ b/packages/vue-dot/src/patterns/NotificationBar/config.ts
@@ -1,4 +1,4 @@
-export default {
+export const config = {
 	snackBar: {
 		value: true,
 		timeout: 0,

--- a/packages/vue-dot/src/patterns/NotificationBar/locales.ts
+++ b/packages/vue-dot/src/patterns/NotificationBar/locales.ts
@@ -1,3 +1,3 @@
-export default {
+export const locales = {
 	close: 'Fermer'
 };

--- a/packages/vue-dot/src/patterns/NotificationBar/tests/NotificationBar.spec.ts
+++ b/packages/vue-dot/src/patterns/NotificationBar/tests/NotificationBar.spec.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
-import localVue, { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { localVue, mountComponent } from '@/tests';
+import { html } from '@/tests/html';
 
 import Vuex, { Store } from 'vuex';
 localVue.use(Vuex);

--- a/packages/vue-dot/src/patterns/PageCard/PageCard.vue
+++ b/packages/vue-dot/src/patterns/PageCard/PageCard.vue
@@ -18,9 +18,9 @@
 	import Vue from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import config from './config';
+	import { config } from './config';
 
-	import customizable from '../../mixins/customizable';
+	import { customizable } from '../../mixins/customizable';
 
 	const Props = Vue.extend({
 		props: {

--- a/packages/vue-dot/src/patterns/PageCard/config.ts
+++ b/packages/vue-dot/src/patterns/PageCard/config.ts
@@ -1,1 +1,1 @@
-export default {};
+export const config = {};

--- a/packages/vue-dot/src/patterns/PageCard/tests/PageCard.spec.ts
+++ b/packages/vue-dot/src/patterns/PageCard/tests/PageCard.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import PageCard from '../';
 

--- a/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
+++ b/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
@@ -34,7 +34,7 @@
 
 	import { Options } from './types';
 
-	import LocalStorageUtility from '../../helpers/localStorageUtility';
+	import { LocalStorageUtility } from '../../helpers/localStorageUtility';
 
 	const Props = Vue.extend({
 		props: {

--- a/packages/vue-dot/src/patterns/PaginatedTable/tests/PaginatedTable.spec.ts
+++ b/packages/vue-dot/src/patterns/PaginatedTable/tests/PaginatedTable.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import PaginatedTable from '../';
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
@@ -76,15 +76,15 @@
 	import Vue, { PropType } from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import config from './config';
-	import locales from './locales';
+	import { config } from './config';
+	import { locales } from './locales';
 	import { FileListItem, SelectItem } from './types';
 
 	import { Refs } from '../../types';
 
-	import required from '../../rules/required';
+	import { required } from '../../rules/required';
 
-	import customizable from '../../mixins/customizable';
+	import { customizable } from '../../mixins/customizable';
 
 	import FileUpload from '../FileUpload';
 	import { ErrorEvent } from '../FileUpload/types';

--- a/packages/vue-dot/src/patterns/UploadWorkflow/config.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/config.ts
@@ -1,4 +1,4 @@
-export default {
+export const config = {
 	fileUpload: {
 		class: 'mt-6'
 	},

--- a/packages/vue-dot/src/patterns/UploadWorkflow/locales.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/locales.ts
@@ -1,4 +1,4 @@
-export default {
+export const locales = {
 	title: (plural: boolean) => `Document${plural ? 's' : ''} à nous transmettre`,
 	modalTitle: 'Fichier transmis',
 	cancelBtn: 'Retour',

--- a/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import html from '@/tests/html';
+import { html } from '@/tests/html';
 
 import FileUpload from '../../FileUpload';
 import FileList from '../../FileList';

--- a/packages/vue-dot/src/patterns/index.ts
+++ b/packages/vue-dot/src/patterns/index.ts
@@ -7,7 +7,7 @@ import PageCard from './PageCard';
 import PaginatedTable from './PaginatedTable';
 import UploadWorkflow from './UploadWorkflow';
 
-export default {
+export const patterns = {
 	DatePicker,
 	FileList,
 	FileUpload,

--- a/packages/vue-dot/src/registerAllComponents.ts
+++ b/packages/vue-dot/src/registerAllComponents.ts
@@ -1,9 +1,9 @@
 import { VueConstructor } from 'vue';
 
-import registerComponents, { Components } from './helpers/registerComponents';
+import { registerComponents, Components } from './helpers/registerComponents';
 
-import { default as elements } from './elements';
-import { default as patterns } from './patterns';
+import { elements } from './elements';
+import { patterns } from './patterns';
 
 const components: Components[] = [
 	elements,
@@ -15,10 +15,8 @@ const components: Components[] = [
  *
  * @param {VueConstructor} Vue The global Vue instance
  */
-function registerAllComponents(Vue: VueConstructor) {
+export function registerAllComponents(Vue: VueConstructor) {
 	components.forEach((component) => {
 		registerComponents(Vue, component);
 	});
 }
-
-export default registerAllComponents;

--- a/packages/vue-dot/src/rules/email/index.ts
+++ b/packages/vue-dot/src/rules/email/index.ts
@@ -1,9 +1,9 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 
 import { defaultErrorMessages } from './locales';
 
 /** Check that the email is valid */
-export function email(errorMessages = defaultErrorMessages) {
+export function emailFn(errorMessages = defaultErrorMessages) {
 	return (value: string) => {
 		// If the value is empty, return true (valid)
 		if (!value) {
@@ -16,4 +16,4 @@ export function email(errorMessages = defaultErrorMessages) {
 	};
 }
 
-export default email();
+export const email = emailFn();

--- a/packages/vue-dot/src/rules/email/tests/email.spec.ts
+++ b/packages/vue-dot/src/rules/email/tests/email.spec.ts
@@ -1,4 +1,4 @@
-import email, { email as emailFn } from '../';
+import { email, emailFn } from '../';
 
 // Tests
 describe('email', () => {

--- a/packages/vue-dot/src/rules/index.ts
+++ b/packages/vue-dot/src/rules/index.ts
@@ -1,26 +1,24 @@
-import email, { email as emailFn } from './email';
-import isDateValid, { isDateValid as isDateValidFn } from './isDateValid';
-import maxLength, { maxLength as maxLengthFn } from './maxLength';
-import minLength, { minLength as minLengthFn } from './minLength';
-import notAfterToday, { notAfterToday as notAfterTodayFn } from './notAfterToday';
-import notBeforeToday, { notBeforeToday as notBeforeTodayFn } from './notBeforeToday';
-import required, { required as requiredFn } from './required';
-
-import { ValidationRules } from './types';
+import { email, emailFn } from './email';
+import { isDateValid, isDateValidFn } from './isDateValid';
+import { maxLength, maxLengthFn } from './maxLength';
+import { minLength, minLengthFn } from './minLength';
+import { notAfterToday, notAfterTodayFn } from './notAfterToday';
+import { notBeforeToday, notBeforeTodayFn } from './notBeforeToday';
+import { required, requiredFn } from './required';
 
 // Export all rules function
 export const rulesFunctions = {
-	email: emailFn,
-	isDateValid: isDateValidFn,
-	maxLength: maxLengthFn,
-	minLength: minLengthFn,
-	notAfterToday: notAfterTodayFn,
-	notBeforeToday: notBeforeTodayFn,
-	required: requiredFn
+	emailFn,
+	isDateValidFn,
+	maxLengthFn,
+	minLengthFn,
+	notAfterTodayFn,
+	notBeforeTodayFn,
+	requiredFn
 };
 
 // Export all rules
-export default {
+export const rules = {
 	email,
 	isDateValid,
 	maxLength,

--- a/packages/vue-dot/src/rules/isDateValid/checkIfDateValid.ts
+++ b/packages/vue-dot/src/rules/isDateValid/checkIfDateValid.ts
@@ -1,8 +1,9 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 import { ErrorMessages } from '../types';
 
 import dayjs from 'dayjs';
-import parseDate from '../../helpers/parseDate';
+
+import { parseDate } from '../../helpers/parseDate';
 
 import isLeapYear from 'dayjs/plugin/isLeapYear';
 
@@ -14,7 +15,7 @@ const DATE_SEPARATORS = /[- /.]/;
 export const DATE_FORMAT_REGEX = /(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.]\d{4}/;
 
 /** Check if the date is valid (exists in the calendar and has the right format) */
-export default function checkIfDateValid(value: string, errorMessages: ErrorMessages) {
+export function checkIfDateValid(value: string, errorMessages: ErrorMessages) {
 	// If value doesn't match regex, date format isn't valid
 	if (!value.match(DATE_FORMAT_REGEX)) {
 		return ruleMessage(errorMessages, 'wrongFormat');

--- a/packages/vue-dot/src/rules/isDateValid/index.ts
+++ b/packages/vue-dot/src/rules/isDateValid/index.ts
@@ -1,11 +1,11 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 
 import { defaultErrorMessages } from './locales';
 
-import checkIfDateValid from './checkIfDateValid';
+import { checkIfDateValid } from './checkIfDateValid';
 
 /** Check that the date is valid (expects ##/##/#### format) */
-export function isDateValid(errorMessages = defaultErrorMessages) {
+export function isDateValidFn(errorMessages = defaultErrorMessages) {
 	return (value: string) => {
 		// If the value is empty, return true (valid)
 		if (!value) {
@@ -16,4 +16,4 @@ export function isDateValid(errorMessages = defaultErrorMessages) {
 	};
 }
 
-export default isDateValid();
+export const isDateValid = isDateValidFn();

--- a/packages/vue-dot/src/rules/isDateValid/tests/isDateValid.spec.ts
+++ b/packages/vue-dot/src/rules/isDateValid/tests/isDateValid.spec.ts
@@ -1,6 +1,6 @@
-import isDateValid, { isDateValid as isDateValidFn } from '../';
-
 import dayjs from 'dayjs';
+
+import { isDateValid, isDateValidFn } from '../';
 
 const DATE_FORMAT = 'DD/MM/YYYY';
 

--- a/packages/vue-dot/src/rules/maxLength/index.ts
+++ b/packages/vue-dot/src/rules/maxLength/index.ts
@@ -1,9 +1,9 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 
 import { defaultErrorMessages } from './locales';
 
 /** Check that the field does not exceeds the max length */
-export function maxLength(max: number, errorMessages = defaultErrorMessages) {
+export function maxLengthFn(max: number, errorMessages = defaultErrorMessages) {
 	// Return the validation function
 	return (value: string) => {
 		// If the value is empty, return true (valid)
@@ -15,4 +15,4 @@ export function maxLength(max: number, errorMessages = defaultErrorMessages) {
 	};
 }
 
-export default maxLength;
+export const maxLength = maxLengthFn;

--- a/packages/vue-dot/src/rules/maxLength/tests/maxLength.spec.ts
+++ b/packages/vue-dot/src/rules/maxLength/tests/maxLength.spec.ts
@@ -1,4 +1,4 @@
-import maxLength from '../';
+import { maxLength } from '../';
 
 // Tests
 describe('maxLength', () => {

--- a/packages/vue-dot/src/rules/minLength/index.ts
+++ b/packages/vue-dot/src/rules/minLength/index.ts
@@ -1,9 +1,9 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 
 import { defaultErrorMessages } from './locales';
 
 /** Check that the field exceeds the min length */
-export function minLength(min: number, errorMessages = defaultErrorMessages) {
+export function minLengthFn(min: number, errorMessages = defaultErrorMessages) {
 	// Return the validation function
 	return (value: string) => {
 		// If the value is empty, return true (valid)
@@ -15,4 +15,4 @@ export function minLength(min: number, errorMessages = defaultErrorMessages) {
 	};
 }
 
-export default minLength;
+export const minLength = minLengthFn;

--- a/packages/vue-dot/src/rules/minLength/tests/minLength.spec.ts
+++ b/packages/vue-dot/src/rules/minLength/tests/minLength.spec.ts
@@ -1,4 +1,4 @@
-import minLength from '../';
+import { minLength } from '../';
 
 // Tests
 describe('minLength', () => {

--- a/packages/vue-dot/src/rules/notAfterToday/index.ts
+++ b/packages/vue-dot/src/rules/notAfterToday/index.ts
@@ -1,11 +1,11 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 
 import { defaultErrorMessages } from './locales';
 
-import isDateBeforeNow from './isDateBeforeNow';
+import { isDateBeforeNow } from './isDateBeforeNow';
 
 /** Check that the date is not after today (expects ##/##/#### format) */
-export function notAfterToday(errorMessages = defaultErrorMessages) {
+export function notAfterTodayFn(errorMessages = defaultErrorMessages) {
 	return (value: string) => {
 		// If the value is empty, return true (valid)
 		if (!value) {
@@ -18,4 +18,4 @@ export function notAfterToday(errorMessages = defaultErrorMessages) {
 	};
 }
 
-export default notAfterToday();
+export const notAfterToday = notAfterTodayFn();

--- a/packages/vue-dot/src/rules/notAfterToday/isDateBeforeNow.ts
+++ b/packages/vue-dot/src/rules/notAfterToday/isDateBeforeNow.ts
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs';
-import parseDate from '../../helpers/parseDate';
+
+import { parseDate } from '../../helpers/parseDate';
 
 /** Check that the date is before now */
-export default function isDateBeforeNow(value: string) {
+export function isDateBeforeNow(value: string) {
 	// Date is DD/MM/YYYY format
 	const date = parseDate(value);
 	const now = dayjs();

--- a/packages/vue-dot/src/rules/notAfterToday/tests/notAfterToday.spec.ts
+++ b/packages/vue-dot/src/rules/notAfterToday/tests/notAfterToday.spec.ts
@@ -1,6 +1,6 @@
-import notAfterToday, { notAfterToday as notAfterTodayFn } from '../';
-
 import dayjs from 'dayjs';
+
+import { notAfterToday, notAfterTodayFn } from '../';
 
 const DATE_FORMAT = 'DD/MM/YYYY';
 

--- a/packages/vue-dot/src/rules/notBeforeToday/index.ts
+++ b/packages/vue-dot/src/rules/notBeforeToday/index.ts
@@ -1,11 +1,11 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 
 import { defaultErrorMessages } from './locales';
 
-import isDateAfterNow from './isDateAfterNow';
+import { isDateAfterNow } from './isDateAfterNow';
 
 /** Check that the date is not before today (expects ##/##/#### format) */
-export function notBeforeToday(errorMessages = defaultErrorMessages) {
+export function notBeforeTodayFn(errorMessages = defaultErrorMessages) {
 	return (value: string) => {
 		// If the value is empty, return true (valid)
 		if (!value) {
@@ -18,4 +18,4 @@ export function notBeforeToday(errorMessages = defaultErrorMessages) {
 	};
 }
 
-export default notBeforeToday();
+export const notBeforeToday = notBeforeTodayFn();

--- a/packages/vue-dot/src/rules/notBeforeToday/isDateAfterNow.ts
+++ b/packages/vue-dot/src/rules/notBeforeToday/isDateAfterNow.ts
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs';
-import parseDate from '../../helpers/parseDate';
+
+import { parseDate } from '../../helpers/parseDate';
 
 /** Check that the date is after now */
-export default function isDateAfterNow(value: string) {
+export function isDateAfterNow(value: string) {
 	// Date is DD/MM/YYYY format
 	const date = parseDate(value);
 	const now = dayjs();

--- a/packages/vue-dot/src/rules/notBeforeToday/tests/notBeforeToday.spec.ts
+++ b/packages/vue-dot/src/rules/notBeforeToday/tests/notBeforeToday.spec.ts
@@ -1,6 +1,6 @@
-import notBeforeToday, { notBeforeToday as notBeforeTodayFn } from '../';
-
 import dayjs from 'dayjs';
+
+import { notBeforeToday, notBeforeTodayFn } from '../';
 
 const DATE_FORMAT = 'DD/MM/YYYY';
 

--- a/packages/vue-dot/src/rules/required/index.ts
+++ b/packages/vue-dot/src/rules/required/index.ts
@@ -1,9 +1,9 @@
-import ruleMessage from '../../helpers/ruleMessage';
+import { ruleMessage } from '../../helpers/ruleMessage';
 
 import { defaultErrorMessages } from './locales';
 
 /** Check that the field is non-empty */
-export function required(errorMessages = defaultErrorMessages) {
+export function requiredFn(errorMessages = defaultErrorMessages) {
 	// The value can be an array of string in select with the multiple prop
 	return (value: string | string[]) => {
 		let valid: boolean;
@@ -25,4 +25,4 @@ export function required(errorMessages = defaultErrorMessages) {
 	};
 }
 
-export default required();
+export const required = requiredFn();

--- a/packages/vue-dot/src/rules/required/tests/required.spec.ts
+++ b/packages/vue-dot/src/rules/required/tests/required.spec.ts
@@ -1,4 +1,4 @@
-import required, { required as requiredFn } from '../';
+import { required, requiredFn } from '../';
 
 // Tests
 describe('required', () => {

--- a/packages/vue-dot/src/tokens/index.ts
+++ b/packages/vue-dot/src/tokens/index.ts
@@ -1,4 +1,4 @@
-import vuetifyTheme from './vuetifyTheme';
+import { vuetifyTheme } from './vuetifyTheme';
 
 const TAB_CHARACTER = '	';
 
@@ -17,4 +17,7 @@ const tokens = {
 	}
 };
 
+// We need a CommonJS export (and only this) for the
+// package json-to-scss in order to generate a
+// clean token file
 export = tokens;

--- a/packages/vue-dot/src/tokens/vuetifyTheme.ts
+++ b/packages/vue-dot/src/tokens/vuetifyTheme.ts
@@ -2,7 +2,7 @@
  * Colors used in the Vuetify theme
  * that are also Design Tokens
  */
-export default {
+export const vuetifyTheme = {
 	// Brand
 	primary: '#003463',
 	secondary: '#0c4887',

--- a/packages/vue-dot/tests/html.ts
+++ b/packages/vue-dot/tests/html.ts
@@ -31,7 +31,7 @@ interface HTMLFnOpts {
  * @param {string} options.functionRemplacement Default remplacement is '{[Function]}'.
  * @param {AttrIgnoreFunction} options.attrIgnore Default is `undefined`.
  */
-export default function html(wrapper: Wrapper<Vue>, options?: HTMLFnOpts) {
+export function html(wrapper: Wrapper<Vue>, options?: HTMLFnOpts) {
 	const opts = {
 		...DEFAULT_OPTIONS,
 		...options

--- a/packages/vue-dot/tests/index.ts
+++ b/packages/vue-dot/tests/index.ts
@@ -35,4 +35,4 @@ export function mountComponent(
 	});
 }
 
-export default localVue;
+export { localVue };

--- a/packages/vue-dot/tests/integration/__snapshots__/rules.spec.ts.snap
+++ b/packages/vue-dot/tests/integration/__snapshots__/rules.spec.ts.snap
@@ -14,12 +14,12 @@ Object {
 
 exports[`rules should list all rules functions 1`] = `
 Object {
-  "email": [Function],
-  "isDateValid": [Function],
-  "maxLength": [Function],
-  "minLength": [Function],
-  "notAfterToday": [Function],
-  "notBeforeToday": [Function],
-  "required": [Function],
+  "emailFn": [Function],
+  "isDateValidFn": [Function],
+  "maxLengthFn": [Function],
+  "minLengthFn": [Function],
+  "notAfterTodayFn": [Function],
+  "notBeforeTodayFn": [Function],
+  "requiredFn": [Function],
 }
 `;

--- a/packages/vue-dot/tests/integration/directives.spec.ts
+++ b/packages/vue-dot/tests/integration/directives.spec.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+
 import registerDirectives from '../../src/directives';
 
 import { getDirectives } from './utils';

--- a/packages/vue-dot/tests/integration/libTheme.spec.ts
+++ b/packages/vue-dot/tests/integration/libTheme.spec.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+
 import VueDot from '../../src';
 
 import { getComponents, getDirectives } from './utils';

--- a/packages/vue-dot/tests/integration/plugin.spec.ts
+++ b/packages/vue-dot/tests/integration/plugin.spec.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+
 import VueDot from '../../src';
 
 import { getComponents, getDirectives } from './utils';

--- a/packages/vue-dot/tests/integration/registerAllComponents.spec.ts
+++ b/packages/vue-dot/tests/integration/registerAllComponents.spec.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
-import registerAllComponents from '../../src/registerAllComponents';
+
+import { registerAllComponents } from '../../src/registerAllComponents';
 
 import { getComponents } from './utils';
 

--- a/packages/vue-dot/tests/integration/rules.spec.ts
+++ b/packages/vue-dot/tests/integration/rules.spec.ts
@@ -1,4 +1,4 @@
-import rules, { rulesFunctions } from '../../src/rules';
+import { rules, rulesFunctions } from '../../src/rules';
 
 describe('rules', () => {
 	it('should list all rules', () => {

--- a/packages/vue-dot/tests/integration/tokens.spec.ts
+++ b/packages/vue-dot/tests/integration/tokens.spec.ts
@@ -1,16 +1,7 @@
-import * as tokensSrc from '../../src/tokens';
-
-interface TokensObj {
-	default: {
-		_jsonToScss: object;
-	};
-}
+import tokens from '../../src/tokens';
 
 describe('tokens', () => {
 	it('should register all tokens', () => {
-		// Type default import
-		const tokensObj = tokensSrc as unknown as TokensObj;
-		const tokens = tokensObj.default;
 		// Remove config
 		delete tokens._jsonToScss;
 


### PR DESCRIPTION
Inspired by https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/.

Default exports allows to rename things implicitly, eg. if you have `export default myVar;`, you can do `import myThing from './myVar';`. It makes reading/searching code more complicated.

With a named export, you are forced to rename explicitly: `import { myVar as myThing } from './myVar';`.

And we actually had some cases like this!

Eg. we were importing mixins in `camelCase` but they were defined in `PascalCase` because they are classes, this makes the code harder to understand since we're loosing this information.

The point of this PR is to adress this issue, but this **is a breaking change** since we're modifying almost all exports!