### PR TITLE
🐛 vue-dash: Fix missing polyfill for vue-input-facade on IE

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/functions/extendPackage.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/functions/extendPackage.js
@@ -22,6 +22,7 @@ function extendPackage(api, options) {
 			'@cnamts/vue-dot': VueDotVersion,
 			'axios': '^0.20.0',
 			'core-js': '^3.6.5',
+			"custom-event-polyfill": "^1.0.7",
 			'dayjs': '^1.8.34',
 			'languages': '^0.1.3',
 			'vue-input-facade': '^1.3.2',

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/main.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/main.ts
@@ -1,5 +1,9 @@
 import Vue from 'vue';
 
+// Polyfill for vue-input-facade on IE
+// (not included in core-js)
+import 'custom-event-polyfill';
+
 // Register class components hooks
 import Component from 'vue-class-component';
 


### PR DESCRIPTION
# Description

Comme remonté et corrigé par @DamienRenaud, le package `vue-input-facade` ne fonctionne pas sous IE, il nécessite un polyfill pour `new CustomEvent`

## Type de changement

<!-- Veuillez supprimer les options non pertinentes. -->

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
