### PR TITLE
🚨 vue-dash: Add missing JSDoc in vueDotLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,14 @@
 
 - 🚨 **Lint**
   - **config:** Ajout d'ESLint ([#683](https://github.com/assurance-maladie-digital/design-system/pull/683)) ([bf09d5f](https://github.com/assurance-maladie-digital/design-system/commit/bf09d5f62b71b076d0be3c03de18e2df5ad9175e))
+  - **config:** Ajout des descriptions JSDoc manquantes dans `vueDotLoader` ([#708](https://github.com/assurance-maladie-digital/design-system/pull/708))
 
 - 🔧 **Configuration**
   - **template:** Suppression de TSLint et mise à jour de la configuration d'ESLint ([#642](https://github.com/assurance-maladie-digital/design-system/pull/642)) ([9f2a06](https://github.com/assurance-maladie-digital/design-system/commit/9f2a06aba4a188a4ebfd58ce6bf407e1c1a88606))
   - **template:** Mise à jour d'ESLint et de la configuration ([#693](https://github.com/assurance-maladie-digital/design-system/pull/693)) ([882df8c](https://github.com/assurance-maladie-digital/design-system/commit/882df8cab1959ec833b2577d0cdca0026f4a66b1))
 
 - ⬆️ **Dépendances**
-  - **template:** Mise à jour de Cypress vers la `v5` ([#707]https://github.com/assurance-maladie-digital/design-system/pull/707)
+  - **template:** Mise à jour de Cypress vers la `v5` ([#707]https://github.com/assurance-maladie-digital/design-system/pull/707) ([6abfc29](https://github.com/assurance-maladie-digital/design-system/commit/6abfc295ad70827d06c1f54eddd38f1457b339b7))
 
 ### Interne
 

--- a/packages/vue-cli-plugin-vue-dash/vueDotLoader.js
+++ b/packages/vue-cli-plugin-vue-dash/vueDotLoader.js
@@ -44,6 +44,18 @@ function getVueDotComponent(componentName) {
 	return [componentName, `import ${componentName} from '@cnamts/vue-dot/src/${componentType}/${componentName}'`];
 }
 
+/**
+ * This function will be called for every tag used in each vue component
+ * It should return an array, the first element will be inserted into the
+ * components array, the second should be a corresponding import
+ *
+ * @see https://github.com/vuetifyjs/vuetify-loader#automatic-imports
+ *
+ * @param {string} _ The tag as it was originally used in the template
+ * @param {object} options The options of the component
+ * @param {string} options.camelTag The tag normalized to PascalCase
+ * @returns {Array} The Vue Dot components
+ */
 function match(_, { camelTag }) {
 	if (isVueDotComponent(camelTag)) {
 		return getVueDotComponent(camelTag);


### PR DESCRIPTION
# Description

Ajout des descriptions JSDoc manquantes dans `vueDotLoader`.

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
