### PR TITLE
🔧 Add build stage to CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - node_modules
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.0
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 install:
@@ -16,11 +16,12 @@ install:
 jobs:
   include:
     - stage: test
-      name: 'Lint and test'
+      name: 'Lint, test & build'
       before_script:
         - yarn global add codecov
       script:
         - lerna run lint
         - lerna run test
+        - lerna run build
       after_script:
         - codecov


### PR DESCRIPTION
Build library after tests because some cases cannot be catched by lint or tests (eg. library size)