### PR TITLE
🔧 Use TypeScript for Jest configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - 🐛 **Corrections de bugs**
   - **config:** Correction de la variable d'environnement `VUE_APP_VERSION` déclarée dans `vueDotLoader` ([#750](https://github.com/assurance-maladie-digital/design-system/pull/750)) ([d265dac](https://github.com/assurance-maladie-digital/design-system/commit/d265dacf0386e0b213da216818873a945d9e75b1))
-  - **template:** Correction de la variable `maintenance` non définie dans `AppHeader` ([#751](https://github.com/assurance-maladie-digital/design-system/pull/751))
+  - **template:** Correction de la variable `maintenance` non définie dans `AppHeader` ([#751](https://github.com/assurance-maladie-digital/design-system/pull/751)) ([8519cc9](https://github.com/assurance-maladie-digital/design-system/commit/8519cc915cff09c91b497de37806d1c5ad4c666c))
 
 - 🔥 **Suppressions**
   - **template:** Suppression d'un `margin-left` dupliqué dans le composant `AppHeader` ([#740](https://github.com/assurance-maladie-digital/design-system/pull/740)) ([0b2931a](https://github.com/assurance-maladie-digital/design-system/commit/0b2931af250119a37c96086d623bec2e50655e2d))
@@ -32,6 +32,7 @@
 
 - 🔧 **Configuration**
   - **ci:** Remplacement de Travis CI par CircleCI ([#749](https://github.com/assurance-maladie-digital/design-system/pull/749)) ([d55d994](https://github.com/assurance-maladie-digital/design-system/commit/d55d99476f660a5608da42891053fe079083b2db))
+  - **jest:** Utilisation de TypeScript pour la configuration de Jest ([#752](https://github.com/assurance-maladie-digital/design-system/pull/752))
 
 - 📝 **Documentation**
   - **CHANGELOG:** Correction du fichier CHANGELOG ([#720](https://github.com/assurance-maladie-digital/design-system/pull/720)) ([5f94ff5](https://github.com/assurance-maladie-digital/design-system/commit/5f94ff5ac4efd685a332135a64c54c9b9c0c882c))

--- a/packages/cli-helpers/jest.config.ts
+++ b/packages/cli-helpers/jest.config.ts
@@ -1,9 +1,13 @@
-module.exports = {
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
 	moduleFileExtensions: ['ts', 'js'],
 	transform: {
 		'^.+\\.ts$': require.resolve('ts-jest')
 	},
-	transformIgnorePatterns: ['/node_modules/'],
+	transformIgnorePatterns: [
+		'/node_modules/'
+	],
 	testMatch: [
 		'<rootDir>/src/**/tests/*.spec.ts',
 		'<rootDir>/tests/**/*.spec.ts'
@@ -25,3 +29,5 @@ module.exports = {
 		'!**/*.d.ts'
 	]
 };
+
+export default config;

--- a/packages/design-tokens/jest.config.ts
+++ b/packages/design-tokens/jest.config.ts
@@ -1,9 +1,13 @@
-module.exports = {
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
 	moduleFileExtensions: ['ts', 'js'],
 	transform: {
 		'^.+\\.ts$': require.resolve('ts-jest')
 	},
-	transformIgnorePatterns: ['/node_modules/'],
+	transformIgnorePatterns: [
+		'/node_modules/'
+	],
 	testMatch: [
 		'<rootDir>/src/**/tests/*.spec.ts',
 		'<rootDir>/tests/**/*.spec.ts'
@@ -25,3 +29,5 @@ module.exports = {
 		'!**/*.d.ts'
 	]
 };
+
+export default config;

--- a/packages/form-builder/jest.config.ts
+++ b/packages/form-builder/jest.config.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
 	preset: '@vue/cli-plugin-unit-jest/presets/typescript',
 	testMatch: [
 		'<rootDir>/src/**/tests/*.spec.ts',
@@ -30,3 +32,5 @@ module.exports = {
 		'./node_modules/(?!vuetify)'
 	]
 };
+
+export default config;

--- a/packages/vue-dot/jest.config.ts
+++ b/packages/vue-dot/jest.config.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
 	preset: '@vue/cli-plugin-unit-jest/presets/typescript',
 	testMatch: [
 		'<rootDir>/src/**/tests/*.spec.ts',
@@ -27,6 +29,8 @@ module.exports = {
 		'!**/data/**'
 	],
 	transformIgnorePatterns: [
-		'./node_modules/(?!vuetify|@cnamts/vue-dot)'
+		'./node_modules/(?!vuetify)'
 	]
 };
+
+export default config;


### PR DESCRIPTION
## Description

Utilisation de TypeScript pour la configuration de Jest
Il faut utiliser node.js 12 lors du dev sur le DS à cause de cette erreur https://github.com/jsdom/jsdom/issues/2961
(on peut mettre à jour sans soucis, on va devoir le faire sur les envs également)

## Type de changement

- Maintenance

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
