### PR TITLE
🐛 vue-dot: Fix update:options event fired twice in PaginatedTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - **LangBtn:** Correction de la valeur par défaut de la prop `availableLanguages` ([#737](https://github.com/assurance-maladie-digital/design-system/pull/737)) ([e6cdeac](https://github.com/assurance-maladie-digital/design-system/commit/e6cdeac5ab9c3eedfcce277fec6657e4d57c78a1))
   - **FileUpload:** Correction du type `ErrorCodeType` et de l'interface `ErrorEvent` ([#738](https://github.com/assurance-maladie-digital/design-system/pull/738)) ([d00088f](https://github.com/assurance-maladie-digital/design-system/commit/d00088f5a2584b8ae2dcc6d1464f76e47f5b4f19))
   - **peerDependencies:** Correction d'une dépendance `@cnamts/design-tokens` manquante ([#739](https://github.com/assurance-maladie-digital/design-system/pull/739)) ([bab2654](https://github.com/assurance-maladie-digital/design-system/commit/bab26549758ef8dd93494e02fd406a9e2b0b7c56))
+  - **PaginatedTable:** Correction de l'événement `update:options` émis deux fois ([#766](https://github.com/assurance-maladie-digital/design-system/pull/766))
 
 ### Vue Dash
 
@@ -53,7 +54,7 @@
   - **@types/node:** Mise à jour vers la `v12.19.7` ([#745](https://github.com/assurance-maladie-digital/design-system/pull/745)) ([fd9d165](https://github.com/assurance-maladie-digital/design-system/commit/fd9d165c349351111a604a722f857d4eabfc3e2c))
   - **vuex:** Mise à jour vers la `3.6.0` ([#747](https://github.com/assurance-maladie-digital/design-system/pull/747)) ([1ca4491](https://github.com/assurance-maladie-digital/design-system/commit/1ca44918ffacc2afd857fcfeee0f713ba54324f5))
   - **core-js:** Mise à jour vers la `v3.8.0` ([#748](https://github.com/assurance-maladie-digital/design-system/pull/748)) ([3d61261](https://github.com/assurance-maladie-digital/design-system/commit/3d61261f20add9c22e1722fc24dd94c28ef3ee06))
-  - **babel-loader:** Mise à jour vers la `v8.2.2` ([#755](https://github.com/assurance-maladie-digital/design-system/pull/755))
+  - **babel-loader:** Mise à jour vers la `v8.2.2` ([#756](https://github.com/assurance-maladie-digital/design-system/pull/756)) ([beec1d8](https://github.com/assurance-maladie-digital/design-system/commit/beec1d8bc22740b37ec4795582fbd5dfcadc6482))
 
 ## v2.0.0-beta.3
 

--- a/packages/vue-dot/playground/examples/PaginatedTableEx.vue
+++ b/packages/vue-dot/playground/examples/PaginatedTableEx.vue
@@ -86,11 +86,6 @@
 			}
 		];
 
-		/** Fetch data when rendered */
-		mounted() {
-			this.fetchData();
-		}
-
 		fetchData(): void {
 			this.getDataFromApi()
 				.then((value) => {

--- a/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
+++ b/packages/vue-dot/src/patterns/PaginatedTable/PaginatedTable.vue
@@ -115,8 +115,6 @@
 			if (Object.keys(this.localOptions).length) {
 				this.localOptions = {} as DataOptions;
 			}
-
-			this.$emit('update:options', value);
 		}
 
 		/** Local storage key */


### PR DESCRIPTION
## Description

L'événement `update:options` est émis deux fois sur la `PaginatedTable` car on a `v-on="$listeners"` sur la `VDataTable` mais qu'on émet également le même événement dans le setter `optionsCalc`

Lorsque l'on écoute l'événement `<PaginatedTable @update:options="fetchData" />`, il est émis sur la `VDataTable` et la `PaginatedTable`, la méthode `fetchData` est donc appelée deux fois

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
