### PR TITLE
♻️ docs: Compute prev & next items without position

### DIFF
--- a/packages/docs-v2/src/content/composants/copy-btn.md
+++ b/packages/docs-v2/src/content/composants/copy-btn.md
@@ -1,7 +1,6 @@
 ---
 title: CopyBtn
 description: L'élément `CopyBtn` est utilisé pour afficher un bouton permettant à l'utilisateur de copier du texte.
-position: 4
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/custom-icon.md
+++ b/packages/docs-v2/src/content/composants/custom-icon.md
@@ -1,7 +1,6 @@
 ---
 title: CustomIcon
 description: L'élément `CustomIcon` est utilisé pour afficher une icône personnalisée parmi celles définies dans les options de Vue Dot.
-position: 5
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/data-list-group.md
+++ b/packages/docs-v2/src/content/composants/data-list-group.md
@@ -1,7 +1,6 @@
 ---
 title: DataListGroup
 description: Le pattern `DataListGroup` est utilisé pour afficher une liste de `DataList`.
-position: 7
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/data-list.md
+++ b/packages/docs-v2/src/content/composants/data-list.md
@@ -1,7 +1,6 @@
 ---
 title: DataList
 description: L'élément `DataList` est utilisé pour afficher une liste d'informations.
-position: 6
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/date-picker.md
+++ b/packages/docs-v2/src/content/composants/date-picker.md
@@ -1,7 +1,6 @@
 ---
 title: DatePicker
 description: Le pattern `DatePicker` est un composant utilisé pour permettre à l'utilisateur de sélectionner ou de saisir une date.
-position: 8
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/dialog-box.md
+++ b/packages/docs-v2/src/content/composants/dialog-box.md
@@ -1,7 +1,6 @@
 ---
 title: DialogBox
 description: L'élément `DialogBox` est utilisé pour afficher une boîte de dialogue avec des boutons d'actions.
-position: 9
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/download-btn.md
+++ b/packages/docs-v2/src/content/composants/download-btn.md
@@ -1,7 +1,6 @@
 ---
 title: DownloadBtn
 description: L'élément `DownloadBtn` est utilisé pour permettre à l'utilisateur de télécharger un document provenant d'une API.
-position: 10
 ---
 
 <notification-bar></notification-bar>

--- a/packages/docs-v2/src/content/composants/error-page.md
+++ b/packages/docs-v2/src/content/composants/error-page.md
@@ -1,7 +1,6 @@
 ---
 title: ErrorPage
 description: Le template `ErrorPage` est utilisé pour afficher une page d'erreur.
-position: 11
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/file-upload.md
+++ b/packages/docs-v2/src/content/composants/file-upload.md
@@ -1,7 +1,6 @@
 ---
 title: FileUpload
 description: Le pattern `FileUpload` est utilisé pour permettre à l'utilisateur de sélectionner ou de glisser-déposer des fichiers.
-position: 12
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/footer-wrapper.md
+++ b/packages/docs-v2/src/content/composants/footer-wrapper.md
@@ -1,7 +1,6 @@
 ---
 title: FooterWrapper
 description: Le pattern `FooterWrapper` est utilisé avec le composant `FooterBtn` pour afficher un pied de page.
-position: 13
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/form-builder.md
+++ b/packages/docs-v2/src/content/composants/form-builder.md
@@ -1,7 +1,6 @@
 ---
 title: FormBuilder
 description: Le composant `FormBuilder` est utilisé pour afficher un questionnaire.
-position: 14
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/form-field-list.md
+++ b/packages/docs-v2/src/content/composants/form-field-list.md
@@ -1,7 +1,6 @@
 ---
 title: FormFieldList
 description: Le composant `FormFieldList` est utilisé pour afficher un formulaire composé d'une liste de champs.
-position: 15
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/form-field.md
+++ b/packages/docs-v2/src/content/composants/form-field.md
@@ -1,7 +1,6 @@
 ---
 title: FormField
 description: Le composant `FormField` est utilisé pour afficher un champ de formulaire.
-position: 16
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/header-loading.md
+++ b/packages/docs-v2/src/content/composants/header-loading.md
@@ -1,7 +1,6 @@
 ---
 title: HeaderLoading
 description: L'élément `HeaderLoading` est une extension du composant `VSkeletonLoader`, il est utilisé pour afficher un élément de chargement avec des dimensions personnalisées.
-position: 17
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/lang-btn.md
+++ b/packages/docs-v2/src/content/composants/lang-btn.md
@@ -1,7 +1,6 @@
 ---
 title: LangBtn
 description: L'élément `LangBtn` est utilisé pour permettre à l'utilisateur de choisir une langue.
