### PR TITLE
♻️ form-builder: Use computed property for isOtherActive in ChoiceField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - **rules:** Correction des messages d'erreur des règles de validation `notAfterToday` et `notBeforeToday` ([#767](https://github.com/assurance-maladie-digital/design-system/pull/767)) ([6c1f24a](https://github.com/assurance-maladie-digital/design-system/commit/6c1f24acf453dac9018b5ed839dab9dad8a3c4fb))
 
 - ♿️ **Accessibilité**
-  - **HeaderLoading:** Ajout des attributs ARIA ([#427](https://github.com/assurance-maladie-digital/design-system/pull/427)) ([2db6606](https://github.com/assurance-maladie-digital/design-system/commit/2db660648e1e2565c0efe1f59a95c9d3198ca5a5))
+  - **HeaderLoading:** Ajout des attributs ARIA ([#758](https://github.com/assurance-maladie-digital/design-system/pull/758)) ([2db6606](https://github.com/assurance-maladie-digital/design-system/commit/2db660648e1e2565c0efe1f59a95c9d3198ca5a5))
 
 ### Vue Dash
 
@@ -29,7 +29,10 @@
 
 - 🐛 **Corrections de bugs**
   - **peerDependencies:** Correction des intervalles de versions des dépendances ([#721](https://github.com/assurance-maladie-digital/design-system/pull/721)) ([951f21a](https://github.com/assurance-maladie-digital/design-system/commit/951f21ae9e6ad935a5fdf92a83d283a82769a526))
-  - **ChoiceButtonField:** Correction de la largeur du champ avec la prop `inline` ([#758]9https://github.com/assurance-maladie-digital/design-system/pull/758)9
+  - **ChoiceButtonField:** Correction de la largeur du champ avec la prop `inline` ([#759]https://github.com/assurance-maladie-digital/design-system/pull/759) ([534a729](https://github.com/assurance-maladie-digital/design-system/commit/534a7294b39ea0ddfc26dcf4da023d576766c9f2))
+
+- ♻️ **Refactoring**
+  - **ChoiceField:** Utilisation d'un getter pour `isOtherActive` ([#760](https://github.com/assurance-maladie-digital/design-system/pull/760))
 
 - 🚨 **Lint**
   - **config:** Correction des erreurs de lint ([#741](https://github.com/assurance-maladie-digital/design-system/pull/741)) ([fbb696c](https://github.com/assurance-maladie-digital/design-system/commit/fbb696cf8be995ad3b9a93831acd7fb27393c9ea))

--- a/packages/form-builder/src/components/FormField/fields/ChoiceField.vue
+++ b/packages/form-builder/src/components/FormField/fields/ChoiceField.vue
@@ -2,7 +2,7 @@
 	<div>
 		<!-- The choice field component -->
 		<component
-			:is="getField()"
+			:is="choiceField"
 			:value="choiceValue.value"
 			:items="field.items"
 			:options="fieldOptions"
@@ -28,7 +28,7 @@
 						ref="otherFieldRef"
 						v-bind="otherField.fieldOptions"
 						:value="otherFieldValue"
-						:disabled="!isOtherActive"
+						:disabled="!otherActive"
 						:rows="1"
 						class="vd-form-input"
 						auto-grow
@@ -48,7 +48,7 @@
 				color="accent"
 				dense
 				outlined
-				@input="otherInput"
+				@input="setOtherValue"
 				@change="otherUpdated"
 			/>
 		</template>
@@ -90,9 +90,6 @@
 				handler(value: ChoiceValue) {
 					this.choiceValue = value || this.choiceValue;
 
-					// Set the active status
-					this.isOtherActive = this.getOtherActive();
-
 					/**
 					 * Set the other local value if the other value is not null
 					 * to keep the local value up for the user
@@ -116,7 +113,6 @@
 			value: null
 		};
 
-		isOtherActive = false;
 		otherFieldValue: OtherFieldValue = null;
 
 		/** List all choice field components and their corresponding keys */
@@ -169,7 +165,7 @@
 		 *
 		 * @returns {boolean} The other active status
 		 */
-		getOtherActive(): boolean {
+		get otherActive(): boolean {
 			const choiceFieldValue = this.choiceValue?.value;
 			const selectedChoice = this.field.other?.selectedChoice;
 
@@ -183,11 +179,11 @@
 		}
 
 		/**
-		 * Returns the field that correspond to the type in metadata or select By default
+		 * Returns the field that correspond to the type in metadata or select by default
 		 *
 		 * @returns {string} The choice field component name
 		 */
-		getField(): string {
+		get choiceField(): string {
 			const metadataType = this.field.fieldOptions?.type as string || undefined;
 
 			return metadataType ? this.selectFieldMap[metadataType] : this.selectFieldMap.select;
@@ -205,9 +201,7 @@
 				this.otherFieldValue = null;
 			}
 
-			this.isOtherActive = this.getOtherActive();
-
-			if (this.isOtherActive) {
+			if (this.otherActive) {
 				// Focus the other field when activated
 				this.$nextTick(() => this.$refs.otherFieldRef.focus());
 
@@ -220,7 +214,7 @@
 			this.emitChangeEvent(this.choiceValue);
 		}
 
-		otherInput(otherFieldValue: OtherFieldValue): void {
+		setOtherValue(otherFieldValue: OtherFieldValue): void {
 			this.otherFieldValue = otherFieldValue?.length ? otherFieldValue : null;
 
 			if (this.otherFieldValue && !this.field.multiple) {


### PR DESCRIPTION
## Description

Pas de raison d'utiliser une méthode au lieu d'une propriété calculée pour `isOtherActive` dans `ChoiceField`, on bénéficiera de la mise en cache

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
