### PR TITLE
🐛 vue-dot: Fix inert FooterBtn color overwritten by Vuetify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Non publié
 
+### Vue Dot
+
+- 🐛 **Corrections de bugs**
+  - **FooterBtn:** Correction de la couleur du bouton écrasée par Vuetify avec la prop `inert` ([#939](https://github.com/assurance-maladie-digital/design-system/pull/939))
+
 ### Design Tokens
 
 - ♻️ **Refactoring**
-  - **colors:** Mise à jour des couleurs du thème ([#935](https://github.com/assurance-maladie-digital/design-system/pull/935))
+  - **colors:** Mise à jour des couleurs du thème ([#935](https://github.com/assurance-maladie-digital/design-system/pull/935)) ([18ac9cb](https://github.com/assurance-maladie-digital/design-system/commit/18ac9cb11d2e55b1146735d821770ae390c6c060))
 
 ### Interne
 

--- a/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/FooterBtn.vue
+++ b/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/FooterBtn.vue
@@ -47,7 +47,7 @@
 </script>
 
 <style lang="scss" scoped>
-	.vd-footer-btn.v-btn {
+	.theme--light.vd-footer-btn.v-btn {
 		color: #424242 !important;
 	}
 </style>


### PR DESCRIPTION
## Description

Correction de la couleur du bouton écrasée par Vuetify avec la prop `inert`.

Parfois, les styles de Vuetify sont intégrés avant ceux du `FooterBtn`, et comme le sélecteur de Vuetify qui applique la couleur a la même spécificité que celui du composant `FooterBtn`, c'est celui-ci qui est appliqué :

![screenshot-declare ameli fr-2021 03 05-11_48_04](https://user-images.githubusercontent.com/10298932/110105665-f696fc80-7da8-11eb-87f9-3823f73e6c2a.png)

Le style appliqué par Vuetify :

```css
.theme--light.v-btn.v-btn--disabled {
    color: rgba(0, 0, 0, .26) !important;
}
```

Le style appliqué par le composant `FooterBtn` :

```css
.vd-footer-btn.v-btn[data-v-60a6e493] {
    color: #424242 !important;
}
```

Les deux sélecteurs ont une spécificité de `030`, en ajoutant `.theme--light` au sélecteur du composant `FooterBtn`, la spécificité de celui-ci devient `040` et notre sélecteur sera toujours apploqué.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
