### PR TITLE
♻️ vue-dot: Rename IDataList interface to DataList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Non publié
 
+### Vue Dot
+
+- ♻️ **Refactoring**
+  - **DataList:** Renommage de l'interface `IDataList` en `DataList` ([#649](https://github.com/assurance-maladie-digital/design-system/pull/649))
+
 ### Vue Dash
 
 - ✨ **Nouvelles fonctionnalités**
@@ -9,7 +14,18 @@
 
 - ⬆️ **Dépendances**
   - **jest:** Mise à jour vers la `v26.6.0` ([#646](https://github.com/assurance-maladie-digital/design-system/pull/646)) ([ba66508](https://github.com/assurance-maladie-digital/design-system/commit/ba665081397191d5a96179dee920681857fec0f3))
-  - **eslint-plugin-jsdoc:** Mise à jour vers la `v30.7.3` ([#647](https://github.com/assurance-maladie-digital/design-system/pull/647))
+  - **eslint-plugin-jsdoc:** Mise à jour vers la `v30.7.3` ([#647](https://github.com/assurance-maladie-digital/design-system/pull/647)) ([4f3411b](https://github.com/assurance-maladie-digital/design-system/commit/4f3411bc48e17629dc3971a6ef08c0779a7a23f9))
+
+### 📚 Guide de migration
+
+#### Renommer l'interface `IDataList`
+
+L'interface `IDataList` a été renommée en `DataList` :
+
+```diff
+-import { IDataList } from ' @cnamts/vue-dot/src/elements/DataList/types';
++import { DataList } from ' @cnamts/vue-dot/src/elements/DataList/types';
+```
 
 ## v2.0.0-beta.2
 
@@ -291,7 +307,7 @@ Puis importer ceux-ci depuis le package :
 +import { tokens } from '@cnamts/design-tokens;
 ```
 
-De même, la constante `vuetifyTheme` a changé d'emplacement et est maintenant appelée `lightTheme`
+De même, la constante `vuetifyTheme` a changé d'emplacement et est maintenant appelée `lightTheme` :
 
 ```diff
 -import { vuetifyTheme } from '@cnamts/vue-dot/src/tokens/vuetifyTheme';
@@ -366,7 +382,7 @@ Cette version comporte de nouvelles fonctionnalités ainsi que des corrections d
 
 #### Largeur des composants `FileUpload` et `UploadWorkflow`
 
-Ces composants ont maintenant une largeur par défaut de `100%`, vous pouvez utiliser la prop `width` pour définir une largeur:
+Ces composants ont maintenant une largeur par défaut de `100%`, vous pouvez utiliser la prop `width` pour définir une largeur :
 
 ```diff
 <FileUpload
@@ -463,12 +479,15 @@ Au moment de la sortie de cette version, [Vue the mask](https://github.com/vuejs
 Pour mettre à jour, vous devez supprimer `vue-the-mask` du fichier `package.json`, en utilisant la commande `yarn remove vue-the-mask`, et installer `vue-input-facade` en utilisant `yarn add vue-input-facade`.
 
 Après avoir installé le nouveau package, vous devez mettre à jour la déclaration du module :
+
 ```diff
 // src/modules.d.ts
 -declare module 'vue-the-mask';
 +declare module 'vue-input-facade';
 ```
+
 Et aussi mettre à jour l'utilisation du plugin :
+
 ```diff
 // src/plugins/vue-dot.ts
 -// Register v-mask directive
@@ -480,6 +499,7 @@ Et aussi mettre à jour l'utilisation du plugin :
 ```
 
 Il est également nécessaire d'ajouter `vue-input-facade` à la liste des dépendances qui doivent être transpilées pour assurer la comptabilité des navigateurs comme IE 11 :
+
 ```diff
 // vue.config.js
 // Transpile ES6 inside dependencies
@@ -491,6 +511,7 @@ transpileDependencies: [
 ```
 
 Pour la compatibilité des navigateurs comme IE 11, vous devez également ajouter le polyfill `custom-event-polyfill` en utilisant `yarn add custom-event-polyfill`, puis l'importer dans votre application :
+
 ```diff
 // main.ts
 +// Polyfill for vue-input-facade on IE
@@ -506,6 +527,7 @@ Si vous l'utilisez, vous devez rechercher et remplacer `v-mask` par `v-facade`. 
 ### Renommer `showWeekEnds` sur le `DatePicker`
 
 La prop `showWeekEnds` a été renommée en `showWeekends` :
+
 ```diff
 <DatePicker
 -	showWeekEnds

--- a/packages/vue-dot/playground/examples/DataListEx.vue
+++ b/packages/vue-dot/playground/examples/DataListEx.vue
@@ -33,7 +33,7 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	import { IDataList } from '../../src/elements/DataList/types';
+	import { DataList } from '../../src/elements/DataList/types';
 
 	import { mdiCalendar } from '@mdi/js';
 
@@ -43,7 +43,7 @@
 
 		actionValue: string | null = 'New text';
 
-		data: IDataList = [
+		data: DataList = [
 			{
 				key: 'Civility',
 				value: 'Mr',

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -56,7 +56,7 @@
 	import Component, { mixins } from 'vue-class-component';
 
 	import { locales } from './locales';
-	import { DataListIcons, IDataList } from './types';
+	import { DataListIcons, DataList as IDataList } from './types';
 
 	import DataListItem from './DataListItem';
 	import DataListLoading from './DataListLoading';

--- a/packages/vue-dot/src/elements/DataList/tests/data/dataList.ts
+++ b/packages/vue-dot/src/elements/DataList/tests/data/dataList.ts
@@ -1,6 +1,6 @@
-import { IDataList } from './../../types';
+import { DataList } from './../../types';
 
-export const dataList: IDataList = [
+export const dataList: DataList = [
 	{
 		key: 'Civility',
 		value: ''

--- a/packages/vue-dot/src/elements/DataList/types.d.ts
+++ b/packages/vue-dot/src/elements/DataList/types.d.ts
@@ -1,6 +1,6 @@
 import { Options } from '../../mixins/customizable';
 
-export interface IDataListItem {
+export interface DataListItem {
 	key: string;
 	value?: string | number;
 	action?: string;
@@ -9,7 +9,7 @@ export interface IDataListItem {
 	options?: Options;
 }
 
-export type IDataList = IDataListItem[];
+export type DataList = DataListItem[];
 
 export interface DataListIcons {
 	[iconName: string]: string;

--- a/packages/vue-dot/src/patterns/SubHeader/tests/data/subHeader.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/data/subHeader.ts
@@ -1,7 +1,7 @@
-import { IDataList } from '../../../../elements/DataList/types';
+import { DataList } from '../../../../elements/DataList/types';
 import { DataListsItem } from '../../types';
 
-export const dataListItems: IDataList = [
+export const dataListItems: DataList = [
 	{
 		key: 'Libellé',
 		value: 'Texte saisi'
@@ -12,7 +12,7 @@ export const dataListItems: IDataList = [
 	}
 ];
 
-export const dataListItemsActions: IDataList = [
+export const dataListItemsActions: DataList = [
 	{
 		key: 'Libellé',
 		value: 'Texte à modifier',

--- a/packages/vue-dot/src/patterns/SubHeader/types.d.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/types.d.ts
@@ -1,4 +1,4 @@
-import { IDataList } from '../../elements/DataList/types';
+import { DataList } from '../../elements/DataList/types';
 
 export interface IDataListAction {
 	dataListIndex: number;
@@ -7,7 +7,7 @@ export interface IDataListAction {
 
 export interface DataListsItem {
 	title?: string;
-	items: IDataList;
+	items: DataList;
 	headingLoading?: boolean;
 	itemsNumberLoading?: number;
 }


### PR DESCRIPTION
# Description

Renommage de l'interface `IDataList` en `DataList`. Elle était nommée comme ça pour éviter un conflit avec `class DataList`, mais en fait on peut renommer l'interface lors de l'import pour ne pas avoir le préfixe dans le code client

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
