### PR TITLE
🐛 vue-dot: Fix filePromise type & file download in DownloadBtn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - 🐛 **Corrections de bugs**
   - **LangBtn:** Correction de l'espacement lorsque la prop `hide-down-arrow` est présente ([#1039](https://github.com/assurance-maladie-digital/design-system/pull/1039)) ([6556629](https://github.com/assurance-maladie-digital/design-system/commit/6556629cca23dbd2780a261d2e2f8bec15c55c75))
-  - **DataList:** Correction d'un espace en trop sur le dernier item de la liste ([#1040](https://github.com/assurance-maladie-digital/design-system/pull/1040))
+  - **DataList:** Correction d'un espace en trop sur le dernier item de la liste ([#1040](https://github.com/assurance-maladie-digital/design-system/pull/1040)) ([91a8c07](https://github.com/assurance-maladie-digital/design-system/commit/91a8c07703573899ab42a91513005724c3ce71ed))
+  - **DownloadBtn:** Correction du type de la prop `file-promise` et du téléchargement du fichier ([#1041](https://github.com/assurance-maladie-digital/design-system/pull/1041))
 
 ### Interne
 

--- a/packages/vue-dot/src/elements/DownloadBtn/DownloadBtn.vue
+++ b/packages/vue-dot/src/elements/DownloadBtn/DownloadBtn.vue
@@ -41,7 +41,7 @@
 	const Props = Vue.extend({
 		props: {
 			filePromise: {
-				type: Promise as PropType<Promise<AxiosResponse<string>>>,
+				type: Function as PropType<() => Promise<AxiosResponse<Blob>>>,
 				required: true
 			},
 			notification: {
@@ -107,7 +107,7 @@
 			this.state = STATE_ENUM.pending;
 
 			try {
-				const { data, headers } = await this.filePromise;
+				const { data, headers } = await this.filePromise();
 				const { name, type } = this.getFileInfo(headers);
 
 				downloadFile(data, name, type);

--- a/packages/vue-dot/src/elements/DownloadBtn/tests/data/filePromise.ts
+++ b/packages/vue-dot/src/elements/DownloadBtn/tests/data/filePromise.ts
@@ -1,14 +1,17 @@
 import { AxiosResponse } from 'axios';
 
-export const filePromise: Promise<AxiosResponse<string>> = new Promise((resolve) => {
-	resolve({
-		data: 'test',
-		status: 200,
-		statusText: 'OK',
-		headers: {
-			'Content-Disposition': 'attachment; filename="attestation.txt"',
-			'Content-Type': 'text/plain'
-		},
-		config: {}
+/** Returns a promise that returns a file */
+export function filePromise(): Promise<AxiosResponse<string>> {
+	return new Promise((resolve) => {
+		resolve({
+			data: 'test',
+			status: 200,
+			statusText: 'OK',
+			headers: {
+				'Content-Disposition': 'attachment; filename="attestation.txt"',
+				'Content-Type': 'text/plain'
+			},
+			config: {}
+		});
 	});
-});
+}


### PR DESCRIPTION
## Description

Correction du type de la prop `file-promise` et du téléchargement du fichier.

## Type de changement

- Correction de bug
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
