### PR TITLE
🔥 vue-dash: Remove unnecessary styles

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/theme/styles/utility.scss
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/theme/styles/utility.scss
@@ -1,24 +1,5 @@
 // Custom utility classes
 
-// Hide content visually but not for screen readers
-.sr-only {
-	position: absolute !important;
-	top: 0;
-	left: -999px;
-	width: 1px !important;
-	height: 1px !important;
-	white-space: nowrap;
-	overflow: hidden;
-	clip: rect(1px, 1px, 1px, 1px);
-}
-
-// Style for required fields
-.required label::after {
-	top: -2px;
-	content: '*';
-	position: relative;
-}
-
 // Fade <transition>
 .fade-enter-active,
 .fade-leave-active {
@@ -44,15 +25,6 @@
 	.input-container {
 		max-width: 100%;
 	}
-}
-
-.form-input {
-	width: 328px;
-	flex: none;
-}
-
-.no-flex {
-	flex: none !important;
 }
 
 .pointer {

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/theme/styles/vuetify.scss
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/theme/styles/vuetify.scss
@@ -92,7 +92,7 @@ table.v-table thead th,
 		flex: none;
 
 		input {
-			@extend .sr-only;
+			@extend .d-sr-only;
 		}
 	}
 


### PR DESCRIPTION
- La classe `sr-only` est maintenant dans Vuetify sous le nom `d-sr-only`
- Le fait de spécifier les champs obligatoires n'est pas conseillé dans le Design System, il est préférable de spécifier les champs optionnels quand la plupart sont obligatoires, le cas contraire n'arrive que très rarement (suppression de `.required`)
- La classe `form-input` est remplacée par celle déjà présente dans Vue Dot `vd-form-input` qui utilise les Design Tokens
- La classe `no-flex` est remplacée par les nouvelles classes d'aide de Vuetify (l'équivalent devrait être `flex-grow-0`)

Il faudra aussi analyser le reset inclut dans Vuetify, il est possible qu'on puisse supprimer le notre !