### PR TITLE
feat(vue-dot): function deepMapValues

### DIFF
--- a/packages/vue-dot/src/functions/deepMapValues/index.ts
+++ b/packages/vue-dot/src/functions/deepMapValues/index.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type UnknownValue = any;
+
+export interface MappedValues {
+	[key: string]: UnknownValue
+}
+
+/**
+ * Return the mapped values for each first deep finded key of each sub collection
+ *
+ * @param {any} collection The collection to inspect deeply
+ * @param {string} key The key to assign the value for the parent key
+ * @param {any} mappedValues The new collection of mapped values
+ * @returns {any} The new collection
+ */
+export function deepMapValues<T = any>(
+	collection: UnknownValue,
+	key: string,
+	mappedValues: MappedValues = {}
+): MappedValues {
+	if (collection instanceof Array) {
+		collection.forEach(item => deepMapValues(item, key, mappedValues));
+	} else if (typeof collection === 'object') {
+		Object.getOwnPropertyNames(collection).forEach(collectionKey => {
+			// Check if the collectionKey equal the desired key
+			// else, continue deep find
+			if (
+				typeof collection[collectionKey] === 'object' &&
+				collection[collectionKey].hasOwnProperty(key)
+			) {
+				// Assign the desired value to the current collectionKey if it's not null
+				if (collection[collectionKey][key]) {
+					mappedValues[collectionKey] = collection[collectionKey][key];
+				}
+			} else {
+				deepMapValues(
+					collection[collectionKey],
+					key,
+					mappedValues
+				);
+			}
+		});
+	}
+
+	return mappedValues;
+}

--- a/packages/vue-dot/src/functions/deepMapValues/index.ts
+++ b/packages/vue-dot/src/functions/deepMapValues/index.ts
@@ -9,18 +9,16 @@ export interface MappedValues {
  * Return the mapped values for each first deep finded key of each sub collection
  *
  * @param {any} collection The collection to inspect deeply
- * @param {string} key The key to assign the value for the parent key
+ * @param {string| number} key The key/index to assign the value for the parent key
  * @param {any} mappedValues The new collection of mapped values
  * @returns {any} The new collection
  */
 export function deepMapValues<T = any>(
 	collection: UnknownValue,
-	key: string,
+	key: string | number,
 	mappedValues: MappedValues = {}
 ): MappedValues {
-	if (collection instanceof Array) {
-		collection.forEach(item => deepMapValues(item, key, mappedValues));
-	} else if (typeof collection === 'object') {
+	if (typeof collection === 'object' && !(Array.isArray(collection))) {
 		Object.getOwnPropertyNames(collection).forEach(collectionKey => {
 			// Check if the collectionKey equal the desired key
 			// else, continue deep find

--- a/packages/vue-dot/src/functions/deepMapValues/tests/__snapshots__/deepMapValues.spec.ts.snap
+++ b/packages/vue-dot/src/functions/deepMapValues/tests/__snapshots__/deepMapValues.spec.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deepMapValues returns the desired values 1`] = `
+Object {
+  "question1": 1,
+  "question2": Object {
+    "other": "autre",
+    "value": "2",
+  },
+  "question4": Object {
+    "other": null,
+    "value": null,
+  },
+}
+`;

--- a/packages/vue-dot/src/functions/deepMapValues/tests/deepMapValues.spec.ts
+++ b/packages/vue-dot/src/functions/deepMapValues/tests/deepMapValues.spec.ts
@@ -39,5 +39,7 @@ describe('deepMapValues', () => {
 			question2: BASE_OBJECT.section1.question2.value,
 			question4: BASE_OBJECT.section1.question4.value
 		});
+
+		expect(newCollection).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/functions/deepMapValues/tests/deepMapValues.spec.ts
+++ b/packages/vue-dot/src/functions/deepMapValues/tests/deepMapValues.spec.ts
@@ -8,12 +8,24 @@ const BASE_OBJECT = {
 		},
 		question2: {
 			value: {
-				value: '2'
+				value: '2',
+				other: 'autre'
 			}
 		},
 		question3: {
 			value: null
-		}
+		},
+		question4: {
+			value: {
+				value: null,
+				other: null
+			}
+		},
+		question5: [
+			{
+				value: '1'
+			}
+		]
 	}
 };
 
@@ -23,10 +35,9 @@ describe('deepMapValues', () => {
 		const newCollection = deepMapValues(BASE_OBJECT, 'value');
 
 		expect(newCollection).toEqual({
-			question1: 1,
-			question2: {
-				value: '2'
-			}
+			question1: BASE_OBJECT.section1.question1.value,
+			question2: BASE_OBJECT.section1.question2.value,
+			question4: BASE_OBJECT.section1.question4.value
 		});
 	});
 });

--- a/packages/vue-dot/src/functions/deepMapValues/tests/deepMapValues.spec.ts
+++ b/packages/vue-dot/src/functions/deepMapValues/tests/deepMapValues.spec.ts
@@ -1,0 +1,32 @@
+import { deepMapValues } from '..';
+
+const BASE_OBJECT = {
+	value: 0,
+	section1: {
+		question1: {
+			value: 1
+		},
+		question2: {
+			value: {
+				value: '2'
+			}
+		},
+		question3: {
+			value: null
+		}
+	}
+};
+
+// Tests
+describe('deepMapValues', () => {
+	it('returns the desired values', () => {
+		const newCollection = deepMapValues(BASE_OBJECT, 'value');
+
+		expect(newCollection).toEqual({
+			question1: 1,
+			question2: {
+				value: '2'
+			}
+		});
+	});
+});


### PR DESCRIPTION
Add the function ```deepMapValues``` for deep map the values of one key with the parent key.

example: this collection

```
{
  section1: {
    question1: {
      value: 1
    }, 
    question2: {
	value: {
		value: '2',
		other: 'autre'
	}
     },
     question3: {
	value: null
     },
     question4: {
	value: {
		value: null,
		other: null
	}
      },
      question5: [
	{
		value: '1'
	}
       ]
  }
}
```

deepMapValues(collection, 'value')
return

```
{
  question1: 1,
  question2: {
     value: '2',
     other: 'autre'
  },
  question4: {
     value: null,
     other: null
  }
}
```
