### PR TITLE
🐛 vue-dot: Fix spacing with hide-down-arrow prop in LangBtn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Non publié
 
+### Vue Dot
+
+- 🐛 **Corrections de bugs**
+  - **LangBtn:** Correction de l'espacement lorsque la prop `hide-down-arrow` est présente ([#1039](https://github.com/assurance-maladie-digital/design-system/pull/1039))
+
 ### Interne
 
 - 🔧 **Configuration**
@@ -10,7 +15,7 @@
   - **vuetify:** Mise à jour vers la `v2.4.11` ([#1033](https://github.com/assurance-maladie-digital/design-system/pull/1033)) ([7f1fdf6](https://github.com/assurance-maladie-digital/design-system/commit/7f1fdf6275d72401f0c043e1abbad0e6977581df))
   - **core-js:** Mise à jour vers la `v3.10.2` ([#1034](https://github.com/assurance-maladie-digital/design-system/pull/1034)) ([7d3602a](https://github.com/assurance-maladie-digital/design-system/commit/7d3602a81715820faa1e0095d8022591ad9c1de9))
   - **sass:** Mise à jour vers la `v1.32.11` ([#1035](https://github.com/assurance-maladie-digital/design-system/pull/1035)) ([098733f](https://github.com/assurance-maladie-digital/design-system/commit/098733ff3091915cd922dae7bf96849742219b88))
-  - **babel:** Mise à jour du monorepo vers la `v7.13.16` ([#1036](https://github.com/assurance-maladie-digital/design-system/pull/1036))
+  - **babel:** Mise à jour du monorepo vers la `v7.13.16` ([#1036](https://github.com/assurance-maladie-digital/design-system/pull/1036)) ([0870dec](https://github.com/assurance-maladie-digital/design-system/commit/0870dec9462a54761254ec7f279a6f10a6889689))
 
 ## v2.0.0-beta.8
 

--- a/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
+++ b/packages/vue-dot/src/patterns/LangBtn/LangBtn.vue
@@ -15,7 +15,7 @@
 				v-on="on"
 			>
 				<!-- Current language -->
-				<span class="ml-2">
+				<span :class="currentLangClass">
 					{{ currentLangData.name }}
 				</span>
 
@@ -107,6 +107,10 @@
 
 		currentLang = this.value;
 
+		get currentLangClass(): string | undefined {
+			return this.hideDownArrow ? undefined : 'ml-1';
+		}
+
 		/** Returns the list of languages to display in the list */
 		get languages(): Languages {
 			let data: Languages = {};
@@ -143,7 +147,7 @@
 		}
 
 		/** Returns a formatted object of all the languages */
-		getFormattedLanguages(): Languages{
+		getFormattedLanguages(): Languages {
 			const data: Languages = {};
 
 			languages


### PR DESCRIPTION
## Description

Correction de l'espacement lorsque la prop `hide-down-arrow` est présente :

![screenshot-romantic-bassi-01446c netlify app-2021 04 21-19_37_55](https://user-images.githubusercontent.com/10298932/115597204-4f7b0f80-a2d9-11eb-953e-0ce1a67df16f.png)

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
