### PR TITLE
♻️ vue-dot: Use widthable mixin in DataList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 - 🐛 **Corrections de bugs**
   - **template:** Correction d'une faute d'orthographe dans le fichier `.editorconfig` ([#977](https://github.com/assurance-maladie-digital/design-system/pull/977)) ([2728d53](https://github.com/assurance-maladie-digital/design-system/commit/2728d53e80e6eb28b7ffccfe637275296917d010))
 
+- ♻️ **Refactoring**
+  - **DataList:** Utilisation de la mixin `widthable` ([#981](https://github.com/assurance-maladie-digital/design-system/pull/981))
+
 - 🔥 **Suppressions**
   - **template:** Suppression du fichier `.eslintignore` ([#975](https://github.com/assurance-maladie-digital/design-system/pull/975)) ([692e8b5](https://github.com/assurance-maladie-digital/design-system/commit/692e8b5bb9261a00a9670cf0e59155b9af77e1f4))
   - **template:** Suppression des commentaires inutiles dans le fichier `tsconfig.json` ([#976](https://github.com/assurance-maladie-digital/design-system/pull/976)) ([09ba95f](https://github.com/assurance-maladie-digital/design-system/commit/09ba95f9983a38efd2c819ddd0310e20cc3399c0))
-  - **template:** Suppression des classes inutiles dans le fichier `logo.svg` ([#978](https://github.com/assurance-maladie-digital/design-system/pull/978))
+  - **template:** Suppression des classes inutiles dans le fichier `logo.svg` ([#978](https://github.com/assurance-maladie-digital/design-system/pull/978)) ([5e9ec77](https://github.com/assurance-maladie-digital/design-system/commit/5e9ec776e9e41df95e3494de1a4208f2eb3a5fa6))
 
 ### Interne
 

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="vd-data-list">
+	<div
+		:style="widthStyles"
+		class="vd-data-list"
+	>
 		<VFadeTransition mode="out-in">
 			<!-- The DataList loading skeleton -->
 			<DataListLoading
@@ -9,7 +12,6 @@
 				:title-class="titleClass"
 				:flex="flex"
 				:row="row"
-				:item-width="itemWidth"
 			/>
 
 			<div v-else>
@@ -27,7 +29,6 @@
 					v-if="items.length"
 					class="vd-data-list-field pl-0 d-flex"
 					:class="listClass"
-					:style="{ minWidth }"
 				>
 					<DataListItem
 						v-for="(item, index) in items"
@@ -41,7 +42,6 @@
 						:icon="getIcon(item.icon)"
 						:placeholder="placeholder"
 						:vuetify-options="item.options"
-						:style="{ width: itemWidth }"
 						:class="item.class"
 						class="vd-data-list-item text-body-1 mb-2"
 						@click:action="$emit('click:item-action', index)"
@@ -61,6 +61,8 @@
 
 	import DataListItem from './DataListItem';
 	import DataListLoading from './DataListLoading';
+
+	import { Widthable } from '../../mixins/widthable';
 
 	const Props = Vue.extend({
 		props: {
@@ -95,16 +97,6 @@
 				type: String,
 				default: locales.placeholder
 			},
-			/** The list min-width */
-			minWidth: {
-				type: String,
-				default: undefined
-			},
-			/** The item width */
-			itemWidth: {
-				type: String,
-				default: '200px'
-			},
 			/** Loading mode */
 			loading: {
 				type: Boolean,
@@ -128,7 +120,7 @@
 		}
 	});
 
-	const MixinsDeclaration = mixins(Props);
+	const MixinsDeclaration = mixins(Props, Widthable);
 
 	/**
 	 * DataList is a component that displays list of

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/DataListLoading.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/DataListLoading.vue
@@ -20,7 +20,6 @@
 				v-for="index in itemsNumber"
 				:key="index + '-loading-item'"
 				class="vd-data-list-loading-item mb-4"
-				:style="{ width: itemWidth }"
 				:class="{ 'vd-row': row }"
 			>
 				<HeaderLoading
@@ -62,11 +61,6 @@
 			flex: {
 				type: Boolean,
 				default: false
-			},
-			/** The item width */
-			itemWidth: {
-				type: String,
-				default: '200px'
 			}
 		}
 	});

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/tests/__snapshots__/DataListLoading.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/tests/__snapshots__/DataListLoading.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`DataListLoading renders correctly 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading" label="Test">
   <!---->
   <ul class="vd-data-list-loading-items pl-0 d-flex flex-column">
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
@@ -16,15 +16,15 @@ exports[`DataListLoading renders correctly in column mode 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
   <!---->
   <ul class="vd-data-list-loading-items pl-0 d-flex flex-column">
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
@@ -36,15 +36,15 @@ exports[`DataListLoading renders correctly in flex mode 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
   <!---->
   <ul class="vd-data-list-loading-items pl-0 d-flex flex-wrap">
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
@@ -56,15 +56,15 @@ exports[`DataListLoading renders correctly in row mode 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
   <!---->
   <ul class="vd-data-list-loading-items pl-0 d-flex flex-column">
-    <li class="vd-data-list-loading-item mb-4 vd-row" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4 vd-row">
       <!---->
       <headerloading-stub width="150" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4 vd-row" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4 vd-row">
       <!---->
       <headerloading-stub width="150" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4 vd-row" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4 vd-row">
       <!---->
       <headerloading-stub width="150" height="1.5rem"></headerloading-stub>
     </li>
@@ -76,7 +76,7 @@ exports[`DataListLoading renders correctly with a header 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
   <headerloading-stub width="100" height="1.5rem" class="mb-4"></headerloading-stub>
   <ul class="vd-data-list-loading-items pl-0 d-flex flex-column">
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
@@ -88,15 +88,15 @@ exports[`DataListLoading renders correctly with more items 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
   <!---->
   <ul class="vd-data-list-loading-items pl-0 d-flex flex-column">
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4" style="width: 200px;">
+    <li class="vd-data-list-loading-item mb-4">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>

--- a/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataList renders correctly 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0 d-flex flex-column">
-        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
+        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>
@@ -16,14 +16,14 @@ exports[`DataList renders correctly 1`] = `
 `;
 
 exports[`DataList renders correctly in flex mode 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0 d-flex flex-wrap">
-        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
+        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>
@@ -31,14 +31,14 @@ exports[`DataList renders correctly in flex mode 1`] = `
 `;
 
 exports[`DataList renders correctly with a class 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0 d-flex flex-column">
-        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2 custom-class" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
+        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2 custom-class"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>
@@ -46,16 +46,16 @@ exports[`DataList renders correctly with a class 1`] = `
 `;
 
 exports[`DataList renders correctly with a title 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
     <div>
       <h4 class="mb-3 text-h5">
         Informations
       </h4>
       <ul class="vd-data-list-field pl-0 d-flex flex-column">
-        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
+        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>
@@ -63,12 +63,12 @@ exports[`DataList renders correctly with a title 1`] = `
 `;
 
 exports[`DataList renders correctly with an action 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <transition-stub name="fade-transition" mode="out-in">
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0 d-flex flex-wrap">
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2" style="width: 200px;">
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -80,7 +80,7 @@ exports[`DataList renders correctly with an action 1`] = `
             <!---->
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2" style="width: 200px;">
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -93,7 +93,7 @@ exports[`DataList renders correctly with an action 1`] = `
 			</span></button>
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2" style="width: 200px;">
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -112,7 +112,7 @@ exports[`DataList renders correctly with an action 1`] = `
 `;
 
 exports[`DataList renders correctly with an empty list 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
     <div>
       <!---->
@@ -123,12 +123,12 @@ exports[`DataList renders correctly with an empty list 1`] = `
 `;
 
 exports[`DataList renders correctly with an icon 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <transition-stub name="fade-transition" mode="out-in">
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0 d-flex flex-column">
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2" style="width: 200px;">
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -140,7 +140,7 @@ exports[`DataList renders correctly with an icon 1`] = `
             <!---->
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2" style="width: 200px;"><i aria-hidden="true" class="v-icon notranslate material-icons theme--light mr-4 mt-2" style="font-size: 24px;">test</i>
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2"><i aria-hidden="true" class="v-icon notranslate material-icons theme--light mr-4 mt-2" style="font-size: 24px;">test</i>
           <div class="vd-data-list-item-content">
             <div class="">
               <div class="vd-data-list-item-label text-caption" style="color: rgba(0, 0, 0, 0.6);">
@@ -151,7 +151,7 @@ exports[`DataList renders correctly with an icon 1`] = `
             <!---->
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2" style="width: 200px;">
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -170,22 +170,22 @@ exports[`DataList renders correctly with an icon 1`] = `
 `;
 
 exports[`DataList renders loading state correctly 1`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
-    <datalistloading-stub itemsnumber="3" heading="true" itemwidth="200px" title-class="mb-3 text-h5"></datalistloading-stub>
+    <datalistloading-stub itemsnumber="3" heading="true" title-class="mb-3 text-h5"></datalistloading-stub>
   </vfadetransition-stub>
 </div>
 `;
 
 exports[`DataList renders loading state correctly 2`] = `
-<div class="vd-data-list">
+<div class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0 d-flex flex-column">
-        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2" style="width: 200px;"></datalistitem-stub>
+        <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>

--- a/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
@@ -44,14 +44,14 @@ exports[`SubHeader renders loading state correctly 1`] = `
       <!---->
     </div>
     <div class="layout vd-sub-header-data-list pl-10 pr-8">
-      <div class="vd-data-list">
+      <div class="vd-data-list" style="width: 100%;" item-width="auto">
         <transition-stub name="fade-transition" mode="out-in">
           <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading" title-class="text-subtitle-1 font-weight-bold mb-2 mt-2">
             <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader vd-header-loading mb-4 v-skeleton-loader--is-loading theme--dark" style="height: 1.5rem; width: 100px;">
               <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
             </div>
             <ul class="vd-data-list-loading-items pl-0 d-flex flex-column">
-              <li class="vd-data-list-loading-item mb-4" style="width: auto;">
+              <li class="vd-data-list-loading-item mb-4">
                 <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader vd-header-loading mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 1rem; width: 60px;">
                   <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
                 </div>
@@ -59,7 +59,7 @@ exports[`SubHeader renders loading state correctly 1`] = `
                   <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
                 </div>
               </li>
-              <li class="vd-data-list-loading-item mb-4" style="width: auto;">
+              <li class="vd-data-list-loading-item mb-4">
                 <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader vd-header-loading mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 1rem; width: 60px;">
                   <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
                 </div>
@@ -71,14 +71,14 @@ exports[`SubHeader renders loading state correctly 1`] = `
           </div>
         </transition-stub>
       </div>
-      <div class="vd-data-list">
+      <div class="vd-data-list" style="width: 100%;" item-width="auto">
         <transition-stub name="fade-transition" mode="out-in">
           <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading" title-class="text-subtitle-1 font-weight-bold mb-2 mt-2">
             <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader vd-header-loading mb-4 v-skeleton-loader--is-loading theme--dark" style="height: 1.5rem; width: 100px;">
               <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
             </div>
             <ul class="vd-data-list-loading-items pl-0 d-flex flex-column">
-              <li class="vd-data-list-loading-item mb-4" style="width: auto;">
+              <li class="vd-data-list-loading-item mb-4">
                 <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader vd-header-loading mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 1rem; width: 60px;">
                   <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
                 </div>
@@ -86,7 +86,7 @@ exports[`SubHeader renders loading state correctly 1`] = `
                   <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
                 </div>
               </li>
-              <li class="vd-data-list-loading-item mb-4" style="width: auto;">
+              <li class="vd-data-list-loading-item mb-4">
                 <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader vd-header-loading mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 1rem; width: 60px;">
                   <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
                 </div>


### PR DESCRIPTION
## Description

Utilisation de la mixin `widthable` sur le composant `DataList`

Comme nous allons ajouter le composant `DataListGroup`, l'item ne porte plus la largeur, c'est directement la `DataList` que l'on dimensionne

Le guide de migration sera ajouté avec le composant `DataListGroup`

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
