### PR TITLE
feat(form-builder): deepMapValues

### DIFF
--- a/packages/form-builder/src/functions/deepMapValues/index.ts
+++ b/packages/form-builder/src/functions/deepMapValues/index.ts
@@ -19,7 +19,7 @@ export function deepMapValues<T = any>(
 	mappedValues: MappedValues = {}
 ): MappedValues {
 	if (collection instanceof Array) {
-		collection.forEach(item => deepMapValues(item, key, mappedValues });
+		collection.forEach(item => deepMapValues(item, key, mappedValues));
 	} else if (typeof collection === 'object') {
 		Object.getOwnPropertyNames(collection).forEach(collectionKey => {
 			// Check if the collectionKey equal the desired key

--- a/packages/form-builder/src/functions/deepMapValues/index.ts
+++ b/packages/form-builder/src/functions/deepMapValues/index.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type UnknownValue = any;
+
+export interface MappedValues {
+	[key: string]: UnknownValue
+}
+
+/**
+ * Return the mapped values for each first deep finded key of each sub collection
+ *
+ * @param {any} collection The collection to inspect deeply
+ * @param {string} key The key to assign the value for the parent key
+ * @param {any} mappedValues The new collection of mapped values
+ * @returns {any} The new collection
+ */
+export function deepMapValues<T = any>(
+	collection: UnknownValue,
+	key: string,
+	mappedValues: MappedValues = {}
+): MappedValues {
+	if (collection instanceof Array) {
+		collection.forEach(item => {
+			deepMapValues(item, key, mappedValues);
+		});
+	} else if (typeof collection === 'object') {
+		Object.getOwnPropertyNames(collection).forEach(collectionKey => {
+			/** Check if the collectionKey equal the desired key
+			 *  Else, continue deep find
+			 */
+			if (
+				typeof collection[collectionKey] === 'object' &&
+				collection[collectionKey].hasOwnProperty(key)
+			) {
+				/** Assign the the desired key value to the current collectionKey only if it's not null */
+				if (collection[collectionKey][key]) {
+					mappedValues[collectionKey] =
+						collection[collectionKey][key];
+				}
+			} else {
+				deepMapValues(
+					collection[collectionKey],
+					key,
+					mappedValues
+				);
+			}
+		});
+	}
+
+	return mappedValues;
+}

--- a/packages/form-builder/src/functions/deepMapValues/index.ts
+++ b/packages/form-builder/src/functions/deepMapValues/index.ts
@@ -19,22 +19,18 @@ export function deepMapValues<T = any>(
 	mappedValues: MappedValues = {}
 ): MappedValues {
 	if (collection instanceof Array) {
-		collection.forEach(item => {
-			deepMapValues(item, key, mappedValues);
-		});
+		collection.forEach(item => deepMapValues(item, key, mappedValues });
 	} else if (typeof collection === 'object') {
 		Object.getOwnPropertyNames(collection).forEach(collectionKey => {
-			/** Check if the collectionKey equal the desired key
-			 *  Else, continue deep find
-			 */
+			// Check if the collectionKey equal the desired key
+			// else, continue deep find
 			if (
 				typeof collection[collectionKey] === 'object' &&
 				collection[collectionKey].hasOwnProperty(key)
 			) {
-				/** Assign the the desired key value to the current collectionKey only if it's not null */
+				// Assign the desired value to the current collectionKey if it's not null
 				if (collection[collectionKey][key]) {
-					mappedValues[collectionKey] =
-						collection[collectionKey][key];
+					mappedValues[collectionKey] = collection[collectionKey][key];
 				}
 			} else {
 				deepMapValues(

--- a/packages/form-builder/src/functions/deepMapValues/tests/deepMapValues.spec.ts
+++ b/packages/form-builder/src/functions/deepMapValues/tests/deepMapValues.spec.ts
@@ -19,7 +19,7 @@ const BASE_OBJECT = {
 
 // Tests
 describe('deepMapValues', () => {
-	it('get the values into a new collection', () => {
+	it('returns the desired values', () => {
 		const newCollection = deepMapValues(BASE_OBJECT, 'value');
 
 		expect(newCollection).toEqual({

--- a/packages/form-builder/src/functions/deepMapValues/tests/deepMapValues.spec.ts
+++ b/packages/form-builder/src/functions/deepMapValues/tests/deepMapValues.spec.ts
@@ -1,0 +1,32 @@
+import { deepMapValues } from '..';
+
+const BASE_OBJECT = {
+	value: 0,
+	section1: {
+		question1: {
+			value: 1
+		},
+		question2: {
+			value: {
+				value: '2'
+			}
+		},
+		question3: {
+			value: null
+		}
+	}
+};
+
+// Tests
+describe('deepMapValues', () => {
+	it('get the values into a new collection', () => {
+		const newCollection = deepMapValues(BASE_OBJECT, 'value');
+
+		expect(newCollection).toEqual({
+			question1: 1,
+			question2: {
+				value: '2'
+			}
+		});
+	});
+});

--- a/packages/form-builder/src/functions/getFormValues/index.ts
+++ b/packages/form-builder/src/functions/getFormValues/index.ts
@@ -1,6 +1,8 @@
 import { FormValues } from './types';
 
 import { Form } from '../../components/FormBuilder/types';
+import { deepMapValues } from '../deepMapValues';
+import { deepCopy } from '@cnamts/vue-dot/src/helpers/deepCopy';
 
 /**
  * Return an array with field values
@@ -9,16 +11,5 @@ import { Form } from '../../components/FormBuilder/types';
  * @returns {FormValues} The form values
  */
 export function getFormValues(form: Form): FormValues {
-	const formValues: FormValues = {};
-
-	// TODO: Use deepFind?
-	for (const [, section] of Object.entries(form)) {
-		for (const [fieldName, field] of Object.entries(section.questions)) {
-			if (field.value !== null) {
-				formValues[fieldName] = field.value;
-			}
-		}
-	}
-
-	return formValues;
+	return deepMapValues(deepCopy(form), 'value');
 }

--- a/packages/form-builder/src/functions/getFormValues/index.ts
+++ b/packages/form-builder/src/functions/getFormValues/index.ts
@@ -2,7 +2,6 @@ import { FormValues } from './types';
 
 import { Form } from '../../components/FormBuilder/types';
 import { deepMapValues } from '../deepMapValues';
-import { deepCopy } from '@cnamts/vue-dot/src/helpers/deepCopy';
 
 /**
  * Return an array with field values
@@ -11,5 +10,5 @@ import { deepCopy } from '@cnamts/vue-dot/src/helpers/deepCopy';
  * @returns {FormValues} The form values
  */
 export function getFormValues(form: Form): FormValues {
-	return deepMapValues(deepCopy(form), 'value');
+	return deepMapValues(form, 'value');
 }


### PR DESCRIPTION
Add the function deepMapValue for deep map the values of one key with the parent key.

example: this object
```
{
  section1: {
    question1: {
      value: 1
    }, 
    question2: {
      value: {
         value: 1
      }
    },
    question3: {
       value: null
    }
  }
}
```
return 
```
{
  question1: 1,
  question2: {
     value: 1
  }
}
```

Function getFormValues updated with new function to deepMapValues for compose the FormValues