### PR TITLE
♻️ vue-dot: Force type to date & fix icon alignment in DatePicker

### DIFF
--- a/packages/vue-dot/playground/examples/DatePickerEx.vue
+++ b/packages/vue-dot/playground/examples/DatePickerEx.vue
@@ -38,14 +38,11 @@
 
 		<DatePicker
 			v-model="birthDate"
-			date-format="DD-MM-YYYY"
-			birthdate
-			append-icon
 			:vuetify-options="{
 				// The textField options can be binded
 				// directly if needed
 				textField: {
-					placeholder: ' ',
+					placeholder: null,
 					hint: null,
 					outlined: true,
 					clearable: true,
@@ -60,6 +57,10 @@
 					width: '310px'
 				}
 			}"
+			date-format="DD-MM-YYYY"
+			date-format-return="DD/MM/YYYY"
+			append-icon
+			birthdate
 		>
 			<template #append-icon>
 				<VIcon>

--- a/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
@@ -60,6 +60,7 @@
 			ref="picker"
 			v-model="date"
 			v-bind="options.datePicker"
+			type="date"
 			:picker-date.sync="internalPickerDate"
 			:max="options.datePicker.max || max"
 			:min="options.datePicker.min || min"
@@ -259,7 +260,9 @@
 		.v-input__prepend-inner,
 		.v-input__append-inner,
 		.v-input__append-outer {
-			margin-top: 10px !important;
+			.v-btn--icon {
+				margin-top: -7px;
+			}
 		}
 	}
 </style>


### PR DESCRIPTION
Forçage du type du `VDatePicker` en `date` comme on ne supporte pas le mode `month`

Et correction de l'alignement des icônes dans le `DatePicker` ; jusqu'à présent on déplaçait vers le bas toutes les icônes pour que nos boutons s'affichent correctement, mais cela affectait les boutons Vuetify qui sont plus petits, ils n'étaient plus centrés

Maintenant on déplace vers le haut uniquement nos boutons et tout est bien aligné :

![screenshot-127 0 0 1_8081-2020 05 29-18_50_54](https://user-images.githubusercontent.com/10298932/83279270-29d2ac80-a1d5-11ea-8aed-0f7316636ed0.png)
