### PR TITLE
🚨 Update lint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@
 
 ### Interne
 
+- 🚨 **Lint**
+  - **config:** Mise à jour des règles de lint ([#651](https://github.com/assurance-maladie-digital/design-system/pull/651))
+
 - ⬆️ **Dépendances**
   - **jest:** Mise à jour vers la `v26.6.0` ([#646](https://github.com/assurance-maladie-digital/design-system/pull/646)) ([ba66508](https://github.com/assurance-maladie-digital/design-system/commit/ba665081397191d5a96179dee920681857fec0f3))
   - **eslint-plugin-jsdoc:** Mise à jour vers la `v30.7.3` ([#647](https://github.com/assurance-maladie-digital/design-system/pull/647)) ([4f3411b](https://github.com/assurance-maladie-digital/design-system/commit/4f3411bc48e17629dc3971a6ef08c0779a7a23f9))
-  - **typescript-eslint:** Mise à jour du monorepo vers la `v4.5.0` ([#648](https://github.com/assurance-maladie-digital/design-system/pull/648))
+  - **typescript-eslint:** Mise à jour du monorepo vers la `v4.5.0` ([#648](https://github.com/assurance-maladie-digital/design-system/pull/648)) ([6796d57](https://github.com/assurance-maladie-digital/design-system/commit/6796d57e34c1cf09f359b1149a24aeb52a60f548))
 
 ### 📚 Guide de migration
 

--- a/packages/form-builder/.eslintrc.js
+++ b/packages/form-builder/.eslintrc.js
@@ -32,13 +32,26 @@ module.exports = {
 
 		// .vue <script> indent
 		'vue/script-indent': ['error', 'tab', {
-			'baseIndent': 1,
-			'switchCase': 1,
-			'ignores': []
+			baseIndent: 1,
+			switchCase: 1,
+			ignores: []
+		}],
+
+		// Allow modifiers in slot names
+		// eg. <template v-slot.foo>
+		'vue/valid-v-slot': ['error', {
+			allowModifiers: true
+		}],
+
+		// Allow event names like click:row
+		'vue/custom-event-name-casing': ['error', {
+			ignores: ['/^[a-z]+(?:-[a-z]+)*:[a-z]+(?:-[a-z]+)*$/u']
 		}],
 
 		// Maximum 1 empty line
-		'no-multiple-empty-lines': ['error', { 'max': 1 }],
+		'no-multiple-empty-lines': ['error', {
+			max: 1
+		}],
 
 		// Remove trailing coma
 		'comma-dangle': ['error', 'never'],
@@ -48,7 +61,7 @@ module.exports = {
 			'error',
 			'PascalCase',
 			{
-				'ignores': [
+				ignores: [
 					'keep-alive',
 					'component',
 					'transition',
@@ -73,9 +86,9 @@ module.exports = {
 
 		// Limit .vue files to 350 lines
 		'max-lines': ['error', {
-			'max': 350,
-			'skipBlankLines': true,
-			'skipComments': true
+			max: 350,
+			skipBlankLines: true,
+			skipComments: true
 		}],
 
 		'object-curly-spacing': ['error', 'always'],
@@ -88,7 +101,7 @@ module.exports = {
 		'@typescript-eslint/explicit-module-boundary-types': [
 			'error',
 			{
-				'allowedNames': [
+				allowedNames: [
 					'beforeCreate',
 					'created',
 					'beforeMount',
@@ -106,13 +119,6 @@ module.exports = {
 		'jsdoc/require-returns': 0
 	},
 	overrides: [
-		{
-			files: ['*.vue'],
-			rules: {
-				// Waiting on https://github.com/vuejs/eslint-plugin-vue/issues/1260
-				'vue/custom-event-name-casing': 'off'
-			}
-		},
 		{
 			files: ['*.js'],
 			rules: {

--- a/packages/form-builder/src/components/FormBuilder/mixins/tests/formBuilderCore.spec.ts
+++ b/packages/form-builder/src/components/FormBuilder/mixins/tests/formBuilderCore.spec.ts
@@ -38,7 +38,7 @@ const updatedField = updatedTestForm.section1.questions;
 
 /** Create the wrapper */
 function createWrapper(form: Form) {
-	const component = Vue.component('test', {
+	const component = Vue.component('Test', {
 		mixins: [
 			FormBuilderCore
 		],

--- a/packages/form-builder/src/components/FormField/mixins/tests/choiceComponent.spec.ts
+++ b/packages/form-builder/src/components/FormField/mixins/tests/choiceComponent.spec.ts
@@ -40,7 +40,7 @@ const testField: TestComponent = {
 
 /** Create the wrapper */
 function createWrapper(field: TestComponent) {
-	const testComponent = Vue.component('test', {
+	const testComponent = Vue.component('Test', {
 		mixins: [
 			ChoiceComponent
 		],

--- a/packages/form-builder/src/components/FormField/mixins/tests/fieldComponent.spec.ts
+++ b/packages/form-builder/src/components/FormField/mixins/tests/fieldComponent.spec.ts
@@ -16,7 +16,7 @@ const testField = {
 
 /** Create the wrapper */
 function createWrapper(field: Field) {
-	const component = Vue.component('test', {
+	const component = Vue.component('Test', {
 		mixins: [
 			FieldComponent
 		],

--- a/packages/form-builder/src/components/FormField/mixins/tests/fieldMap.spec.ts
+++ b/packages/form-builder/src/components/FormField/mixins/tests/fieldMap.spec.ts
@@ -5,7 +5,7 @@ import { FieldMap } from '../fieldMap';
 
 /** Create the wrapper */
 function createWrapper() {
-	const component = Vue.component('test', {
+	const component = Vue.component('Test', {
 		mixins: [
 			FieldMap
 		],

--- a/packages/vue-dot/.eslintrc.js
+++ b/packages/vue-dot/.eslintrc.js
@@ -32,13 +32,26 @@ module.exports = {
 
 		// .vue <script> indent
 		'vue/script-indent': ['error', 'tab', {
-			'baseIndent': 1,
-			'switchCase': 1,
-			'ignores': []
+			baseIndent: 1,
+			switchCase: 1,
+			ignores: []
+		}],
+
+		// Allow modifiers in slot names
+		// eg. <template v-slot.foo>
+		'vue/valid-v-slot': ['error', {
+			allowModifiers: true
+		}],
+
+		// Allow event names like click:row
+		'vue/custom-event-name-casing': ['error', {
+			ignores: ['/^[a-z]+(?:-[a-z]+)*:[a-z]+(?:-[a-z]+)*$/u']
 		}],
 
 		// Maximum 1 empty line
-		'no-multiple-empty-lines': ['error', { 'max': 1 }],
+		'no-multiple-empty-lines': ['error', {
+			max: 1
+		}],
 
 		// Remove trailing coma
 		'comma-dangle': ['error', 'never'],
@@ -48,7 +61,7 @@ module.exports = {
 			'error',
 			'PascalCase',
 			{
-				'ignores': [
+				ignores: [
 					'keep-alive',
 					'component',
 					'transition',
@@ -73,9 +86,9 @@ module.exports = {
 
 		// Limit .vue files to 350 lines
 		'max-lines': ['error', {
-			'max': 350,
-			'skipBlankLines': true,
-			'skipComments': true
+			max: 350,
+			skipBlankLines: true,
+			skipComments: true
 		}],
 
 		'object-curly-spacing': ['error', 'always'],
@@ -88,7 +101,7 @@ module.exports = {
 		'@typescript-eslint/explicit-module-boundary-types': [
 			'error',
 			{
-				'allowedNames': [
+				allowedNames: [
 					'beforeCreate',
 					'created',
 					'beforeMount',
@@ -106,13 +119,6 @@ module.exports = {
 		'jsdoc/require-returns': 0
 	},
 	overrides: [
-		{
-			files: ['*.vue'],
-			rules: {
-				// Waiting on https://github.com/vuejs/eslint-plugin-vue/issues/1260
-				'vue/custom-event-name-casing': 'off'
-			}
-		},
 		{
 			files: ['*.js'],
 			rules: {


### PR DESCRIPTION
# Description

Suite à la mise à jour du plugin ESLint Vue on peut réactiver la règle `vue/custom-event-name-casing` et modifier la configuration de la règle `vue/valid-v-slot`

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
