### PR TITLE
🐛 vue-dash: Fix wrong @extend in default theme

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/theme/styles/vuetify.scss
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/theme/styles/vuetify.scss
@@ -1,5 +1,8 @@
 // Override some Vuetify styles
 
+// Import visually-hidden mixin
+@import 'vuetify/src/styles/tools/_display.sass';
+
 // Reset max-width for Vuetify ripples
 .v-ripple__container,
 .v-ripple__container *,
@@ -91,7 +94,7 @@ table.v-table thead th,
 		flex: none;
 
 		input {
-			@extend .d-sr-only;
+			@include visually-hidden;
 		}
 	}
 


### PR DESCRIPTION
# Description

On ne peut pas faire un `@extend` d'une classe qui n'est pas importée, et en regardant le code source de Vuetify j'ai trouvé la mixin `visually-hidden` qui fait exactement ce dont on a besoin ici !

## Type de changement

<!-- Veuillez supprimer les options non pertinentes. -->

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Mes nouveaux tests unitaires et ceux existants passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
