### PR TITLE
🐛 vue-dot: Fix "Invalid Date" when wrong format used in DatePicker

### DIFF
--- a/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
@@ -51,7 +51,14 @@ const MixinsDeclaration = mixins(Props);
 				}
 
 				// Format the date to internal format using dateFormatReturn
-				this.date = this.parseDateForModel(date);
+				const parsed = this.parseDateForModel(date);
+
+				// If parsed is an empty string, the date isn't valid, don't continue
+				if (!parsed) {
+					return;
+				}
+
+				this.date = parsed;
 				this.setTextFieldModel();
 
 				// Validate warning rules
@@ -138,7 +145,13 @@ export class DateLogic extends MixinsDeclaration {
 
 	/** Parse a date with dateFormatReturn format to internal format */
 	parseDateForModel(date: string): string {
-		return parseDate(date, this.dateFormatReturn).format(INTERNAL_FORMAT);
+		const parsed = parseDate(date, this.dateFormatReturn);
+
+		if (!parsed.isValid()) {
+			return '';
+		}
+
+		return parsed.format(INTERNAL_FORMAT);
 	}
 
 	parseTextFieldDate(date: string): string {
@@ -182,7 +195,6 @@ export class DateLogic extends MixinsDeclaration {
 	// Setter
 	set dateFormatted(value: string) {
 		this.textFieldDate = value;
-		this.saveFromTextField();
 	}
 
 	/** Save the date from calendar */
@@ -217,11 +229,6 @@ export class DateLogic extends MixinsDeclaration {
 		}
 
 		const formatted = this.parseTextFieldDate(this.textFieldDate);
-
-		// If formatted is an empty string, the date isn't valid, don't continue
-		if (!formatted) {
-			return;
-		}
 
 		// Set the internal date
 		this.date = formatted;

--- a/packages/vue-dot/src/patterns/DatePicker/tests/birthdate.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/birthdate.spec.ts
@@ -85,26 +85,26 @@ describe('Birthdate', () => {
 		expect(wrapper.vm.max).toBe(dayjs().format('YYYY-MM-DD'));
 	});
 
-	it('calls setActivePicker in watch when menu goes from false to true', () => {
+	it('calls setActivePicker in watch when menu goes from false to true', async() => {
 		const spy = jest.fn();
 		const wrapper = createWrapper(true, spy, false);
 
 		wrapper.vm.menu = true;
 
-		wrapper.vm.$nextTick(() => {
-			expect(spy).toHaveBeenCalled();
-		});
+		await wrapper.vm.$nextTick();
+
+		expect(spy).toHaveBeenCalled();
 	});
 
-	it('calls setActivePicker in watch when menu goes from true to false', () => {
+	it('calls setActivePicker in watch when menu goes from true to false', async() => {
 		const spy = jest.fn();
 		const wrapper = createWrapper(true, spy, true);
 
 		wrapper.vm.menu = false;
 
-		wrapper.vm.$nextTick(() => {
-			expect(spy).toHaveBeenCalled();
-		});
+		await wrapper.vm.$nextTick();
+
+		expect(spy).toHaveBeenCalled();
 	});
 
 	it('updates the active picker when setActivePicker is called', () => {

--- a/packages/vue-dot/src/patterns/DatePicker/tests/dateLogic.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/dateLogic.spec.ts
@@ -130,14 +130,14 @@ describe('DateLogic', () => {
 		expect(wrapper.vm.date).toBe('2019-10-29');
 	});
 
-	it('doesn\'t emit change event when the date is invalid', () => {
+	it('emits change event with empty value when the date is invalid', async() => {
 		const wrapper = createWrapper({
 			value: '29-10-2019'
 		});
 
 		wrapper.vm.saveFromTextField();
 
-		expect(wrapper.emitted('change')).toBeFalsy();
+		expect(wrapper.emitted('change')).toEqual([['']]);
 	});
 
 	// parseTextFieldDate
@@ -212,7 +212,7 @@ describe('DateLogic', () => {
 	});
 
 	// Error event
-	it('emits error event when VTextField has error', () => {
+	it('emits error event when VTextField has error', async() => {
 		const wrapper = createWrapper(undefined, {
 			textField: {
 				validateOnBlur: true
@@ -221,18 +221,19 @@ describe('DateLogic', () => {
 
 		wrapper.vm.$refs.input.hasError = true;
 
-		wrapper.vm.$nextTick(() => {
-			expect(wrapper.emitted('error')).toBeTruthy();
-		});
+		await wrapper.vm.$nextTick();
+
+		expect(wrapper.emitted('error')).toBeTruthy();
 	});
 
 	// dateFormatted
-	it('emits change event when dateFormatted is set', () => {
+	it('sets the date correctly when dateFormatted is called', () => {
+		const date = '29/10/2019';
 		const wrapper = createWrapper();
 
-		wrapper.vm.dateFormatted = '29/10/2019';
+		wrapper.vm.dateFormatted = date;
 
-		expect(wrapper.emitted('change')).toBeTruthy();
+		expect(wrapper.vm.textFieldDate).toBe(date);
 	});
 
 	it('returns an empty string when the value is empty', () => {


### PR DESCRIPTION
Lorsqu'un autre format que celui utilisé pour le `v-model` était utilisé, le composant affichait `Invalid Date` dans le champ de texte

Pour corriger cela, lorsque la date est invalide on retourne une chaîne

Cela entraîne un changement de comportement plus général : maintenant lorsqu'il y a une erreur, le composant émet un événement `change` avec une valeur vide

J'ai aussi supprimé un appel à `this.saveFromTextField();` lorsque le `v-model` est mis à jour car on l'appelle déjà lors du `blur`