### PR TITLE
♻️ vue-dot: Refactor ErrorPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,30 @@ L'interface `IDataList` a été renommée en `DataList` :
 +import { DataList } from '@cnamts/vue-dot/src/elements/DataList/types';
 ```
 
+#### Renommer `cta` et `title` sur `ErrorPage`
+
+Les props `cta` et `title` ont été renommées en `btn-text` et `page-title`, et la prop `btn-text` a maintenant la valeur `Retour à l'accueil` par défaut :
+
+```diff
+<ErrorPage
+-	title="Page non trouvée"
++	page-title="Page non trouvée"
+	message="Il semblerait qu'il y ait eu une erreur !"
+	code="404"
+-	cta="Retour à l'acceuil"
+>
+```
+
+Pour désactiver le bouton vous devez maintenant utiliser la prop `no-btn` :
+
+```diff
+<ErrorPage
+	page-title="Page non trouvée"
+	message="Il semblerait qu'il y ait eu une erreur !"
++	no-btn
+>
+```
+
 ## v2.0.0-beta.2
 
 **Version publiée le 19/10/2020.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
 L'interface `IDataList` a été renommée en `DataList` :
 
 ```diff
--import { IDataList } from ' @cnamts/vue-dot/src/elements/DataList/types';
-+import { DataList } from ' @cnamts/vue-dot/src/elements/DataList/types';
+-import { IDataList } from '@cnamts/vue-dot/src/elements/DataList/types';
++import { DataList } from '@cnamts/vue-dot/src/elements/DataList/types';
 ```
 
 ## v2.0.0-beta.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ♻️ **Refactoring**
   - **DataList:** Renommage de l'interface `IDataList` en `DataList` ([#649](https://github.com/assurance-maladie-digital/design-system/pull/649)) ([62cf170](https://github.com/assurance-maladie-digital/design-system/commit/62cf170b49cc6bad6d02c56e1fcf75d653dac303))
