### PR TITLE
♻️ vue-dot: Add SubHeader loading state

### DIFF
--- a/packages/vue-dot/playground/examples/SubHeaderEx.vue
+++ b/packages/vue-dot/playground/examples/SubHeaderEx.vue
@@ -1,22 +1,51 @@
 <template>
 	<DocSection title="SubHeader">
 		<SubHeader
+			:loading="loading"
 			:data-lists="dataLists"
 			title-text="Prénom Nom (d'usage)"
 			sub-title-text="1 69 08 75 125 456 75"
 		>
 			<!-- ProgressBar -->
 			<template #additional-informations>
-				<p class="white--text mt-8 mb-0">
-					Profil complété à 50%
-				</p>
+				<template v-if="loading">
+					<HeaderLoading
+						class="mt-8"
+						height="23"
+						width="150"
+						dark
+					/>
 
-				<VProgressLinear
-					v-bind="progressLinearOpts"
-					:value="progressValue"
-				/>
+					<HeaderLoading
+						class="mt-2"
+						height="10"
+						width="300"
+						tile
+						dark
+					/>
+				</template>
+
+				<template v-else>
+					<p class="white--text mt-8 mb-0">
+						Profil complété à 50%
+					</p>
+
+					<VProgressLinear
+						v-bind="progressLinearOpts"
+						:value="progressValue"
+						class="mb-5"
+					/>
+				</template>
 			</template>
 		</SubHeader>
+
+		<VBtn
+			class="mt-4"
+			color="accent"
+			@click="loading = !loading"
+		>
+			{{ loading ? 'Unset' : 'Set' }} loading
+		</VBtn>
 	</DocSection>
 </template>
 
@@ -65,5 +94,7 @@
 			backgroundColor: '#fff',
 			backgroundOpacity: '.24'
 		};
+
+		loading = false;
 	}
 </script>

--- a/packages/vue-dot/playground/examples/SubHeaderEx.vue
+++ b/packages/vue-dot/playground/examples/SubHeaderEx.vue
@@ -8,18 +8,20 @@
 		>
 			<!-- ProgressBar -->
 			<template #additional-informations>
+				<VSpacer />
+
 				<template v-if="loading">
 					<HeaderLoading
 						class="mt-8"
-						height="23"
+						height="24"
 						width="150"
 						dark
 					/>
 
 					<HeaderLoading
-						class="mt-2"
-						height="10"
-						width="300"
+						class="mt-2 mb-1"
+						height="8"
+						width="100%"
 						tile
 						dark
 					/>
@@ -33,7 +35,7 @@
 					<VProgressLinear
 						v-bind="progressLinearOpts"
 						:value="progressValue"
-						class="mb-5"
+						class="mb-1"
 					/>
 				</template>
 			</template>

--- a/packages/vue-dot/src/elements/HeaderLoading/HeaderLoading.vue
+++ b/packages/vue-dot/src/elements/HeaderLoading/HeaderLoading.vue
@@ -28,4 +28,11 @@
 			border-radius: 35px;
 		}
 	}
+
+	// Remove border radius when tile option is activated
+	.vd-header-loading.v-skeleton-loader--tile ::v-deep	{
+		.v-skeleton-loader__heading {
+			border-radius: 0;
+		}
+	}
 </style>

--- a/packages/vue-dot/src/elements/HeaderLoading/HeaderLoading.vue
+++ b/packages/vue-dot/src/elements/HeaderLoading/HeaderLoading.vue
@@ -1,0 +1,31 @@
+<template>
+	<VSkeletonLoader
+		v-bind="$attrs"
+		class="vd-header-loading"
+		type="heading"
+	/>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	/**
+	 * HeaderLoading is a component that extends VSkeletonLoader
+	 * to provide a loader that you can size as needed
+	 */
+	@Component({
+		inheritAttrs: false
+	})
+	export default class HeaderLoading extends Vue {}
+</script>
+
+<style lang="scss" scoped>
+	.vd-header-loading ::v-deep {
+		.v-skeleton-loader__heading {
+			width: 100%;
+			height: 100%;
+			border-radius: 35px;
+		}
+	}
+</style>

