### PR TITLE
♻️ global: Don't import package.json in client code

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppFooter.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppFooter.vue
@@ -20,13 +20,10 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	import pkg from '../../../package.json';
-
 	/** The application footer */
 	@Component
 	export default class Footer extends Vue {
-		/** The version from package.json */
-		version = pkg.version;
+		version = process.env.VUE_APP_VERSION;
 	}
 </script>
 

--- a/packages/vue-cli-plugin-vue-dash/generator/template/vue.config.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/vue.config.js
@@ -1,5 +1,8 @@
 // Vue CLI configuration
 // see https://cli.vuejs.org/guide/ for help
+
+process.env.VUE_APP_VERSION = require('./package.json').version;
+
 module.exports = {
 	configureWebpack: {
 		devtool: 'source-map',

--- a/packages/vue-dot/playground/Playground.vue
+++ b/packages/vue-dot/playground/Playground.vue
@@ -78,8 +78,6 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	import { version } from '../package.json';
-
 	import { LOCAL_STORAGE_CONTROL } from './plugins/vue-dot';
 
 	import { LocalStorageUtility } from '../src/helpers/localStorageUtility';
@@ -92,7 +90,7 @@
 	 */
 	@Component
 	export default class Playground extends Vue {
-		version = version;
+		version = process.env.VUE_APP_VERSION;
 
 		localStorageUtility = new LocalStorageUtility(LOCAL_STORAGE_CONTROL.version);
 

--- a/packages/vue-dot/vue.config.js
+++ b/packages/vue-dot/vue.config.js
@@ -8,6 +8,8 @@ const CopyPlugin = require('copy-webpack-plugin');
 const LIB_MODE = Boolean(process.env.LIB_MODE); // Use Boolean() to convert undefined to false
 const LIMIT_SIZE = 350000;
 
+process.env.VUE_APP_VERSION = require('./package.json').version;
+
 const LIB_MODE_CONFIG = {
 	// No source map on library mode, we don't need them
 	// because we're publishing the source


### PR DESCRIPTION
Use a proper env var instead of importing version from `package.json` (which included the full file in the client bundle)