-position: 18
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/notification-bar.md
+++ b/packages/docs-v2/src/content/composants/notification-bar.md
@@ -1,7 +1,6 @@
 ---
 title: NotificationBar
 description: Le pattern `NotificationBar` est utilisé avec le module Vuex `notification` pour afficher des notifications à l'utilisateur.
-position: 19
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/page-card.md
+++ b/packages/docs-v2/src/content/composants/page-card.md
@@ -1,7 +1,6 @@
 ---
 title: PageCard
 description: L'élément `PageCard` est utilisé pour afficher une page.
-position: 20
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/paginated-table.md
+++ b/packages/docs-v2/src/content/composants/paginated-table.md
@@ -1,7 +1,6 @@
 ---
 title: PaginatedTable
 description: Le pattern `PaginatedTable` est utilisé pour afficher une `VDataTable` avec une pagination persistante.
-position: 21
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/sub-header.md
+++ b/packages/docs-v2/src/content/composants/sub-header.md
@@ -1,7 +1,6 @@
 ---
 title: SubHeader
 description: Le pattern `SubHeader` est utilisé pour afficher un bloc d'informations sous l'en-tête principale.
-position: 22
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/table-toolbar.md
+++ b/packages/docs-v2/src/content/composants/table-toolbar.md
@@ -1,7 +1,6 @@
 ---
 title: TableToolbar
 description: Le pattern `TableToolbar` est utilisé pour afficher une barre au-dessus des tableaux.
-position: 23
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/composants/upload-workflow.md
+++ b/packages/docs-v2/src/content/composants/upload-workflow.md
@@ -1,7 +1,6 @@
 ---
 title: UploadWorkflow
 description: Le pattern `UploadWorkflow` est utilisé pour permettre à l'utilisateur de sélectionner une liste de fichiers.
-position: 24
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/demarrer/contribuer.md
+++ b/packages/docs-v2/src/content/demarrer/contribuer.md
@@ -1,7 +1,6 @@
 ---
 title: Contribuer
 description: Merci de prendre le temps de contribuer au Design System, c'est de cette manière qu'il va pouvoir évoluer et s'adapter aux différents besoins des équipes et des projets.
-position: 2
 ---
 
 ## Rapports de bugs

--- a/packages/docs-v2/src/content/demarrer/installation.md
+++ b/packages/docs-v2/src/content/demarrer/installation.md
@@ -1,7 +1,6 @@
 ---
 title: Installation
 description: Création d'un nouveau projet ou ajout d'un composant du Design System à un projet existant.
-position: 1
 ---
 
 ## Création d'un nouveau projet

--- a/packages/docs-v2/src/content/demarrer/introduction.md
+++ b/packages/docs-v2/src/content/demarrer/introduction.md
@@ -1,6 +1,5 @@
 ---
 title: Introduction
-position: 0
 ---
 
 Notre Design System est un outil Open Source au service des produits digitaux de l'Assurance Maladie. Il met à disposition des équipes de conception, développeurs, designers ainsi qu'aux product owners un ensemble d'outils et de principes qui serviront de fondation pour le développement des applications.

--- a/packages/docs-v2/src/content/directives/debounce.md
+++ b/packages/docs-v2/src/content/directives/debounce.md
@@ -1,7 +1,6 @@
 ---
 title: Debounce
 description: La directive `v-debounce` est utilisée pour différer une mise à jour de `v-model` sur un champ de formulaire.
-position: 25
 ---
 
 <doc-tabs>

--- a/packages/docs-v2/src/content/guides/nouveau-composant.md
+++ b/packages/docs-v2/src/content/guides/nouveau-composant.md
@@ -1,7 +1,6 @@
 ---
 title: Nouveau composant
 description: Création d'un nouveau composant dans un projet standard.
-position: 27
 ---
 
 ## Syntaxe

--- a/packages/docs-v2/src/content/guides/nouvelle-page.md
+++ b/packages/docs-v2/src/content/guides/nouvelle-page.md
@@ -1,7 +1,6 @@
 ---
 title: Nouvelle page
 description: Création d'une nouvelle page dans un projet standard.
-position: 29
 ---
 
 ## Création de la page

--- a/packages/docs-v2/src/content/guides/validation-formulaire.md
+++ b/packages/docs-v2/src/content/guides/validation-formulaire.md
@@ -1,7 +1,6 @@
 ---
 title: Validation d'un formulaire
 description: Création et validation d'un formulaire dans un projet standard.
