### PR TITLE
🐛 vue-dash: Fix missing data-cy attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@
   - **prompts:** Ajout de l'option Cypress ([#567](https://github.com/assurance-maladie-digital/design-system/pull/567)) ([7555363](https://github.com/assurance-maladie-digital/design-system/commit/7555363bae9b65feed20faa3360aadbcc41d3efc))
   - **config:** Ajout du tree-shaking de VueDot ([#685](https://github.com/assurance-maladie-digital/design-system/pull/685)) ([de1bf9e](https://github.com/assurance-maladie-digital/design-system/commit/de1bf9ea69a2797707202e8213d950ecfd0c9b41))
 
+- 🐛 **Corrections de bugs**
+  - **template:** Correction des attributs `data-cy` manquants ([#695](https://github.com/assurance-maladie-digital/design-system/pull/695))
+
 - ♻️ **Refactoring**
   - **template:** Refonte du fichier `index.html` ([#682](https://github.com/assurance-maladie-digital/design-system/pull/682)) ([195d33d](https://github.com/assurance-maladie-digital/design-system/commit/195d33dbe0e051214eb2aa09c57af4dc4491f585))
-  - **template:** Suppression des routes dans les traductions ([#694](https://github.com/assurance-maladie-digital/design-system/pull/694))
+  - **template:** Suppression des routes dans les traductions ([#694](https://github.com/assurance-maladie-digital/design-system/pull/694)) ([48ff81d](https://github.com/assurance-maladie-digital/design-system/commit/48ff81d12d1961c152b8d5196178eae1fc6b70fe))
 
 - 🚨 **Lint**
   - **config:** Ajout d'ESLint ([#683](https://github.com/assurance-maladie-digital/design-system/pull/683)) ([bf09d5f](https://github.com/assurance-maladie-digital/design-system/commit/bf09d5f62b71b076d0be3c03de18e2df5ad9175e))

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/App.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/App.vue
@@ -8,7 +8,7 @@
 
 		<AppToolbar />
 
-		<NotificationBar />
+		<NotificationBar<% if (cypress) { %> data-cy="notificationBar"<% } %> />
 
 		<VMain>
 			<!-- Transition between routes -->

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppToolbar.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppToolbar.vue
@@ -8,7 +8,6 @@
 			v-if="!maintenance"
 			dark
 			background-color="transparent"
-			data-cy="toolbar-tabs"
 		>
 			<VTab
 				v-for="link in links"

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/HeaderMenu.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/HeaderMenu.vue
@@ -5,7 +5,6 @@
 		origin="top center"
 		offset-y
 		left
-		data-cy="header-menu"
 	>
 		<template #activator="{ on }">
 			<VBtn

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/About.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/About.vue
@@ -9,7 +9,8 @@
 			:key="index"
 			:title="data.title"
 			:links="data.links"
-			class="mt-4"
+			class="mt-4"<% if (cypress) { %>
+			data-cy="links"<% } %>
 		/>
 
 		<VBtn
@@ -19,7 +20,8 @@
 			color="accent"
 			class="mt-8"
 			outlined
-			exact
+			exact<% if (cypress) { %>
+			data-cy="backBtn"<% } %>
 		>
 			<VIcon class="mr-2">
 				{{ backArrowIcon }}

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/Home.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/Home.vue
@@ -14,7 +14,8 @@
 		<RouterLink
 			:to=" {
 				name: 'about'
-			}"
+			}"<% if (cypress) { %>
+			data-cy="aboutLink"<% } %>
 		>
 			<% if (i18n) { %>{{ $t('views.home.about.label') }}<% } else { %>À propos<% } %>
 		</RouterLink>
@@ -24,7 +25,8 @@
 		<VBtn
 			color="accent"
 			outlined
-			class="mt-8"
+			class="mt-8"<% if (cypress) { %>
+			data-cy="notify"<% } %>
 			@click="sendNotification"
 		>
 			<% if (i18n) { %>{{ $t('views.home.notify') }}<% } else { %>Envoyer une notification (exemple)<% } %>

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/NotFound.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/NotFound.vue
@@ -6,7 +6,8 @@
 		:cta="$t('views.notFound.cta')"<% } else { %>code="404"
 		title="Page non trouvée"
 		message="Il semblerait qu'il y ait eu une erreur !"
-		cta="Retour à la page d'accueil"<% } %>
+		cta="Retour à la page d'accueil"<% } if (cypress) { %>
+		data-cy="errorPage"<% } %>
 	/>
 </template>
 


### PR DESCRIPTION
# Description

Correction des attributs `data-cy` manquants et suppression des attributs en trop
Aussi on n'ajoute les attributs que si l'option `cypress` est sélectionnée

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
