### PR TITLE
🐛 vue-dot: Fix notAfterToday & notBeforeToday locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   - **LangBtn:** Correction de la valeur par défaut de la prop `availableLanguages` ([#737](https://github.com/assurance-maladie-digital/design-system/pull/737)) ([e6cdeac](https://github.com/assurance-maladie-digital/design-system/commit/e6cdeac5ab9c3eedfcce277fec6657e4d57c78a1))
   - **FileUpload:** Correction du type `ErrorCodeType` et de l'interface `ErrorEvent` ([#738](https://github.com/assurance-maladie-digital/design-system/pull/738)) ([d00088f](https://github.com/assurance-maladie-digital/design-system/commit/d00088f5a2584b8ae2dcc6d1464f76e47f5b4f19))
   - **peerDependencies:** Correction d'une dépendance `@cnamts/design-tokens` manquante ([#739](https://github.com/assurance-maladie-digital/design-system/pull/739)) ([bab2654](https://github.com/assurance-maladie-digital/design-system/commit/bab26549758ef8dd93494e02fd406a9e2b0b7c56))
-  - **PaginatedTable:** Correction de l'événement `update:options` émis deux fois ([#766](https://github.com/assurance-maladie-digital/design-system/pull/766))
+  - **PaginatedTable:** Correction de l'événement `update:options` émis deux fois ([#766](https://github.com/assurance-maladie-digital/design-system/pull/766)) ([6484e72](https://github.com/assurance-maladie-digital/design-system/commit/6484e72a6d665f773264db83e677533ff5fcb403))
+  - **rules:** Correction des messages d'erreur des règles de validation `notAfterToday` et `notBeforeToday` ([#767](https://github.com/assurance-maladie-digital/design-system/pull/767))
 
 ### Vue Dash
 

--- a/packages/vue-dot/src/rules/notAfterToday/locales.ts
+++ b/packages/vue-dot/src/rules/notAfterToday/locales.ts
@@ -1,5 +1,5 @@
 import { ErrorMessages } from '../types';
 
 export const defaultErrorMessages: ErrorMessages = {
-	default: 'La date doit être postérieure à aujourd\'hui.'
+	default: 'La date doit être antérieure à aujourd\'hui.'
 };

--- a/packages/vue-dot/src/rules/notBeforeToday/locales.ts
+++ b/packages/vue-dot/src/rules/notBeforeToday/locales.ts
@@ -1,5 +1,5 @@
 import { ErrorMessages } from '../types';
 
 export const defaultErrorMessages: ErrorMessages = {
-	default: 'La date ne doit pas être antérieure à aujourd\'hui.'
+	default: 'La date doit être postérieure à aujourd\'hui.'
 };


### PR DESCRIPTION
## Description

Correction des messages d'erreur des règles de validation `notAfterToday` et `notBeforeToday`

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
