### PR TITLE
🐛 form-builder: Fix ChoiceFieldButton width when inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - **rules:** Correction des messages d'erreur des règles de validation `notAfterToday` et `notBeforeToday` ([#767](https://github.com/assurance-maladie-digital/design-system/pull/767)) ([6c1f24a](https://github.com/assurance-maladie-digital/design-system/commit/6c1f24acf453dac9018b5ed839dab9dad8a3c4fb))
 
 - ♿️ **Accessibilité**
-  - **HeaderLoading:** Ajout des attributs ARIA ([#427](https://github.com/assurance-maladie-digital/design-system/pull/427))
+  - **HeaderLoading:** Ajout des attributs ARIA ([#427](https://github.com/assurance-maladie-digital/design-system/pull/427)) ([2db6606](https://github.com/assurance-maladie-digital/design-system/commit/2db660648e1e2565c0efe1f59a95c9d3198ca5a5))
 
 ### Vue Dash
 
@@ -29,6 +29,7 @@
 
 - 🐛 **Corrections de bugs**
   - **peerDependencies:** Correction des intervalles de versions des dépendances ([#721](https://github.com/assurance-maladie-digital/design-system/pull/721)) ([951f21a](https://github.com/assurance-maladie-digital/design-system/commit/951f21ae9e6ad935a5fdf92a83d283a82769a526))
+  - **ChoiceButtonField:** Correction de la largeur du champ avec la prop `inline` ([#758]9https://github.com/assurance-maladie-digital/design-system/pull/758)9
 
 - 🚨 **Lint**
   - **config:** Correction des erreurs de lint ([#741](https://github.com/assurance-maladie-digital/design-system/pull/741)) ([fbb696c](https://github.com/assurance-maladie-digital/design-system/commit/fbb696cf8be995ad3b9a93831acd7fb27393c9ea))

--- a/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -405,7 +405,7 @@ exports[`FormBuilder renders correctly 1`] = `
         Informations supplémentaires
       </p>
       <div>
-        <div class="vd-choice-button-field vd-form-input">
+        <div class="vd-choice-button-field">
           <div class="vd-choice-button-field-toggle mb-2 layout wrap accent--text v-item-group theme--light v-btn-toggle" inline="true" type="choiceButton" hint="Texte informatif"><button type="button" value="0" class="text-none text-wrap py-2 text-left v-btn v-btn--depressed v-btn--flat v-btn--outlined theme--light elevation-0 v-size--default accent--text" style="height: auto; min-height: 40px;"><span class="v-btn__content"><span class="text-body-1">
 				9h30
 			</span>

--- a/packages/form-builder/src/components/FormField/fields/ChoiceButtonField.vue
+++ b/packages/form-builder/src/components/FormField/fields/ChoiceButtonField.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="vd-choice-button-field vd-form-input">
+	<div
+		class="vd-choice-button-field"
+		:class="{ 'vd-form-input': !isInline }"
+	>
 		<VBtnToggle
 			v-bind="options"
 			:value="choiceFieldValue"
@@ -91,7 +94,7 @@
 		}
 
 		get isInline(): boolean | null {
-			return this.options?.inline as unknown as boolean | null;
+			return this.options?.inline as boolean | null;
 		}
 
 		get showHint(): boolean {


### PR DESCRIPTION
## Description

La largeur du champ `ChoiceFieldButton` était fixe, ce qui forçait le retour à la ligne au bout d'une certaine longueur

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
