### PR TITLE
🐛 vue-dot: Fix error with number value in DataListItem

### DIFF
--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -56,7 +56,7 @@
 	import Component, { mixins } from 'vue-class-component';
 
 	import { locales } from './locales';
-	import { DataListIcons } from './types';
+	import { DataListIcons, IDataList } from './types';
 
 	import DataListItem from './DataListItem';
 	import DataListLoading from './DataListLoading';
@@ -65,7 +65,7 @@
 		props: {
 			/** The items to display */
 			items: {
-				type: Array as PropType<DataListItem[]>,
+				type: Array as PropType<IDataList>,
 				required: true
 			},
 			icons: {

--- a/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
@@ -130,8 +130,11 @@
 			return this.$vuetify.theme.dark ? 'rgba(255, 255, 255, .7)' : 'rgba(0, 0, 0, .6)';
 		}
 
-		get itemValue(): string {
-			return this.value.toString() || this.placeholder;
+		get itemValue(): string {			
+			if(typeof this.value === 'number' && !this.value.isNaN())
+				return this.value.toString();
+				
+			return this.value || this.placeholder;
 		}
 	}
 </script>

--- a/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
@@ -130,10 +130,11 @@
 			return this.$vuetify.theme.dark ? 'rgba(255, 255, 255, .7)' : 'rgba(0, 0, 0, .6)';
 		}
 
-		get itemValue(): string {			
-			if(typeof this.value === 'number' && !this.value.isNaN())
-				return this.value.toString();
-				
+		get itemValue(): string {
+			if (typeof this.value === 'number') {
+				return isNaN(this.value) ? this.placeholder : this.value.toString();
+			}
+
 			return this.value || this.placeholder;
 		}
 	}

--- a/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
@@ -82,7 +82,7 @@
 			},
 			/** Value to display */
 			value: {
-				type: String,
+				type: [String, Number],
 				default: undefined
 			},
 			/** Action to display */
@@ -131,7 +131,7 @@
 		}
 
 		get itemValue(): string {
-			return this.value || this.placeholder;
+			return this.value.toString() || this.placeholder;
 		}
 	}
 </script>

--- a/packages/vue-dot/src/elements/DataList/types.d.ts
+++ b/packages/vue-dot/src/elements/DataList/types.d.ts
@@ -2,7 +2,7 @@ import { Options } from '../../mixins/customizable';
 
 export interface IDataListItem {
 	key: string;
-	value?: string;
+	value?: string | number;
 	action?: string;
 	chip?: boolean;
 	icon?: string;


### PR DESCRIPTION
# Description
Issue à l'origine de la PR :
https://github.com/assurance-maladie-digital/design-system/issues/469

**Problématique** :   
Les DataListItem ne prenaient que des valeurs de types string, si on lui passait un nombre le composant rencontrait une erreur.


## Type de changement

J'ai modifié la prop `value` du DataListIem pour qu'elle retourne systématiquement un string et j'ai modifié DataListItem et IDataList pour qu'il accepte des valeurs string ou number.

- [x] Correction de bug (changement non-bloquant qui corrige un problème)

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Mes nouveaux tests unitaires et ceux existants passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
