### PR TITLE
🐛 vue-dot : change the select multiple property path

### DIFF
--- a/packages/vue-dot/src/patterns/FormBuilder/tests/data/questionForm.ts
+++ b/packages/vue-dot/src/patterns/FormBuilder/tests/data/questionForm.ts
@@ -107,8 +107,8 @@ export const questionForm: Form = {
 		description: 'Informations supplémentaires',
 		value: null,
 		items: defaultItems,
+		multiple: true,
 		metadata: {
-			multiple: true,
 			outlined: true
 		}
 	},
@@ -202,9 +202,9 @@ export const questionForm: Form = {
 				value: null
 			}
 		],
+		multiple: true,
 		metadata: {
-			type: 'choiceButton',
-			multiple: true
+			type: 'choiceButton'
 		}
 	}
 };

--- a/packages/vue-dot/src/patterns/FormField/fields/ChoiceButtonField.vue
+++ b/packages/vue-dot/src/patterns/FormField/fields/ChoiceButtonField.vue
@@ -2,6 +2,7 @@
 	<div>
 		<VItemGroup
 			:value="choiceValue"
+			:multiple="Boolean(field.multiple)"
 			v-bind="field.metadata"
 		>
 			<template v-for="(item, index) in filteredItems">

--- a/packages/vue-dot/src/patterns/FormField/fields/SelectField.vue
+++ b/packages/vue-dot/src/patterns/FormField/fields/SelectField.vue
@@ -1,6 +1,7 @@
 <template>
 	<VSelect
 		v-bind="field.metadata"
+		:multiple="Boolean(field.multiple)"
 		:value="field.value"
 		:items="field.items"
 		@change="emitChangeEvent"

--- a/packages/vue-dot/src/patterns/FormField/types.d.ts
+++ b/packages/vue-dot/src/patterns/FormField/types.d.ts
@@ -36,5 +36,6 @@ export interface Field {
 	metadata?: FieldMetadata;
 	items?: FieldItem[];
 	mask?: string;
+	multiple?: boolean;
 	dynamic?: boolean;
 }


### PR DESCRIPTION
Defect QUE-108 field type select multiple
The 'multiple' property given by the api is in the root of the field instead of 'metadata/fieldOptions'.