### PR TITLE
🐛 vue-dash: Fix missing Design Tokens dependency in template

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/functions/extendPackage.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/functions/extendPackage.js
@@ -1,18 +1,25 @@
 const vdPkg = require('../../package.json');
-// Use dev dependency to get Vue Dot version
-let VueDotVersion = vdPkg.devDependencies['@cnamts/vue-dot'] || 'next';
 
-// If the version is an alpha or a beta
-if (VueDotVersion.includes('alpha') || VueDotVersion.includes('beta')) {
-	// Remove ^ char to avoid version auto-bump
-	VueDotVersion = VueDotVersion.replace('^', '');
+function normalizeVersion(version) {
+	// If the version is an alpha or a beta
+	if (version.includes('alpha') || version.includes('beta')) {
+		// Remove ^ char to avoid version auto-bump
+		return version.replace('^', '');
+	}
+
+	return version;
 }
+
+// Use dev dependencies to get packages versions
+const VueDotVersion = normalizeVersion(vdPkg.devDependencies['@cnamts/vue-dot'] || 'next');
+const DesignTokensVersion = normalizeVersion(vdPkg.devDependencies['@cnamts/design-tokens'] || 'next');
 
 /** Extend package.json */
 function extendPackage(api, options) {
 	const newPackageProperties = {
 		dependencies: {
-			'@cnamts/vue-dot': `${VueDotVersion}`,
+			'@cnamts/design-tokens': DesignTokensVersion,
+			'@cnamts/vue-dot': VueDotVersion,
 			'axios': '^0.19.2',
 			'core-js': '^3.6.5',
 			'dayjs': '^1.8.33',

--- a/packages/vue-cli-plugin-vue-dash/package.json
+++ b/packages/vue-cli-plugin-vue-dash/package.json
@@ -21,11 +21,12 @@
 	"main": "index.js",
 	"dependencies": {
 		"@cnamts/cli-helpers": "^2.0.0-alpha.51",
-		"dayjs": "^1.8.23",
-		"fs-extra": "^9.0.0",
+		"dayjs": "^1.8.34",
+		"fs-extra": "^9.0.1",
 		"superb": "^4.0.0"
 	},
 	"devDependencies": {
+		"@cnamts/design-tokens": "^2.0.0-beta.0",
 		"@cnamts/vue-dot": "^2.0.0-beta.0"
 	},
 	"publishConfig": {


### PR DESCRIPTION
# Description

Il manquait la dépendance `@cnamts/vue-dot` dans le template de Vue Dash

## Type de changement

<!-- Veuillez supprimer les options non pertinentes. -->

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Mes nouveaux tests unitaires et ceux existants passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
