### PR TITLE
⬆️ vue-dash: Update jest to v26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,15 @@
 
 - 🚨 **Lint**
   - **config:** Ajout d'ESLint ([#683](https://github.com/assurance-maladie-digital/design-system/pull/683)) ([bf09d5f](https://github.com/assurance-maladie-digital/design-system/commit/bf09d5f62b71b076d0be3c03de18e2df5ad9175e))
-  - **config:** Ajout des descriptions JSDoc manquantes dans `vueDotLoader` ([#708](https://github.com/assurance-maladie-digital/design-system/pull/708))
+  - **config:** Ajout des descriptions JSDoc manquantes dans `vueDotLoader` ([#708](https://github.com/assurance-maladie-digital/design-system/pull/708)) ([8f136bf](https://github.com/assurance-maladie-digital/design-system/commit/8f136bf385281e9cd096cafdffc3638c55a641ec))
 
 - 🔧 **Configuration**
   - **template:** Suppression de TSLint et mise à jour de la configuration d'ESLint ([#642](https://github.com/assurance-maladie-digital/design-system/pull/642)) ([9f2a06](https://github.com/assurance-maladie-digital/design-system/commit/9f2a06aba4a188a4ebfd58ce6bf407e1c1a88606))
   - **template:** Mise à jour d'ESLint et de la configuration ([#693](https://github.com/assurance-maladie-digital/design-system/pull/693)) ([882df8c](https://github.com/assurance-maladie-digital/design-system/commit/882df8cab1959ec833b2577d0cdca0026f4a66b1))
 
 - ⬆️ **Dépendances**
-  - **template:** Mise à jour de Cypress vers la `v5` ([#707]https://github.com/assurance-maladie-digital/design-system/pull/707) ([6abfc29](https://github.com/assurance-maladie-digital/design-system/commit/6abfc295ad70827d06c1f54eddd38f1457b339b7))
+  - **template:** Mise à jour de Cypress vers la `v5` ([#707](https://github.com/assurance-maladie-digital/design-system/pull/707) ([6abfc29](https://github.com/assurance-maladie-digital/design-system/commit/6abfc295ad70827d06c1f54eddd38f1457b339b7))
+  - **template:** Mise à jour de Jest vers la `v26` ([#709](https://github.com/assurance-maladie-digital/design-system/pull/709)
 
 ### Interne
 

--- a/packages/vue-cli-plugin-vue-dash/generator/functions/extendPackage.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/functions/extendPackage.js
@@ -56,21 +56,23 @@ function extendPackage(api, options) {
 			'@typescript-eslint/parser': '^4.7.0',
 			'@vue/eslint-config-standard': '^5.1.2',
 			'@vue/eslint-config-typescript': '^7.0.0',
-			'babel-jest': '^26.5.2',
 			'eslint': '^7.13.0',
 			'eslint-plugin-import': '^2.22.1',
 			'eslint-plugin-node': '^11.1.0',
 			'eslint-plugin-promise': '^4.2.1',
 			'eslint-plugin-standard': '^4.1.0',
 			'eslint-plugin-vue': '^7.1.0',
-			'jest': '^26.5.3',
 			'jest-serializer-vue': '^2.0.2',
-			'ts-jest': '^26.4.1',
 			'vue-class-component': '^7.2.6',
 			'vue-cli-plugin-vuetify': '^2.0.7',
 			'vuetify-loader': '^1.6.0',
 			'webfontloader': '^1.6.28',
 			'webpack': '^4.44.2'
+		},
+		resolutions: {
+			'jest': '^26.6.3',
+			'ts-jest': '^26.4.4',
+			'babel-jest': '^26.6.3'
 		}
 	};
 
@@ -96,7 +98,6 @@ function extendPackage(api, options) {
 		newPackageProperties.scripts['test:e2e'] = 'vue-cli-service test:e2e --headless';
 		newPackageProperties.scripts['test:e2e:gui'] = 'vue-cli-service test:e2e';
 
-		newPackageProperties.resolutions = {};
 		newPackageProperties.resolutions['cypress'] = '^5.6.0';
 	}
 


### PR DESCRIPTION
# Description

Mise à jour de Jest vers la `v26` dans le SK
La version était bloquée par Vue CLI, on la débloque car éprouvé par le Design System, maintenant tout le monde est aligné

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
