### PR TITLE
🔥 vue-dash: Remove global component imports in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Vue Dash
 
 - 🔥 **Suppressions**
-  - **template:** Utilisation du composant `ErrorPage` de Vue Dot ([#605](https://github.com/assurance-maladie-digital/design-system/pull/605))
+  - **template:** Utilisation du composant `ErrorPage` de Vue Dot ([#605](https://github.com/assurance-maladie-digital/design-system/pull/605)) ([cea80b5](https://github.com/assurance-maladie-digital/design-system/commit/cea80b59029ef986bc3d0c4c4344c228d2e331e4))
+  - **template:** Suppression des imports des composants globaux ([#580](https://github.com/assurance-maladie-digital/design-system/pull/580))
 
 ### FormBuilder
 

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/main.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/main.ts
@@ -24,9 +24,6 @@ import { router } from './router';
 import { store } from './store';<% if (i18n) { %>
 import { i18n } from './i18n';<% } %>
 
-// Register global components
-import './components/global';
-
 // Remove "tip" from browser console
 Vue.config.productionTip = false;
 

--- a/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/index.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/index.ts
@@ -74,9 +74,6 @@ localVue.use(InputFacade);
 
 addVApp();
 
-// Register global components
-import '@/components/global';
-
 /**
  * Generic mount function
  *


### PR DESCRIPTION
# Description

Suppression d'imports des composants globaux toujours présents, ce qui générait des erreurs

## Type de changement

- [x] Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
