### PR TITLE
✨ vue-dot: Expose input event in DatePicker

### DIFF
--- a/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
@@ -17,6 +17,7 @@
 				:success-messages="textFieldOptions.successMessages || successMessages"
 				:error.sync="internalErrorProp"
 				class="vd-date-picker-text-field"
+				@input="$emit('input', $event)"
 				@blur="textFieldBlur"
 				@click="textFieldClicked"
 			>
@@ -80,7 +81,7 @@
 	import { config } from './config';
 	import { locales } from './locales';
 
-	import { customizable, Options, Customizable } from '../../mixins/customizable';
+	import { customizable, Options } from '../../mixins/customizable';
 	import { Eventable } from '../../mixins/eventable';
 	import { WarningRules } from '../../mixins/warningRules';
 


### PR DESCRIPTION
Demande de l'équipe ATMP pour détecter quand l'utilisateur commence à taper dans le champ

La valeur de l'événement est la valeur **masquée** du `VTextField`