### PR TITLE
⬆️ Upgrade @vue/test-utils

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/index.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/index.ts
@@ -1,23 +1,25 @@
 // Global test configuration
 import Vue from 'vue';
 
-import VueTestUtils,
+import {
 	createLocalVue,
 	mount,
 	shallowMount,
-	VueClass,
 	MountOptions,
-	ShallowMountOptions
+	ShallowMountOptions,
+	Wrapper,
+	VueClass,
+	config
 } from '@vue/test-utils';<% if (i18n) { %>
 
 // If mocks is undefined, init it
-if (!VueTestUtils.config.mocks) {
-	VueTestUtils.config.mocks = {};
+if (!config.mocks) {
+	config.mocks = {};
 }
 
 // Mock i18n functions
-VueTestUtils.config.mocks.$t = (key: string) => key;
-VueTestUtils.config.mocks.$tc = (key: string) => key;<% } %>
+config.mocks.$t = (key: string) => key;
+config.mocks.$tc = (key: string) => key;<% } %>
 
 // Create empty router and export it
 import VueRouter, { RouterOptions } from 'vue-router';
@@ -72,15 +74,15 @@ const vuetify = new Vuetify();
  * Generic mount function
  *
  * @param {VueClass} component The component to mount
- * @param {ShallowMountOptions|MountOptions} [options] The mount function options
- * @param {boolean} [fullMount] Use mount instead of shallowMount
- * @returns {VueTestUtils.Wrapper} The wrapper instance
+ * @param {ShallowMountOptions|MountOptions} [options={}] The mount function options
+ * @param {boolean} [fullMount=false] Use mount instead of shallowMount
+ * @returns {Wrapper} The wrapper instance
  */
 export function mountComponent(
 	component: VueClass<Vue>,
 	options: ShallowMountOptions<Vue> | MountOptions<Vue> = {},
 	fullMount: boolean = false
-): VueTestUtils.Wrapper<Vue> {
+): Wrapper<Vue> {
 	// Use mount() instead of shallowMount() when fullMount is true
 	const fn = fullMount ? mount : shallowMount;
 

--- a/packages/vue-dot/package.json
+++ b/packages/vue-dot/package.json
@@ -55,7 +55,7 @@
 		"@vue/cli-plugin-typescript": "^4.1.2",
 		"@vue/cli-plugin-unit-jest": "^4.1.2",
 		"@vue/cli-service": "^4.1.2",
-		"@vue/test-utils": "1.0.0-beta.30",
+		"@vue/test-utils": "1.0.0-beta.31",
 		"babel-core": "7.0.0-bridge.0",
 		"core-js": "^3.6.4",
 		"json-to-scss": "^1.4.0",

--- a/packages/vue-dot/tests/index.ts
+++ b/packages/vue-dot/tests/index.ts
@@ -5,9 +5,10 @@ import {
 	createLocalVue,
 	mount,
 	shallowMount,
-	VueClass,
 	MountOptions,
-	ShallowMountOptions
+	ShallowMountOptions,
+	Wrapper,
+	VueClass
 } from '@vue/test-utils';
 
 // Create localVue
@@ -19,12 +20,19 @@ Vue.use(Vuetify);
 
 const vuetify = new Vuetify();
 
-/** Generic build fonction */
+/**
+ * Generic mount function
+ *
+ * @param {VueClass} component The component to mount
+ * @param {ShallowMountOptions|MountOptions} [options={}] The mount function options
+ * @param {boolean} [fullMount=false] Use mount instead of shallowMount
+ * @returns {Wrapper} The wrapper instance
+ */
 export function mountComponent(
 	component: VueClass<Vue>,
-	options?: ShallowMountOptions<Vue> | MountOptions<Vue>,
-	fullMount = false
-) {
+	options: ShallowMountOptions<Vue> | MountOptions<Vue> = {},
+	fullMount: boolean = false
+): Wrapper<Vue> {
 	// Use mount() instead of shallowMount() when fullMount is true
 	const fn = fullMount ? mount : shallowMount;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3004,10 +3004,10 @@
   resolved "https://registry.yarnpkg.com/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.1.tgz#18723530d304f443021da2292d6ec9502826104a"
   integrity sha512-8VCoJeeH8tCkzhkpfOkt+abALQkS11OIHhte5MBzYaKMTqK0A3ZAKEUVAffsOklhEv7t0yrQt696Opnu9oAx+w==
 
-"@vue/test-utils@1.0.0-beta.30":
-  version "1.0.0-beta.30"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.30.tgz#d5f26d1e2411fdb7fa7fdedb61b4b4ea4194c49d"
-  integrity sha512-Wyvcha9fNk8+kzTDwb3xWGjPkCPzHSYSwKP6MplrPTG/auhqoad7JqUEceZLc6u7AU4km2pPQ8/m9s0RgCZ0NA==
+"@vue/test-utils@1.0.0-beta.31":
+  version "1.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.31.tgz#580d6e45f07452e497d69807d80986e713949b73"
+  integrity sha512-IlhSx5hyEVnbvDZ3P98R1jNmy88QAd/y66Upn4EcvxSD5D4hwOutl3dIdfmSTSXs4b9DIMDnEVjX7t00cvOnvg==
   dependencies:
     dom-event-types "^1.0.0"
     lodash "^4.17.15"


### PR DESCRIPTION
In version 1.0.0-beta.31, @vue/test-utils removed default export, so we needed to upgrade Vue Dot tests and Vue Dash template