### PR TITLE
♻️ vue-dot: Invert boolean props with default true

### DIFF
--- a/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
+++ b/packages/vue-dot/src/patterns/FileUpload/FileUpload.vue
@@ -4,7 +4,7 @@
 		it will trigger the <input>
 	-->
 	<label
-		v-ripple="ripple"
+		v-ripple="!noRipple"
 		class="file-upload d-block pa-4"
 		:class="[
 			{
@@ -131,10 +131,10 @@
 				type: [Array, Object, File],
 				default: () => []
 			},
-			/** Apply v-ripple on the component */
-			ripple: {
+			/** Disable v-ripple on the component */
+			noRipple: {
 				type: Boolean,
-				default: true
+				default: false
 			},
 			/** Disable the component */
 			disabled: {

--- a/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
+++ b/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
@@ -34,7 +34,7 @@
 
 				<!-- Down arrow -->
 				<VIcon
-					v-if="downArrow"
+					v-if="!hideDownArrow"
 					v-bind="options.icon"
 				>
 					{{ downArrowIcon }}
@@ -96,10 +96,10 @@
 				type: [Array, String] as PropType<string[] | AllLanguagesChar>,
 				default: '*'
 			},
-			/** Show the down arrow inside the activator button */
-			downArrow: {
+			/** Hide the down arrow inside the activator button */
+			hideDownArrow: {
 				type: Boolean,
-				default: true
+				default: false
 			},
 			/** Activate flags mode */
 			flags: {


### PR DESCRIPTION
Inversion des propriétés booléennes avec comme valeur par défaut `true`

Avoir des propriétés avec comme valeur par défaut `true` est une mauvaise pratique car cela oblige l'utilisateur à écrire, par exemple `:ripple="false"` ; il est plus simple d'écrire `no-ripple`