### PR TITLE
♻️ vue-dot: Use kebab-case for event names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Non publié
 
+### Vue Dot
+
+- ♻️ **Refactoring**
+  - **template:** Utilisation de la syntaxe kebab-case pour les noms des événements ([#588](https://github.com/assurance-maladie-digital/design-system/pull/588))
+
 ### Interne
 
 - ⬆️ **Dépendances**
@@ -11,6 +16,19 @@
   - **eslint-plugin-jsdoc:** Mise à jour vers la `v30.6.2` ([#578](https://github.com/assurance-maladie-digital/design-system/pull/578)) ([fffe06e](https://github.com/assurance-maladie-digital/design-system/commit/fffe06e53cd63e3cee542b98bf31b186eff7f001))
   - **dayjs:** Mise à jour vers la `v1.9.1` ([#579](https://github.com/assurance-maladie-digital/design-system/pull/579)) ([6a71b88](https://github.com/assurance-maladie-digital/design-system/commit/6a71b8889423b144a3f12940cceec486548e3200))
   - **vuetify:** Mise à jour vers la `v2.3.12` ([#581](https://github.com/assurance-maladie-digital/design-system/pull/581))
+
+### 📚 Guide de migration
+
+#### Nom des événements
+
+Certains noms d'événements ont été normalisés en kebab-case comme recommandé dans le [Style Guide ESLint de Vue.js](https://eslint.vuejs.org/rules/#priority-a-essential-error-prevention-for-vue-js-3-x) :
+
+- `DataList`
+  - `click:item-action` renommé en `click-item-action`
+- `DataListItem`
+  - `click:action` renommé en `click-action`
+- `SubHeader`
+  - `click:list-item` renommé en `click-list-item`
 
 ## v2.0.0-beta.1
 

--- a/packages/vue-dot/playground/examples/DataListEx.vue
+++ b/packages/vue-dot/playground/examples/DataListEx.vue
@@ -9,7 +9,7 @@
 			list-title="Informations"
 			heading-loading
 			flex
-			@click:item-action="setItemValue"
+			@click-item-action="setItemValue"
 		/>
 
 		<VTextField

--- a/packages/vue-dot/playground/examples/SubHeaderEx.vue
+++ b/packages/vue-dot/playground/examples/SubHeaderEx.vue
@@ -5,7 +5,7 @@
 			:data-lists="dataLists"
 			title-text="Prénom Nom (d'usage)"
 			sub-title-text="1 69 08 75 125 456 75"
-			@click:list-item="setItemValue"
+			@click-list-item="setItemValue"
 		>
 			<!-- ProgressBar -->
 			<template #additional-informations>

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -43,7 +43,7 @@
 						:vuetify-options="item.options"
 						:style="{ width: itemWidth }"
 						class="vd-data-list-item text-body-1 mb-2"
-						@click:action="$emit('click:item-action', index)"
+						@click-action="$emit('click-item-action', index)"
 					/>
 				</ul>
 			</div>

--- a/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
@@ -55,7 +55,7 @@
 					v-if="action"
 					v-bind="options.actionBtn"
 					class="vd-data-list-item-action-btn"
-					@click="$emit('click:action')"
+					@click="$emit('click-action')"
 				>
 					{{ action }}
 				</VBtn>

--- a/packages/vue-dot/src/elements/DataList/DataListItem/tests/DataListItem.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/tests/DataListItem.spec.ts
@@ -85,7 +85,7 @@ describe('DataListItem', () => {
 		expect(html(wrapper)).toMatchSnapshot();
 	});
 
-	it('emits click:action event when the action button is pressed', async() => {
+	it('emits click-action event when the action button is pressed', async() => {
 		// Mount component
 		wrapper = mountComponent(DataListItem, {
 			propsData: {
@@ -105,7 +105,7 @@ describe('DataListItem', () => {
 		// Wait until $emits have been handled
 		await wrapper.vm.$nextTick();
 
-		expect(wrapper.emitted('click:action')).toBeTruthy();
+		expect(wrapper.emitted('click-action')).toBeTruthy();
 	});
 
 	it('renders correctly in row mode', () => {

--- a/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
@@ -172,6 +172,6 @@ describe('DataList', () => {
 		// Wait until $emits have been handled
 		await wrapper.vm.$nextTick();
 
-		expect(wrapper.emitted('click:item-action')).toEqual([[2]]);
+		expect(wrapper.emitted('click-item-action')).toEqual([[2]]);
 	});
 });

--- a/packages/vue-dot/src/global.d.ts
+++ b/packages/vue-dot/src/global.d.ts
@@ -1,4 +1,4 @@
-import Vue, { VueConstructor } from 'vue';
+import { VueConstructor } from 'vue';
 import { VueDotOptions } from '../types';
 import { Framework } from 'vuetify/types';
 

--- a/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
@@ -102,7 +102,7 @@
 							:heading-loading="dataList.headingLoading"
 							item-width="auto"
 							title-class="text-subtitle-1 font-weight-bold mb-2 mt-2"
-							@click:item-action="dataListItemAction(index, $event)"
+							@click-item-action="dataListItemAction(index, $event)"
 						/>
 					</VLayout>
 				</VThemeProvider>
@@ -192,7 +192,7 @@
 		 * @param {number} itemIndex The index of the item into the selected data list
 		 */
 		dataListItemAction(dataListIndex: number, itemIndex: number): void {
-			this.$emit('click:list-item', { dataListIndex, itemIndex } as IDataListAction);
+			this.$emit('click-list-item', { dataListIndex, itemIndex } as IDataListAction);
 		}
 	}
 </script>

--- a/packages/vue-dot/src/patterns/SubHeader/tests/SubHeader.spec.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/SubHeader.spec.ts
@@ -55,7 +55,7 @@ describe('SubHeader', () => {
 
 		await actionBtn.trigger('click');
 
-		expect(wrapper.emitted('click:list-item')).toEqual([[eventActionValue]]);
+		expect(wrapper.emitted('click-list-item')).toEqual([[eventActionValue]]);
 	});
 
 	it('renders loading state correctly', async() => {


### PR DESCRIPTION
# Description

Dans la prochaine version majeure du plugin, ESLint Vue.js, les noms des événements personnalisés doivent être en kebab-case https://eslint.vuejs.org/rules/custom-event-name-casing.html
(c'est également une nouvelle règle dans le Style Guide de Vue 3)

## Type de changement

- [x] Refactoring
- [x] Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
