### PR TITLE
🔥 vue-dash: Remove unused main-ctn class in App component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
   - **template:** Correction de l'export du service `formatDate` ([#840](https://github.com/assurance-maladie-digital/design-system/pull/840)) ([a076f3a](https://github.com/assurance-maladie-digital/design-system/commit/a076f3a7965f930bc257242b6eda032975f81017))
 
 - ♻️ **Refactoring**
-  - **template:** Réécriture du commentaire du service API exemple `folders` ([#841](https://github.com/assurance-maladie-digital/design-system/pull/841))
+  - **template:** Réécriture du commentaire du service API exemple `folders` ([#841](https://github.com/assurance-maladie-digital/design-system/pull/841)) ([d3b9ea3](https://github.com/assurance-maladie-digital/design-system/commit/d3b9ea304baa84b76dc5d23f5ac7b33d7d0c2e17))
+
+- 🔥 **Suppressions**
+  - **template:** Suppression de la classe `main-ctn` non utilisée dans le composant `App` ([#842](https://github.com/assurance-maladie-digital/design-system/pull/842))
 
 ### Interne
 

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/App.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/App.vue
@@ -1,9 +1,6 @@
 <template>
 	<!-- VApp is an element which is required to use Vuetify. See https://vuetifyjs.com/en/ for help -->
-	<VApp
-		v-cloak
-		class="main-ctn"
-	>
+	<VApp v-cloak>
 		<AppHeader />
 
 		<AppToolbar v-if="!$maintenanceEnabled" />


### PR DESCRIPTION
## Description

Suppression de la classe `main-ctn` non utilisée dans le composant `App`

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
