### PR TITLE
♻️ vue-dot: Refactor debounce directive

### DIFF
--- a/packages/vue-dot/src/directives/debounce/index.ts
+++ b/packages/vue-dot/src/directives/debounce/index.ts
@@ -19,12 +19,9 @@ export const debounce: DirectiveOptions = {
 		}
 
 		const modifiers = Object.keys(binding.modifiers);
-		// If we have a modifier, it's the interval for the debounce function
-		// eg. v-debounce.1000="callback"
 
-		// else, it's the default usage and the value is the interval variable
-		// eg. v-debounce="1000"
-		const value: string = modifiers.length > 0 ? modifiers[0] : binding.value;
+		// The first modifier is the time
+		const time = modifiers[0] !== undefined ? parseInt(modifiers[0], 10) : undefined;
 
 		// Change debounce only if interval has changed
 		el.oninput = debounceFn(() => {
@@ -38,6 +35,6 @@ export const debounce: DirectiveOptions = {
 				// Else, fire a change event
 				el.dispatchEvent(new Event('change'));
 			}
-		}, parseInt(value, 10));
+		}, time);
 	}
 };

--- a/packages/vue-dot/src/directives/debounce/tests/debounce.spec.ts
+++ b/packages/vue-dot/src/directives/debounce/tests/debounce.spec.ts
@@ -62,7 +62,7 @@ describe('debounce', () => {
 		const spy = jest.fn();
 
 		const testComponent = createTestComponent(
-			'<input v-model="value" v-debounce="100">',
+			'<input v-model="value" v-debounce>',
 			spy
 		);
 
@@ -77,11 +77,11 @@ describe('debounce', () => {
 		timeoutTest(input, wrapper, spy);
 	});
 
-	it('works correctly if binded to an element and the input is inside (eg. VTextField)', () => {
+	it('works correctly if not directly binded to an input (eg. VTextField)', () => {
 		const spy = jest.fn();
 
 		const testComponent = createTestComponent(
-			'<div v-debounce.1000="e => value = e"><input :value="value" /></div>',
+			'<div v-debounce="e => value = e"><input :value="value" /></div>',
 			spy
 		);
 
@@ -97,6 +97,25 @@ describe('debounce', () => {
 	});
 
 	it('works correctly if the binding is a function', () => {
+		const spy = jest.fn();
+
+		const testComponent = createTestComponent(
+			'<input v-debounce="e => value = e" :value="value" />',
+			spy
+		);
+
+		const wrapper = mount(testComponent);
+
+		const input = wrapper.find('input') as unknown as HTMLInputElement;
+
+		input.value = 'b';
+
+		wrapper.trigger('input');
+
+		timeoutTest(input, wrapper, spy);
+	});
+
+	it('works correctly if a different delay is provided', () => {
 		const spy = jest.fn();
 
 		const testComponent = createTestComponent(
@@ -119,7 +138,7 @@ describe('debounce', () => {
 		const spy = jest.fn();
 
 		const testComponent = createTestComponent(
-			'<div v-debounce="100" />',
+			'<div v-debounce />',
 			spy
 		);
 

--- a/packages/vue-dot/src/functions/debounce/index.ts
+++ b/packages/vue-dot/src/functions/debounce/index.ts
@@ -5,7 +5,7 @@
  * @param {number} [time=500] The interval of the debounce in milliseconds
  */
 export function debounce(callback: (args: IArguments) => void, time: number = 500): () => void {
-	let interval: NodeJS.Timeout | null;
+	let interval: number | null;
 
 	return () => {
 		if (interval) {
@@ -13,7 +13,7 @@ export function debounce(callback: (args: IArguments) => void, time: number = 50
 		}
 
 		// tslint:disable-next-line:only-arrow-functions
-		interval = setTimeout(function() {
+		interval = window.setTimeout(function() {
 			interval = null;
 
 			callback(arguments);


### PR DESCRIPTION
Refonte de la directive `v-debounce`.

Si aucun délai n'était précisé, la directive n'utilisait pas la valeur par défaut la fonction `debounce`.
(Ici : `parseInt(value, 10)`, `value` pouvait être `undefined` ou une fonction, ce qui renvoyait `NaN`)

Il y avait également deux APIs en une :
- `v-debounce="1000"` pour les inputs classiques
- `v-debounce.1000="e => value = e"` pour les composants personnalisés (ex : `VTextField`)

Afin de corriger ce bug et de n'avoir qu'une seule API, le délai est maintenant toujours spécifié en tant que modificateur :
- `v-debounce.1000`
- `v-debounce.1000="e => value = e"`