-position: 28
 ---
 
 ## Création du formulaire

--- a/packages/docs-v2/src/content/index.md
+++ b/packages/docs-v2/src/content/index.md
@@ -1,6 +1,6 @@
 ---
 title: Accueil
-position: -1
+hiddenInDrawer: true
 ---
 
 <!-- Static content in index.vue -->

--- a/packages/docs-v2/src/content/starter-kit/explorer.md
+++ b/packages/docs-v2/src/content/starter-kit/explorer.md
@@ -1,7 +1,6 @@
 ---
 title: Starter Kit Explorer
 description: Sur cette page, vous pouvez retrouver tous les dossiers et fichiers créés par le Starter Kit Vue Dash et des informations explicatives les concernant.
-position: 26
 ---
 
 <doc-content-explorer></doc-content-explorer>

--- a/packages/docs-v2/src/functions/getSurroundDrawerItems.ts
+++ b/packages/docs-v2/src/functions/getSurroundDrawerItems.ts
@@ -1,0 +1,30 @@
+import { Content, ContentFunction, SurroundItems } from '~/types/content';
+import { getSurroundDrawerItemsPaths } from './getSurroundDrawerItemsPaths';
+
+async function getSurroundDrawerItem($content: ContentFunction, path?: string): Promise<Content> {
+	if (!path) {
+		return [];
+	}
+
+	return await $content({ deep: true })
+		.only(['title', 'slug', 'path'])
+		.where({
+			path,
+			position: {
+				$ne: 'hiddenInDrawer'
+			}
+		})
+		.fetch<Content>();
+}
+
+export async function getSurroundDrawerItems($content: ContentFunction, path: string): Promise<SurroundItems> {
+	const { prevPath, nextPath } = getSurroundDrawerItemsPaths(path);
+
+	const [prev] = await getSurroundDrawerItem($content, prevPath);
+	const [next] = await getSurroundDrawerItem($content, nextPath);
+
+	return {
+		prev,
+		next
+	};
+}

--- a/packages/docs-v2/src/functions/getSurroundDrawerItemsPaths.ts
+++ b/packages/docs-v2/src/functions/getSurroundDrawerItemsPaths.ts
@@ -1,0 +1,37 @@
+import { drawerItems } from '~/data/drawerItems';
+import { PageItem, SurroundItemsPaths } from '~/types/drawer';
+
+function flattenDrawerItems(items: PageItem[]): PageItem[] {
+	const flat: PageItem[] = [];
+
+	items.forEach((item) => {
+		if (Array.isArray(item.items)) {
+			flat.push(...flattenDrawerItems(item.items));
+		} else {
+			flat.push(item);
+		}
+	});
+
+	return flat;
+}
+
+export function getSurroundDrawerItemsPaths(itemPath: string): SurroundItemsPaths {
+	const flattenedItems = flattenDrawerItems(drawerItems);
+
+	const itemIndex = flattenedItems.findIndex((item) => item.to === itemPath);
+	let prev;
+	let next;
+
+	if (itemIndex !== 0) {
+		prev = flattenedItems[itemIndex - 1];
+	}
+
+	if (itemIndex !== flattenedItems.length) {
+		next = flattenedItems[itemIndex + 1];
+	}
+
+	return {
+		prevPath: prev?.to,
+		nextPath: next?.to
+	};
+}

--- a/packages/docs-v2/src/types/content.d.ts
+++ b/packages/docs-v2/src/types/content.d.ts
@@ -1,0 +1,22 @@
+import { Context } from '@nuxt/types';
+import { contentFunc, IContentDocument } from '@nuxt/content/types/content';
+
+export type ContentFunction = contentFunc;
+export type ContentDocument = IContentDocument;
+
+export interface AsyncDataParams extends Context {
+	$content: ContentFunction;
+}
+
+export type Content = ContentDocument[];
+
+export interface SurroundItems {
+	prev: ContentDocument;
+	next: ContentDocument;
+}
+
+export interface PageData extends SurroundItems {
+	document: ContentDocument;
+}
+
+export { Context };

--- a/packages/docs-v2/src/types/drawer.d.ts
+++ b/packages/docs-v2/src/types/drawer.d.ts
@@ -11,3 +11,8 @@ export interface DrawerItem {
 	icon: string;
 	items: PageItem[];
 }
+
+export interface SurroundItemsPaths {
+	prevPath?: string;
+	nextPath?: string;
+}


### PR DESCRIPTION
## Description

Calcul automatique des éléments précédents et suivants sur une page et suppression de la propriété `position` lors de l'écriture d'une page

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
