### PR TITLE
🐛 vue-dot: Fix change event not fired on resetFile in UploadWorkflow

### DIFF
--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
@@ -99,6 +99,9 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 		// Clear name and file
 		this.updateFileModel(id, 'name', undefined);
 		this.updateFileModel(id, 'file', undefined);
+
+		// Update v-model
+		this.$emit('change', this.fileList);
 	}
 
 	/** Validate the form and call setFileInList */


### PR DESCRIPTION
# Description

On notifie une modification du v-model lorsque le reset d'un fichier a été demandé, sinon la fonction change du composant UploadWorkflow n'est pas appelée.

Pour la définition du composant suivante
```xml
<UploadWorkflow
    v-if="!genok"
    v-model="files"
    :vuetify-options="vuetifyOptions"
    @change="valueUpdated"
    @error="showError"
>
```
la fonction `valueUpdated` n'était donc jamais appelée lors d'un clic sur l'icone 'corbeille' du composant

<img width="669" alt="Capture d’écran 2020-09-18 à 15 45 59" src="https://user-images.githubusercontent.com/4523119/93604729-0f138600-f9c6-11ea-8603-be448e421f77.png">


## Type de changement

- [ X] Correction de bug

## Checklist

- [X] Ma Pull Request pointe vers la bonne branche
- [X] Mon code suit le style de code de ce projet
- [X] J'ai effectué une review de mon propre code
- [X] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [X] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
