### PR TITLE
✨ form-builder: Allow line breaks in FormField tooltip

### DIFF
--- a/packages/form-builder/src/components/FormBuilder/tests/data/questionForm.ts
+++ b/packages/form-builder/src/components/FormBuilder/tests/data/questionForm.ts
@@ -28,7 +28,7 @@ export const questionForm: Form = {
 				type: 'text',
 				title: 'Question ?',
 				description: 'Informations supplémentaires',
-				tooltip: 'Texte d\'aide\n	- Texte à la ligne avec tabulation et retour à la ligne automatique',
+				tooltip: 'Texte d\'aide\nSecond texte d\'aide',
 				value: null,
 				fieldOptions: {
 					label: 'Label du champ',

--- a/packages/form-builder/src/components/FormBuilder/tests/data/questionForm.ts
+++ b/packages/form-builder/src/components/FormBuilder/tests/data/questionForm.ts
@@ -28,7 +28,7 @@ export const questionForm: Form = {
 				type: 'text',
 				title: 'Question ?',
 				description: 'Informations supplémentaires',
-				tooltip: 'Texte d\'aide\n	- Texte à la ligne avec tabulation',
+				tooltip: 'Texte d\'aide\n	- Texte à la ligne avec tabulation et retour à la ligne automatique',
 				value: null,
 				fieldOptions: {
 					label: 'Label du champ',

--- a/packages/form-builder/src/components/FormBuilder/tests/data/questionForm.ts
+++ b/packages/form-builder/src/components/FormBuilder/tests/data/questionForm.ts
@@ -28,7 +28,7 @@ export const questionForm: Form = {
 				type: 'text',
 				title: 'Question ?',
 				description: 'Informations supplémentaires',
-				tooltip: 'Texte d\'aide',
+				tooltip: 'Texte d\'aide\n	- Texte à la ligne avec tabulation',
 				value: null,
 				fieldOptions: {
 					label: 'Label du champ',

--- a/packages/form-builder/src/components/FormField/FormField.vue
+++ b/packages/form-builder/src/components/FormField/FormField.vue
@@ -26,7 +26,7 @@
 					</VBtn>
 				</template>
 
-				<span>{{ field.tooltip }}</span>
+				<pre>{{ field.tooltip }}</pre>
 			</VTooltip>
 		</h4>
 

--- a/packages/form-builder/src/components/FormField/FormField.vue
+++ b/packages/form-builder/src/components/FormField/FormField.vue
@@ -13,7 +13,6 @@
 			<VTooltip
 				v-if="field.tooltip"
 				right
-				max-width="320"
 			>
 				<template #activator="{ on }">
 					<VBtn
@@ -119,6 +118,7 @@
 	.vd-form-field + .vd-form-field {
 		margin-top: 12px;
 	}
+
 	.field-tooltip-text {
 		white-space: pre-wrap;
 	}

--- a/packages/form-builder/src/components/FormField/FormField.vue
+++ b/packages/form-builder/src/components/FormField/FormField.vue
@@ -13,6 +13,7 @@
 			<VTooltip
 				v-if="field.tooltip"
 				right
+				max-width="320"
 			>
 				<template #activator="{ on }">
 					<VBtn

--- a/packages/form-builder/src/components/FormField/FormField.vue
+++ b/packages/form-builder/src/components/FormField/FormField.vue
@@ -26,7 +26,7 @@
 					</VBtn>
 				</template>
 
-				<pre>{{ field.tooltip }}</pre>
+				<span class="field-tooltip-text">{{ field.tooltip }}</span>
 			</VTooltip>
 		</h4>
 
@@ -117,5 +117,8 @@
 <style lang="scss" scoped>
 	.vd-form-field + .vd-form-field {
 		margin-top: 12px;
+	}
+	.field-tooltip-text {
+		white-space: pre-wrap;
 	}
 </style>


### PR DESCRIPTION
# Description

Update UX field tooltip to accept word wrap or tabulation and white space.

## Solution

Solution 

Use \<pre> instead of <span> to keep word wrap, whitespace or tabulation.

## Type de changement

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