--- a/packages/vue-dot/src/elements/HeaderLoading/index.ts
+++ b/packages/vue-dot/src/elements/HeaderLoading/index.ts
@@ -1,0 +1,3 @@
+import HeaderLoading from './HeaderLoading.vue';
+
+export default HeaderLoading;

--- a/packages/vue-dot/src/elements/HeaderLoading/tests/HeaderLoading.spec.ts
+++ b/packages/vue-dot/src/elements/HeaderLoading/tests/HeaderLoading.spec.ts
@@ -1,0 +1,19 @@
+import Vue from 'vue';
+import { Wrapper } from '@vue/test-utils';
+
+import { mountComponent } from '@/tests';
+import { html } from '@/tests/html';
+
+import HeaderLoading from '../';
+
+let wrapper: Wrapper<Vue>;
+
+// Tests
+describe('HeaderLoading', () => {
+	it('renders correctly', () => {
+		// Mount component
+		wrapper = mountComponent(HeaderLoading);
+
+		expect(html(wrapper)).toMatchSnapshot();
+	});
+});

--- a/packages/vue-dot/src/elements/HeaderLoading/tests/__snapshots__/HeaderLoading.spec.ts.snap
+++ b/packages/vue-dot/src/elements/HeaderLoading/tests/__snapshots__/HeaderLoading.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeaderLoading renders correctly 1`] = `<vskeletonloader-stub type="heading" types="[object Object]" class="vd-header-loading"></vskeletonloader-stub>`;

--- a/packages/vue-dot/src/elements/index.ts
+++ b/packages/vue-dot/src/elements/index.ts
@@ -1,9 +1,11 @@
 import CopyBtn from './CopyBtn';
 import CustomIcon from './CustomIcon';
 import DataList from './DataList';
+import HeaderLoading from './HeaderLoading';
 
 export const elements = {
 	CopyBtn,
 	CustomIcon,
-	DataList
+	DataList,
+	HeaderLoading
 };

--- a/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
@@ -1,19 +1,30 @@
 <template>
 	<div class="vd-sub-header secondary white--text py-3 px-6">
 		<slot name="back-btn">
-			<VBtn
-				v-if="!hideBackBtn"
-				v-bind="options.backBtn"
-				@click="$emit('back')"
-			>
-				<slot name="back-btn-icon">
-					<VIcon class="mr-2">
-						{{ backArrowIcon }}
-					</VIcon>
-				</slot>
+			<template v-if="!hideBackBtn">
+				<VSkeletonLoader
+					v-if="loading"
+					height="28"
+					type="button"
+					class="mb-1"
+					width="100"
+					dark
+				/>
 
-				{{ backBtnText }}
-			</VBtn>
+				<VBtn
+					v-else
+					v-bind="options.backBtn"
+					@click="$emit('back')"
+				>
+					<slot name="back-btn-icon">
+						<VIcon class="mr-2">
+							{{ backArrowIcon }}
+						</VIcon>
+					</slot>
+
+					{{ backBtnText }}
+				</VBtn>
+			</template>
 		</slot>
 
 		<VLayout
@@ -22,21 +33,41 @@
 		>
 			<div class="vd-sub-header-informations">
 				<slot name="title">
-					<h2 class="headline font-weight-bold">
+					<HeaderLoading
+						v-if="loading"
+						width="300"
+						height="32"
+						dark
+					/>
+
+					<h2
+						v-else
+						class="headline font-weight-bold"
+					>
 						{{ titleText }}
 					</h2>
 				</slot>
 
 				<slot name="sub-title">
-					<p
-						v-if="subTitleText"
-						class="title font-weight-bold mt-1 mb-0"
-						:style="{
-							color: fadeWhite
-						}"
-					>
-						{{ subTitleText }}
-					</p>
+					<template v-if="subTitleText">
+						<HeaderLoading
+							v-if="loading"
+							class="mt-1"
+							width="250"
+							height="32"
+							dark
+						/>
+
+						<p
+							v-else
+							class="title font-weight-bold mt-1 mb-0"
+							:style="{
+								color: fadeWhite
+							}"
+						>
+							{{ subTitleText }}
+						</p>
+					</template>
 				</slot>
 
 				<slot name="additional-informations" />
@@ -46,10 +77,13 @@
 				<VLayout
 					v-if="dataLists"
 					v-bind="options.dataListsLayout"
-					class="vd-sub-header-data-list"
+					class="vd-sub-header-data-list mb-5"
 				>
+					<DataListLoading v-if="loading" />
+
 					<DataList
 						v-for="(dataList, index) in dataLists"
+						v-else
 						:key="'vd-sub-header-data-list' + index"
 						:list-title="dataList.title"
 						:list="dataList.items"
@@ -75,6 +109,8 @@
 	import { customizable } from '../../mixins/customizable';
 
 	import DataList from '../../elements/DataList';
+
+	import DataListLoading from './loading/DataListLoading.vue';
 
 	import { mdiKeyboardBackspace } from '@mdi/js';
 
@@ -104,6 +140,10 @@
 			dataLists: {
 				type: Array as PropType<IDataList[]>,
 				default: undefined
+			},
+			loading: {
+				type: Boolean,
+				default: false
 			}
 		}
 	});
@@ -116,7 +156,8 @@
 	 */
 	@Component({
 		components: {
-			DataList
+			DataList,
+			DataListLoading
 		}
 	})
 	export default class SubHeader extends MixinsDeclaration {
@@ -132,6 +173,18 @@
 <style lang="scss" scoped>
 	.vd-sub-header {
 		width: 100%;
+
+		::v-deep {
+			.v-skeleton-loader__heading {
+				width: 100%;
+				height: 100%;
+				border-radius: 20px;
+			}
+		}
+	}
+
+	.vd-sub-header-informations {
+		min-width: 310px;
 	}
 
 	.vd-sub-header-data-list {

--- a/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
@@ -1,12 +1,11 @@
 <template>
-	<div class="vd-sub-header secondary white--text py-3 px-6">
+	<div class="vd-sub-header secondary white--text py-6 px-8">
 		<slot name="back-btn">
 			<template v-if="!hideBackBtn">
 				<VSkeletonLoader
 					v-if="loading"
 					height="28"
 					type="button"
-					class="mb-1"
 					width="100"
 					dark
 				/>
@@ -31,12 +30,15 @@
 			v-bind="options.contentLayout"
 			class="vd-sub-header-content"
 		>
-			<div class="vd-sub-header-informations">
+			<VLayout
+				class="vd-sub-header-informations mt-1"
+				column
+			>
 				<slot name="title">
 					<HeaderLoading
 						v-if="loading"
 						width="300"
-						height="32"
+						height="2rem"
 						dark
 					/>
 
@@ -54,7 +56,7 @@
 							v-if="loading"
 							class="mt-1"
 							width="250"
-							height="32"
+							height="2rem"
 							dark
 						/>
 
@@ -71,13 +73,13 @@
 				</slot>
 
 				<slot name="additional-informations" />
-			</div>
+			</VLayout>
 
 			<slot name="right-content">
 				<VLayout
 					v-if="dataLists"
 					v-bind="options.dataListsLayout"
-					class="vd-sub-header-data-list mb-5"
+					class="vd-sub-header-data-list mt-n2 mx-n2"
 				>
 					<DataListLoading v-if="loading" />
 
@@ -88,7 +90,7 @@
 						:list-title="dataList.title"
 						:list="dataList.items"
 						:label-color="fadeWhite"
-						title-class="subtitle-1 font-weight-bold mb-2"
+						title-class="subtitle-1 font-weight-bold mb-2 mt-3"
 						width="auto"
 						column
 					/>
@@ -184,7 +186,9 @@
 	}
 
 	.vd-sub-header-informations {
-		min-width: 310px;
+		flex: none;
+		width: 310px;
+		margin-right: 8px; // Avoid "contact" with right part
 	}
 
 	.vd-sub-header-data-list {
@@ -193,6 +197,7 @@
 
 		::v-deep .vd-data-list {
 			max-width: 200px;
+			margin-left: 8px;
 
 			// Apply margin right to avoid empty
 			// space on smaller screens
@@ -203,6 +208,24 @@
 			.vd-key {
 				display: inline-block;
 				font-size: .75rem !important;
+			}
+		}
+	}
+
+	@media only screen and (max-width: 425px) {
+		.vd-sub-header-informations {
+			// Let section take all width
+			margin-right: 0;
+		}
+
+		// Remove margin right on DataList on small screens
+		.vd-sub-header-data-list {
+			::v-deep .vd-data-list {
+				margin: 0 8px;
+
+				&:not(:last-child) {
+					margin-right: 8px;
+				}
 			}
 		}
 	}

--- a/packages/vue-dot/src/patterns/SubHeader/config.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/config.ts
@@ -7,7 +7,7 @@ export const config = {
 	},
 	contentLayout: {
 		wrap: true,
-		class: 'justify-space-between mb-5'
+		class: 'justify-space-between'
 	},
 	dataListsLayout: {
 		wrap: true

--- a/packages/vue-dot/src/patterns/SubHeader/config.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/config.ts
@@ -3,7 +3,7 @@ export const config = {
 		color: 'transparent',
 		small: true,
 		depressed: true,
-		class: 'text-none font-weight-regular white--text mx-n4 mb-1'
+		class: 'text-none font-weight-regular white--text mx-n4'
 	},
 	contentLayout: {
 		wrap: true,

--- a/packages/vue-dot/src/patterns/SubHeader/loading/DataListLoading.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/loading/DataListLoading.vue
@@ -1,15 +1,14 @@
 <template>
-	<VLayout>
+	<VLayout wrap>
 		<VLayout
 			v-for="columnIndex in columnsNumber"
 			:key="columnIndex + '-loader'"
-			:style="{
-				marginRight: columnIndex !== columnsNumber ? '80px' : undefined
-			}"
+			class="vd-data-list-loading-item"
 			column
 		>
 			<HeaderLoading
-				height="26"
+				class="mb-2 mt-3"
+				height="1.75rem"
 				width="100"
 				dark
 			/>
@@ -17,16 +16,16 @@
 			<template v-for="index in itemsNumber">
 				<HeaderLoading
 					:key="index + '-key'"
-					class="mt-4"
-					height="14"
+					height="1.25rem"
+					class="mb-1"
 					width="60"
 					dark
 				/>
 
 				<HeaderLoading
 					:key="index + '-value'"
-					class="mt-2"
-					height="22"
+					class="mb-2"
+					height="1.5rem"
 					width="90"
 					dark
 				/>
@@ -57,3 +56,22 @@
 	@Component
 	export default class DataListLoading extends MixinsDeclaration {}
 </script>
+
+<style lang="scss" scoped>
+	.vd-data-list-loading-item {
+		flex: none;
+		margin-left: 8px;
+
+		&:not(:last-child) {
+			margin-right: 80px;
+		}
+	}
+
+	@media only screen and (max-width: 425px) {
+		.vd-data-list-loading-item {
+			&:not(:last-child) {
+				margin-right: 0;
+			}
+		}
+	}
+</style>

--- a/packages/vue-dot/src/patterns/SubHeader/loading/DataListLoading.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/loading/DataListLoading.vue
@@ -1,0 +1,59 @@
+<template>
+	<VLayout>
+		<VLayout
+			v-for="columnIndex in columnsNumber"
+			:key="columnIndex + '-loader'"
+			:style="{
+				marginRight: columnIndex !== columnsNumber ? '80px' : undefined
+			}"
+			column
+		>
+			<HeaderLoading
+				height="26"
+				width="100"
+				dark
+			/>
+
+			<template v-for="index in itemsNumber">
+				<HeaderLoading
+					:key="index + '-key'"
+					class="mt-4"
+					height="14"
+					width="60"
+					dark
+				/>
+
+				<HeaderLoading
+					:key="index + '-value'"
+					class="mt-2"
+					height="22"
+					width="90"
+					dark
+				/>
+			</template>
+		</VLayout>
+	</VLayout>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component, { mixins } from 'vue-class-component';
+
+	const Props = Vue.extend({
+		props: {
+			columnsNumber: {
+				type: Number,
+				default: 4
+			},
+			itemsNumber: {
+				type: Number,
+				default: 2
+			}
+		}
+	});
+
+	const MixinsDeclaration = mixins(Props);
+
+	@Component
+	export default class DataListLoading extends MixinsDeclaration {}
+</script>

--- a/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SubHeader renders correctly 1`] = `
-<div class="vd-sub-header secondary white--text py-3 px-6">
-  <vbtn-stub color="transparent" tag="button" activeclass="" small="true" depressed="true" type="button" class="text-none font-weight-regular white--text mx-n4 mb-1">
+<div class="vd-sub-header secondary white--text py-6 px-8">
+  <vbtn-stub color="transparent" tag="button" activeclass="" small="true" depressed="true" type="button" class="text-none font-weight-regular white--text mx-n4">
     <vicon-stub class="mr-2">
       M21,11H6.83L10.41,7.41L9,6L3,12L9,18L10.41,16.58L6.83,13H21V11Z
     </vicon-stub>
 
     Retour
   </vbtn-stub>
-  <vlayout-stub tag="div" wrap="true" class="vd-sub-header-content justify-space-between mb-5">
-    <div class="vd-sub-header-informations">
+  <vlayout-stub tag="div" wrap="true" class="vd-sub-header-content justify-space-between">
+    <vlayout-stub tag="div" column="" class="vd-sub-header-informations mt-1">
       <h2 class="headline font-weight-bold">
         Test
       </h2>
       <!---->
-    </div>
+    </vlayout-stub>
     <!---->
   </vlayout-stub>
 </div>

--- a/packages/vue-dot/tests/integration/__snapshots__/libTheme.spec.ts.snap
+++ b/packages/vue-dot/tests/integration/__snapshots__/libTheme.spec.ts.snap
@@ -9,6 +9,7 @@ Object {
     "DatePicker",
     "FileList",
     "FileUpload",
+    "HeaderLoading",
     "LangBtn",
     "NotificationBar",
     "PageCard",

--- a/packages/vue-dot/tests/integration/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vue-dot/tests/integration/__snapshots__/plugin.spec.ts.snap
@@ -9,6 +9,7 @@ Object {
     "DatePicker",
     "FileList",
     "FileUpload",
+    "HeaderLoading",
     "LangBtn",
     "NotificationBar",
     "PageCard",

--- a/packages/vue-dot/tests/integration/__snapshots__/registerAllComponents.spec.ts.snap
+++ b/packages/vue-dot/tests/integration/__snapshots__/registerAllComponents.spec.ts.snap
@@ -8,6 +8,7 @@ Array [
   "DatePicker",
   "FileList",
   "FileUpload",
+  "HeaderLoading",
   "LangBtn",
   "NotificationBar",
   "PageCard",


### PR DESCRIPTION
Ajout d'un état de chargement pour le `SubHeader` en utilisant le [`VSkeletonLoader` de Vuetify](https://vuetifyjs.com/en/components/skeleton-loaders) :

![screencast-localhost_8080-2020 02 (online-video-cutter com)](https://user-images.githubusercontent.com/10298932/73762210-2a4fbf00-4770-11ea-88e1-9359c3fc2c2f.gif)

(J'ai dû créer un nouveau composant `HeaderLoading` pour avoir un élément de chargement que je pouvais redimensionner en hauteur)

Et mise à jour du style en accord avec les UX/UI