### PR TITLE
🐛 vue-dot: Fix spacing on last item in DataList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Vue Dot
 
 - 🐛 **Corrections de bugs**
-  - **LangBtn:** Correction de l'espacement lorsque la prop `hide-down-arrow` est présente ([#1039](https://github.com/assurance-maladie-digital/design-system/pull/1039))
+  - **LangBtn:** Correction de l'espacement lorsque la prop `hide-down-arrow` est présente ([#1039](https://github.com/assurance-maladie-digital/design-system/pull/1039)) ([6556629](https://github.com/assurance-maladie-digital/design-system/commit/6556629cca23dbd2780a261d2e2f8bec15c55c75))
+  - **DataList:** Correction d'un espace en trop sur le dernier item de la liste ([#1040](https://github.com/assurance-maladie-digital/design-system/pull/1040))
 
 ### Interne
 

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -41,7 +41,7 @@
 						:placeholder="placeholder"
 						:vuetify-options="item.options"
 						:class="getItemClass(index, item.class)"
-						class="vd-data-list-item text-body-1 mb-2"
+						class="vd-data-list-item text-body-1"
 						@click:action="$emit('click:item-action', index)"
 					/>
 				</ul>
@@ -137,7 +137,7 @@
 
 		getItemClass(index: number, itemClass?: string): ItemClass {
 			const margin = {
-				'mb-2': index === this.items.length
+				'mb-2': index !== this.items.length - 1
 			};
 
 			return [
@@ -151,9 +151,5 @@
 <style lang="scss" scoped>
 	.vd-data-list-field {
 		list-style: none;
-	}
-
-	.vd-data-list-item:last-of-type {
-		margin-bottom: 0 !important;
 	}
 </style>

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/DataListLoading.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/DataListLoading.vue
@@ -16,8 +16,11 @@
 			<li
 				v-for="index in itemsNumber"
 				:key="index + '-loading-item'"
-				class="vd-data-list-loading-item mb-4"
-				:class="{ 'vd-row': row }"
+				class="vd-data-list-loading-item"
+				:class="{
+					'vd-row': row,
+					'mb-4': index !== itemsNumber
+				}"
 			>
 				<HeaderLoading
 					v-if="!row"

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/tests/__snapshots__/DataListLoading.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/tests/__snapshots__/DataListLoading.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`DataListLoading renders correctly 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading" label="Test">
   <!---->
   <ul class="vd-data-list-loading-items pl-0">
-    <li class="vd-data-list-loading-item mb-4">
+    <li class="vd-data-list-loading-item">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
@@ -16,15 +16,15 @@ exports[`DataListLoading renders correctly in row mode 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
   <!---->
   <ul class="vd-data-list-loading-items pl-0">
-    <li class="vd-data-list-loading-item mb-4 vd-row">
+    <li class="vd-data-list-loading-item vd-row mb-4">
       <!---->
       <headerloading-stub width="150" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4 vd-row">
+    <li class="vd-data-list-loading-item vd-row mb-4">
       <!---->
       <headerloading-stub width="150" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4 vd-row">
+    <li class="vd-data-list-loading-item vd-row">
       <!---->
       <headerloading-stub width="150" height="1.5rem"></headerloading-stub>
     </li>
@@ -36,7 +36,7 @@ exports[`DataListLoading renders correctly with a header 1`] = `
 <div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
   <headerloading-stub width="100" height="1.5rem" class="mb-4"></headerloading-stub>
   <ul class="vd-data-list-loading-items pl-0">
-    <li class="vd-data-list-loading-item mb-4">
+    <li class="vd-data-list-loading-item">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
@@ -56,7 +56,7 @@ exports[`DataListLoading renders correctly with more items 1`] = `
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>
-    <li class="vd-data-list-loading-item mb-4">
+    <li class="vd-data-list-loading-item">
       <headerloading-stub width="60" height="1rem" class="mb-1"></headerloading-stub>
       <headerloading-stub width="90" height="1.5rem"></headerloading-stub>
     </li>

--- a/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`DataList renders correctly 1`] = `
       <ul class="vd-data-list-field pl-0">
         <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
         <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>
@@ -23,7 +23,7 @@ exports[`DataList renders correctly with a class 1`] = `
       <ul class="vd-data-list-field pl-0">
         <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
         <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2 custom-class"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>
@@ -40,7 +40,7 @@ exports[`DataList renders correctly with a title 1`] = `
       <ul class="vd-data-list-field pl-0">
         <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
         <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>
@@ -78,7 +78,7 @@ exports[`DataList renders correctly with an action 1`] = `
 			</span></button>
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -136,7 +136,7 @@ exports[`DataList renders correctly with an icon 1`] = `
             <!---->
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
+        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -170,7 +170,7 @@ exports[`DataList renders loading state correctly 2`] = `
       <ul class="vd-data-list-field pl-0">
         <datalistitem-stub label="Civility" value="" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
         <datalistitem-stub label="Name" value="Dupont" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
-        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1 mb-2"></datalistitem-stub>
+        <datalistitem-stub label="First name" value="Paul" placeholder="…" class="vd-data-list-item text-body-1"></datalistitem-stub>
       </ul>
     </div>
   </vfadetransition-stub>


### PR DESCRIPTION
## Description

Correction d'un espace en trop sur le dernier item de la liste en mode chargement et simplification du correctif en mode normal.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
