### PR TITLE
✨ vue-dot: Add class attribute on DataList items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Vue Dot
 
+- ✨ **Nouvelles fonctionnalités**
+  - **DataList:** Ajout de l'attribut `class` dans les items ([#851](https://github.com/assurance-maladie-digital/design-system/pull/851))
+
 - ♻️ **Refactoring**
   - **TableToolbar:** Renommage de `createBtn` en `addBtn` ([#849](https://github.com/assurance-maladie-digital/design-system/pull/849)) ([98a8ce3](https://github.com/assurance-maladie-digital/design-system/commit/98a8ce335350350174242452fa90f41f11452e72))
 
@@ -29,7 +32,7 @@
   - **eslint-plugin-vue:** Mise à jour vers la `v7.5.0` ([#843](https://github.com/assurance-maladie-digital/design-system/pull/843) ([ef1b1b1](https://github.com/assurance-maladie-digital/design-system/commit/ef1b1b1226d8cf228f5f829b4c5b768aa98f8353))
   - **dayjs:** Mise à jour vers la `v1.10.4` ([#844](https://github.com/assurance-maladie-digital/design-system/pull/844)) ([b443a69](https://github.com/assurance-maladie-digital/design-system/commit/b443a69fa09a92f62a764cf240311317b7c3e160))
   - **@vue/cli:** Mise à jour du monorepo vers la `v4.5.11` ([#845](https://github.com/assurance-maladie-digital/design-system/pull/845)) ([22b1625](https://github.com/assurance-maladie-digital/design-system/commit/22b1625e8eba7a5d35ebf0917c5424939a3a615c))
-  - **eslint-plugin-jsdoc:** Mise à jour vers la `v31.2.2` ([#848](https://github.com/assurance-maladie-digital/design-system/pull/848))
+  - **eslint-plugin-jsdoc:** Mise à jour vers la `v31.2.2` ([#848](https://github.com/assurance-maladie-digital/design-system/pull/848)) ([95d5109](https://github.com/assurance-maladie-digital/design-system/commit/95d51095a03bd25e244925f5c0f31deeebcb0db8))
 
 ### 📚 Guide de migration
 

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -42,6 +42,7 @@
 						:placeholder="placeholder"
 						:vuetify-options="item.options"
 						:style="{ width: itemWidth }"
+						:class="item.class"
 						class="vd-data-list-item text-body-1 mb-2"
 						@click:action="$emit('click:item-action', index)"
 					/>

--- a/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
@@ -5,7 +5,7 @@ import { mountComponent } from '@/tests';
 import { html } from '@/tests/utils/html';
 
 import DataList from '../';
-import { dataList } from './data/dataList';
+import { getDataList } from './data/dataList';
 
 let wrapper: Wrapper<Vue>;
 
@@ -15,7 +15,7 @@ describe('DataList', () => {
 		// Mount component
 		wrapper = mountComponent(DataList, {
 			propsData: {
-				items: dataList
+				items: getDataList()
 			}
 		});
 
@@ -36,7 +36,7 @@ describe('DataList', () => {
 		// Mount component
 		wrapper = mountComponent(DataList, {
 			propsData: {
-				items: dataList,
+				items: getDataList(),
 				listTitle: 'Informations'
 			}
 		});
@@ -51,7 +51,7 @@ describe('DataList', () => {
 		// Mount component
 		wrapper = mountComponent(DataList, {
 			propsData: {
-				items: dataList,
+				items: getDataList(),
 				flex: true
 			}
 		});
@@ -78,7 +78,7 @@ describe('DataList', () => {
 	});
 
 	it('renders correctly with an icon', () => {
-		const listWithIcon = dataList;
+		const listWithIcon = getDataList();
 
 		// Add an action to the second item
 		listWithIcon[1].icon = 'mdiTest';
@@ -86,7 +86,7 @@ describe('DataList', () => {
 		// Mount component
 		wrapper = mountComponent(DataList, {
 			propsData: {
-				items: dataList,
+				items: listWithIcon,
 				icons: {
 					mdiTest: 'test'
 				}
@@ -100,11 +100,31 @@ describe('DataList', () => {
 		expect(html(wrapper)).toMatchSnapshot();
 	});
 
+	it('renders correctly with a class', async() => {
+		const listWithClass = getDataList();
+
+		// Add a class to the second item
+		listWithClass[1].class = 'custom-class';
+
+		// Mount component
+		wrapper = mountComponent(DataList, {
+			propsData: {
+				items: listWithClass
+			}
+		});
+
+		// Check that items now exist
+		const itemsExists = wrapper.find('.vd-data-list-item.custom-class').exists();
+		expect(itemsExists).toBe(true);
+
+		expect(html(wrapper)).toMatchSnapshot();
+	});
+
 	it('renders loading state correctly', async() => {
 		// Mount component
 		wrapper = mountComponent(DataList, {
 			propsData: {
-				items: dataList,
+				items: getDataList(),
 				loading: true,
 				itemsNumberLoading: 3,
 				headingLoading: true
@@ -129,7 +149,7 @@ describe('DataList', () => {
 	});
 
 	it('renders correctly with an action', async() => {
-		const listWithAction = dataList;
+		const listWithAction = getDataList();
 
 		// Add an action to the second item
 		listWithAction[1].action = 'Edit';
@@ -146,7 +166,7 @@ describe('DataList', () => {
 	});
 
 	it('emits action event', async() => {
-		const listWithAction = dataList;
+		const listWithAction = getDataList();
 
 		// Add an action to the second item
 		listWithAction[2].action = 'Edit';

--- a/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
@@ -30,6 +30,21 @@ exports[`DataList renders correctly in flex mode 1`] = `
 </div>
 `;
 
+exports[`DataList renders correctly with a class 1`] = `
+<div class="vd-data-list">
+  <vfadetransition-stub mode="out-in" origin="top center 0">
+    <div>
+      <!---->
+      <ul class="vd-data-list-field pl-0 d-flex flex-column">
+        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
+        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2 custom-class" style="width: 200px;"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
+      </ul>
+    </div>
+  </vfadetransition-stub>
+</div>
+`;
+
 exports[`DataList renders correctly with a title 1`] = `
 <div class="vd-data-list">
   <vfadetransition-stub mode="out-in" origin="top center 0">

--- a/packages/vue-dot/src/elements/DataList/tests/data/dataList.ts
+++ b/packages/vue-dot/src/elements/DataList/tests/data/dataList.ts
@@ -1,16 +1,21 @@
 import { DataList } from './../../types';
 
-export const dataList: DataList = [
-	{
-		key: 'Civility',
-		value: ''
-	},
-	{
-		key: 'Name',
-		value: 'Dupont'
-	},
-	{
-		key: 'First name',
-		value: 'Paul'
-	}
-];
+/**
+ *
+ */
+export function getDataList(): DataList {
+	return [
+		{
+			key: 'Civility',
+			value: ''
+		},
+		{
+			key: 'Name',
+			value: 'Dupont'
+		},
+		{
+			key: 'First name',
+			value: 'Paul'
+		}
+	];
+}

--- a/packages/vue-dot/src/elements/DataList/types.d.ts
+++ b/packages/vue-dot/src/elements/DataList/types.d.ts
@@ -7,6 +7,7 @@ export interface DataListItem {
 	chip?: boolean;
 	icon?: string;
 	options?: Options;
+	class?: string;
 }
 
 export type DataList = DataListItem[];


### PR DESCRIPTION
## Description

Ajout de l'attribut `class` dans les items de la `DataList`, cela permet d'identifier les items, par exemple pour mettre certains labels en gras on peut ajouter une classe `bold-label` :

```
items: DataListItem[] = [
	{
		key: 'Civility',
		value: 'Mr',
		class: 'bold-label'
	}
];
```
avec ces styles :
```scss
.vd-data-list-item.bold-label .vd-data-list-item-label {
	font-weight: 700;
}
```
 
J'ai également modifié les tests car la liste utilisée était modifiée dans les tests, en utilisant une fonction elle n'est plus modifiée

Fixes #470 

## Type de changement

- Nouvelle fonctionnalité
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
