### PR TITLE
🐛 form-builder: Fix textarea width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - 🐛 **Corrections de bugs**
   - **FormField:** Correction des marges sur le champ période ([#580](https://github.com/assurance-maladie-digital/design-system/pull/580)) ([d8c8303](https://github.com/assurance-maladie-digital/design-system/commit/d8c8303e2ab9f6c8e43bf8abbcc7d73b74103527))
-  - **FormField:** Correction de la largeur sur le champ textarea
+  - **FormField:** Correction de la largeur sur le champ textarea ([#609](https://github.com/assurance-maladie-digital/design-system/pull/609))
 
 ### Interne
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - 🐛 **Corrections de bugs**
   - **FormField:** Correction des marges sur le champ période ([#580](https://github.com/assurance-maladie-digital/design-system/pull/580)) ([d8c8303](https://github.com/assurance-maladie-digital/design-system/commit/d8c8303e2ab9f6c8e43bf8abbcc7d73b74103527))
-  - **FormField:** Correction de la largeur sur le champ textarea ([#609](https://github.com/assurance-maladie-digital/design-system/pull/609))
+  - **FormField:** Correction de la largeur du champ textarea ([#609](https://github.com/assurance-maladie-digital/design-system/pull/609))
 
 ### Interne
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - 🐛 **Corrections de bugs**
   - **FormField:** Correction des marges sur le champ période ([#580](https://github.com/assurance-maladie-digital/design-system/pull/580)) ([d8c8303](https://github.com/assurance-maladie-digital/design-system/commit/d8c8303e2ab9f6c8e43bf8abbcc7d73b74103527))
+  - **FormField:** Correction de la largeur sur le champ textarea
 
 ### Interne
 

--- a/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -84,7 +84,7 @@ exports[`FormBuilder renders correctly 1`] = `
       <p class="text-body-2 grey--text text--darken-1">
         Informations supplémentaires
       </p>
-      <div class="v-input vd-form-input v-textarea theme--light v-text-field v-text-field--enclosed v-text-field--outlined">
+      <div class="v-input v-textarea theme--light v-text-field v-text-field--enclosed v-text-field--outlined">
         <div class="v-input__control">
           <div class="v-input__slot">
             <fieldset aria-hidden="true">

--- a/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -84,7 +84,7 @@ exports[`FormBuilder renders correctly 1`] = `
       <p class="text-body-2 grey--text text--darken-1">
         Informations supplémentaires
       </p>
-      <div class="v-input v-textarea theme--light v-text-field v-text-field--enclosed v-text-field--outlined">
+      <div class="v-input vd-form-input-xl v-textarea theme--light v-text-field v-text-field--enclosed v-text-field--outlined">
         <div class="v-input__control">
           <div class="v-input__slot">
             <fieldset aria-hidden="true">

--- a/packages/form-builder/src/components/FormField/fields/TextareaField.vue
+++ b/packages/form-builder/src/components/FormField/fields/TextareaField.vue
@@ -2,6 +2,7 @@
 	<VTextarea
 		v-bind="field.fieldOptions"
 		:value="field.value"
+		class="vd-form-input-xl"
 		@change="emitChangeEvent"
 	/>
 </template>

--- a/packages/form-builder/src/components/FormField/fields/TextareaField.vue
+++ b/packages/form-builder/src/components/FormField/fields/TextareaField.vue
@@ -2,7 +2,6 @@
 	<VTextarea
 		v-bind="field.fieldOptions"
 		:value="field.value"
-		class="vd-form-input"
 		@change="emitChangeEvent"
 	/>
 </template>


### PR DESCRIPTION
# Description

Réduction de largeur sur le champ textarea en mettant la classe 'vd-form-input-xl' sur le champ 'TextereaField' pour avoir un max-width plus grand.

Avant: 
![image](https://user-images.githubusercontent.com/6760432/95441281-3e306e00-095a-11eb-9e30-3f310b4f23e6.png)

Après: 
![image](https://user-images.githubusercontent.com/6760432/95479192-c7f82f80-098a-11eb-967d-ef955f447d0a.png)




## Type de changement

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
