### PR TITLE
🐛 vue-dash: Fix missing vue-input-facade in transpileDependencies

### DIFF
--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/global.d.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/global.d.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import { VuexBindings } from './store/types';
 
 declare module 'vue/types/vue' {

--- a/packages/vue-cli-plugin-vue-dash/generator/template/vue.config.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/vue.config.js
@@ -21,7 +21,8 @@ module.exports = {
 	// Transpile ES6 inside dependencies
 	transpileDependencies: [
 		/node_modules[/\\\\]vuetify[/\\\\]/,
-		'vuex-persist'
+		'vuex-persist',
+		'vue-input-facade'
 	],
 	// Disable parallel build on the platform
 	parallel: process.env.NODE_ENV !== 'production'


### PR DESCRIPTION
# Description

Il manquait la dépendance `vue-input-facade` dans `transpileDependencies` dans le template par défaut

## Type de changement

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
