### PR TITLE
feat(form-builder): champ select multiple devient 'null' quand pas de valeur sélectionné

### DIFF
--- a/packages/form-builder/src/components/FormField/fields/ChoiceField.vue
+++ b/packages/form-builder/src/components/FormField/fields/ChoiceField.vue
@@ -198,7 +198,11 @@
 		 * @param {ChoiceFieldValue} choiceFieldValue The new choice value selected
 		 */
 		choiceUpdated(choiceFieldValue: ChoiceFieldValue): void {
-			this.choiceValue.value = choiceFieldValue;
+			if (Array.isArray(choiceFieldValue) && !choiceFieldValue.length) {
+				this.choiceValue.value = null;
+			} else {
+				this.choiceValue.value = choiceFieldValue;
+			}
 
 			if (this.choiceValue.value && !this.otherField?.selectedChoice) {
 				this.otherFieldValue = null;

--- a/packages/form-builder/src/components/FormField/fields/tests/ChoiceField.spec.ts
+++ b/packages/form-builder/src/components/FormField/fields/tests/ChoiceField.spec.ts
@@ -6,6 +6,7 @@ import { html } from '@cnamts/vue-dot/tests/utils/html';
 import { Field } from './../../types';
 
 import ChoiceField from '../ChoiceField.vue';
+import SelectField from '../SelectField.vue';
 
 let wrapper: Wrapper<Vue>;
 
@@ -95,5 +96,37 @@ describe('ChoiceField', () => {
 		});
 
 		expect(html(wrapper)).toMatchSnapshot();
+	});
+
+	it('unselect choice to set value to null in multiple mode', async() => {
+		// Mount component
+		wrapper = mountComponent(ChoiceField, {
+			propsData: {
+				field: {
+					...testField,
+					multiple: true,
+					value: {
+						value: [0]
+					}
+				}
+			}
+		}, true);
+
+		wrapper.findComponent(SelectField).vm.$emit('change', []);
+
+		await wrapper.vm.$nextTick();
+
+		const event = wrapper.emitted('change') || [];
+
+		expect(event[0][0]).toEqual(
+			{
+				...testField,
+				multiple: true,
+				value: {
+					value: null,
+					other: null
+				}
+			}
+		);
 	});
 });


### PR DESCRIPTION
# Description

Remise à 'null' de la valeur du champ select dans le cas d'un tableau vide (cas logiquement en mode multiple)

## Type de changement

<!-- Veuillez supprimer les options non pertinentes. -->

- [x] Changement bloquant (correctif ou fonctionnalité qui empêcherait une fonctionnalité existante de fonctionner comme prévu)

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Mes nouveaux tests unitaires et ceux existants passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