+  - **ErrorPage:** Refonte du composant ([#651](https://github.com/assurance-maladie-digital/design-system/pull/651))
 
 ### Vue Dash
 
@@ -19,7 +20,7 @@
   - **jest:** Mise à jour vers la `v26.6.0` ([#646](https://github.com/assurance-maladie-digital/design-system/pull/646)) ([ba66508](https://github.com/assurance-maladie-digital/design-system/commit/ba665081397191d5a96179dee920681857fec0f3))
   - **eslint-plugin-jsdoc:** Mise à jour vers la `v30.7.3` ([#647](https://github.com/assurance-maladie-digital/design-system/pull/647)) ([4f3411b](https://github.com/assurance-maladie-digital/design-system/commit/4f3411bc48e17629dc3971a6ef08c0779a7a23f9))
   - **typescript-eslint:** Mise à jour du monorepo vers la `v4.5.0` ([#648](https://github.com/assurance-maladie-digital/design-system/pull/648)) ([6796d57](https://github.com/assurance-maladie-digital/design-system/commit/6796d57e34c1cf09f359b1149a24aeb52a60f548))
-  - **@types/jest:** Mise à jour vers la `v26.0.15` ([#650](https://github.com/assurance-maladie-digital/design-system/pull/650))
+  - **@types/jest:** Mise à jour vers la `v26.0.15` ([#650](https://github.com/assurance-maladie-digital/design-system/pull/650)) ([0be84b2](https://github.com/assurance-maladie-digital/design-system/commit/0be84b2be875be1316f32c673afd95d6083a7b51))
 
 ### 📚 Guide de migration
 

--- a/packages/vue-dot/playground/examples/DataListEx.vue
+++ b/packages/vue-dot/playground/examples/DataListEx.vue
@@ -33,7 +33,7 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	import { DataList } from '../../src/elements/DataList/types';
+	import { DataList, DataListIcons } from '../../src/elements/DataList/types';
 
 	import { mdiCalendar } from '@mdi/js';
 
@@ -82,7 +82,7 @@
 			}
 		];
 
-		icons = {
+		icons: DataListIcons = {
 			mdiCalendar
 		};
 

--- a/packages/vue-dot/playground/examples/ErrorPageEx.vue
+++ b/packages/vue-dot/playground/examples/ErrorPageEx.vue
@@ -1,10 +1,9 @@
 <template>
 	<DocSection title="ErrorPage">
 		<ErrorPage
-			title="Page non trouvé"
+			page-title="Page non trouvée"
 			message="Il semblerait qu'il y ait eu une erreur !"
 			code="404"
-			cta="Rtour à l'acceuil"
 		/>
 	</DocSection>
 </template>

--- a/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
+++ b/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
@@ -5,7 +5,7 @@
 	>
 		<span
 			v-if="code"
-			class="font-weight-bold primary--text code"
+			class="font-weight-bold primary--text vd-code"
 		>
 			{{ code }}
 		</span>
@@ -18,13 +18,13 @@
 			}"
 			class="mb-2 font-weight-bold"
 		>
-			{{ title }}
+			{{ pageTitle }}
 		</h2>
 
 		<p>{{ message }}</p>
 
 		<VLayout
-			v-if="cta && btnRoute"
+			v-if="!noBtn && btnText && btnRoute"
 			class="mt-6"
 		>
 			<VSpacer />
@@ -34,7 +34,7 @@
 				color="primary"
 				exact
 			>
-				{{ cta }}
+				{{ btnText }}
 			</VBtn>
 		</VLayout>
 	</PageCard>
@@ -46,15 +46,12 @@
 
 	import { Next } from '../../types';
 
+	import { locales } from './locales';
+
 	const Props = Vue.extend({
 		props: {
-			/** The HTTP code to display (optional) */
-			code: {
-				type: String,
-				default: undefined
-			},
-			/** The title of the ErrorPage (if no code is passed, it will be bigger) */
-			title: {
+			/** The title of the ErrorPage (bigger if code prop isn't present) */
+			pageTitle: {
 				type: String,
 				required: true
 			},
@@ -63,15 +60,25 @@
 				type: String,
 				required: true
 			},
-			/** Display a link to 'home' route when a text is passed */
-			cta: {
+			/** The HTTP code to display (optional) */
+			code: {
 				type: String,
 				default: undefined
 			},
-			/** The route of the CTA button, default to home page */
+			/** Display a link to 'home' route when a text is passed */
+			btnText: {
+				type: String,
+				default: locales.btnText
+			},
+			/** The route of the button, default to home page */
 			btnRoute: {
 				type: [Array, Object] as PropType<Next>,
 				default: () => ({ name: 'home' })
+			},
+			/** Remove the button */
+			noBtn: {
+				type: Boolean,
+				default: false
 			}
 		}
 	});
@@ -82,8 +89,9 @@
 </script>
 
 <style lang="scss" scoped>
-	.code {
+	.vd-code {
 		font-size: 6rem;
+		line-height: 6rem;
 		font-family: serif;
 	}
 </style>

--- a/packages/vue-dot/src/templates/ErrorPage/locales.ts
+++ b/packages/vue-dot/src/templates/ErrorPage/locales.ts
@@ -1,0 +1,3 @@
+export const locales = {
+	btnText: 'Retour à l\'accueil'
+};

--- a/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
@@ -14,7 +14,7 @@ describe('ErrorPage', () => {
 		// Mount component
 		wrapper = mountComponent(ErrorPage, {
 			propsData: {
-				title: 'Error',
+				pageTitle: 'Error',
 				message: 'Error message'
 			}
 		});

--- a/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ErrorPage renders correctly 1`] = `
-<pagecard width="680" card-class="px-5" title="Error">
+<pagecard width="680" card-class="px-5">
   <!---->
   <h2 class="mb-2 font-weight-bold text-h4 mb-4">
-
+    Error
   </h2>
   <p>Error message</p>
   <vlayout-stub tag="div" class="mt-6">

--- a/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
@@ -1,12 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ErrorPage renders correctly 1`] = `
-<pagecard width="680" card-class="px-5">
+<pagecard width="680" card-class="px-5" title="Error">
   <!---->
   <h2 class="mb-2 font-weight-bold text-h4 mb-4">
-    Error
+
   </h2>
   <p>Error message</p>
-  <!---->
+  <vlayout-stub tag="div" class="mt-6">
+    <vspacer-stub></vspacer-stub>
+    <vbtn-stub color="primary" tag="button" activeclass="" exact="true" to="[object Object]" type="button">
+      Retour à l'accueil
+    </vbtn-stub>
+  </vlayout-stub>
 </pagecard>
 `;


### PR DESCRIPTION
# Description

Modification des props du template `ErrorPage`, maintenant on met une valeur par défaut dans `btnText` (anciennement `cta`), mais cela empêche la désactivation du bouton donc on ajoute la prop `noBtn`

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
