### PR TITLE
🐛 vue-dot: Fix error display in UploadWorkflow

### DIFF
--- a/packages/vue-dot/src/patterns/UploadWorkflow/FileList/FileList.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/FileList/FileList.vue
@@ -93,7 +93,7 @@
 						</VBtn>
 
 						<VBtn
-							v-if="file.state === 'success'"
+							v-if="file.state !== 'initial'"
 							v-bind="options.deleteFileBtn"
 							@click="$emit('delete-file', file.id)"
 						>

--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
@@ -77,17 +77,19 @@ describe('EventsFileFired', () => {
 	});
 
 	// setFileInList
-	it('sets list item state to success and emits change event', () => {
+	it('sets list item state to success and emits change event', async() => {
 		const wrapper = createWrapper() as Wrapper<TestComponent>;
 		wrapper.vm.selectedItem = '1';
 
 		wrapper.vm.setFileInList();
 
+		await wrapper.vm.$nextTick();
+
 		expect(wrapper.vm.fileList[0].state).toBe('success');
 		expect(wrapper.emitted('change')).toBeTruthy();
 	});
 
-	it('sets list item state to error and emits change event', () => {
+	it('sets list item state to error and emits change event', async() => {
 		const wrapper = createWrapper() as Wrapper<TestComponent>;
 		wrapper.vm.selectedItem = '1';
 
@@ -95,17 +97,21 @@ describe('EventsFileFired', () => {
 
 		wrapper.vm.setFileInList();
 
+		await wrapper.vm.$nextTick();
+
 		expect(wrapper.vm.fileList[0].state).toBe('error');
 		expect(wrapper.emitted('change')).toBeTruthy();
 	});
 
-	it('sets list item name and file and emits change event', () => {
+	it('sets list item name and file and emits change event', async() => {
 		const wrapper = createWrapper() as Wrapper<TestComponent>;
 		wrapper.vm.selectedItem = '1';
 
 		wrapper.vm.uploadedFile = testFile;
 
 		wrapper.vm.setFileInList();
+
+		await wrapper.vm.$nextTick();
 
 		expect(wrapper.vm.fileList[0].name).toBe('avatar.png');
 		expect(wrapper.vm.fileList[0].file).toEqual(testFile);
@@ -126,7 +132,7 @@ describe('EventsFileFired', () => {
 	});
 
 	// dialogConfirm
-	it('closes and resets the dialog form if valid', () => {
+	it('closes and resets the dialog form if valid', async() => {
 		const wrapper = createWrapper() as Wrapper<TestComponent>;
 
 		// Mock validation functions
@@ -135,17 +141,21 @@ describe('EventsFileFired', () => {
 
 		wrapper.vm.dialogConfirm();
 
+		await wrapper.vm.$nextTick();
+
 		expect(wrapper.vm.$refs.form.reset).toHaveBeenCalled();
 		expect(wrapper.emitted('change')).toBeTruthy();
 	});
 
-	it('doesn\'t closes and resets the dialog form if valid', () => {
+	it('doesn\'t closes and resets the dialog form if valid', async() => {
 		const wrapper = createWrapper() as Wrapper<TestComponent>;
 
 		wrapper.vm.$refs.form.validate = jest.fn().mockReturnValue(false);
 		wrapper.vm.$refs.form.reset = jest.fn();
 
 		wrapper.vm.dialogConfirm();
+
+		await wrapper.vm.$nextTick();
 
 		expect(wrapper.vm.$refs.form.reset).not.toHaveBeenCalled();
 		expect(wrapper.emitted('change')).toBeFalsy();
@@ -183,12 +193,14 @@ describe('EventsFileFired', () => {
 	});
 
 	// uploadError
-	it('emits error event and reset uploaded file', () => {
+	it('emits error event and reset uploaded file', async() => {
 		const wrapper = createWrapper() as Wrapper<TestComponent>;
 
 		wrapper.vm.uploadedFile = testFile;
 
 		wrapper.vm.uploadError('error');
+
+		await wrapper.vm.$nextTick();
 
 		expect(wrapper.vm.uploadedFile).toBe(null);
 		expect(wrapper.emitted('error')).toBeTruthy();

--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
@@ -88,8 +88,7 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 		// Reset error
 		this.error = false;
 
-		// Update v-model
-		this.$emit('change', this.fileList);
+		this.emitChangeEvent();
 	}
 
 	/** Reset a file from the list */
@@ -100,8 +99,15 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 		this.updateFileModel(id, 'name', undefined);
 		this.updateFileModel(id, 'file', undefined);
 
-		// Update v-model
-		this.$emit('change', this.fileList);
+		this.emitChangeEvent();
+	}
+
+	/** Update v-model */
+	emitChangeEvent(): void {
+		// Emit in next tick to respect event order
+		this.$nextTick(() => {
+			this.$emit('change', this.fileList);
+		});
 	}
 
 	/** Validate the form and call setFileInList */
@@ -137,7 +143,13 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 		// Reset file (if previously selected)
 		this.uploadedFile = null;
 
+		this.setFileInList();
+
 		// Pass the default FileUpload error
-		this.$emit('error', error);
+		this.$nextTick(() => {
+			this.$emit('error', error);
+		});
+
+		this.error = false;
 	}
 }


### PR DESCRIPTION
# Description

Lorsqu'un fichier erroné puis un fichier valide étaient sélectionnés, l'état final de la ligne dans la liste était `error` au lieu de `success`

L'affichage des erreurs a également été modifié, maintenant un fichier en erreur est affiché dans la liste (avec en plus le bouton "supprimer" pour réinitialiser)

Les événements `change` et `error` sont maintenant émis dans `$nextTick`

## Type de changement

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
