### PR TITLE
🐛 vue-dash: Fix template styles

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/functions/getFooterDate.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/functions/getFooterDate.js
@@ -5,13 +5,13 @@ dayjs.locale('fr');
 
 const { capitalizeFirstLetter } = require('../../utils');
 
-/** Returns the current date with '– MMMM YYYY' format */
+/** Returns the current date with 'MMMM YYYY' format */
 function getFooterDate() {
 	const month = dayjs().format('MMMM');
 	const capitalizedMonth = capitalizeFirstLetter(month);
 
 	const year = dayjs().format('YYYY');
-	const date = `– ${capitalizedMonth} ${year}`;
+	const date = `${capitalizedMonth} ${year}`;
 
 	return date;
 }

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppHeader.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppHeader.vue
@@ -1,9 +1,8 @@
 <template>
 	<VAppBar
-		wrap
-		align-center
 		height="80"
-		class="app-header white no-flex"
+		color="white"
+		class="app-header flex-grow-0"
 	>
 		<RouterLink
 			<% if (i18n) { %>:aria-label="$t('components.layout.appHeader.logoBtn.label')"<% } else { %>aria-label="Accueil"<% } %>

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppToolbar.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppToolbar.vue
@@ -1,8 +1,8 @@
 <template>
 	<VToolbar
 		dense
-		tag="section"
-		class="secondary no-flex"
+		tag="nav"
+		class="secondary flex-grow-0"
 	>
 		<VTabs
 			v-if="!maintenance"


### PR DESCRIPTION
# Description

Correction :
- des composants `AppHeader` et `AppToolbar` qui prenaient trop de hauteur car la classe `no-flex` n'existe plus dans les styles par défaut (il faut utiliser `flex-grow-0` [de Vuetify](https://vuetifyjs.com/en/styles/flex/#flex-grow-and-shrink) à la place)
- du mois dans `AppFooter` qui était précédé de `– ` (reliquat de l'ancien footer)
- des attributs `wrap` et `align-center` qui ne sont pas des attributs de `VAppBar` (mais de `VLayout`, ce sont aussi des reliquats de l'ancien template)
- de la couleur de fond du `VAppBar` appliqué via une classe au lieu d'utiliser l'attribut dédié `color`
- du tag `section` appliqué à la place de `nav` (ce dernier fait plus de sens car c'est une liste de liens de navigation) (d'ailleurs il faudrait peut-être renommer `AppToolbar` en `AppNavigation` ?)

## Type de changement

<!-- Veuillez supprimer les options non pertinentes. -->

- [x] Correction de bug (changement non-bloquant qui corrige un problème)

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Mes nouveaux tests unitaires et ceux existants passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
