### PR TITLE
🔥 vue-dot: Remove tokens import in DialogBox

### DIFF
--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -62,11 +62,7 @@
 
 	import { customizable } from '../../mixins/customizable';
 
-	import tokens from '../../tokens';
-
 	import { mdiClose } from '@mdi/js';
-
-	const defaultWidth = tokens['dialog-width']['dialog-medium'];
 
 	const Props = Vue.extend({
 		props: {
@@ -86,7 +82,7 @@
 			/** The width of the DialogBox */
 			width: {
 				type: String,
-				default: defaultWidth
+				default: '800px'
 			},
 			/** The label of the cancel button*/
 			cancelBtnText: {


### PR DESCRIPTION
Lors de l'utilisation de la version actuelle de Vue Dot dans une appli créée avec Vue Dash, il y a une erreur :

```
warning  in ./node_modules/@cnamts/vue-dot/src/elements/DialogBox/DialogBox.vue?vue&type=script&lang=ts&

"export 'default' (imported as 'tokens') was not found in '../../tokens'
```

à priori ça serait lié à Babel (https://github.com/webpack/webpack/issues/4817)
En attendant de trouver la solution je retire l'import