### PR TITLE
🐛 vue-dot: Fix max date in birthdate mode in DatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Non publié
 
+### Vue Dot
+
+- 🐛 **Corrections de bugs**
+  - **DatePicker:** Correction du calcul de la date maximale en mode `birthdate` ([#1046](https://github.com/assurance-maladie-digital/design-system/pull/1046))
+
 ### Interne
 
 - 🔥 **Suppressions**
-  - **lerna:** Suppression des propriétés `gitHead` dans les fichiers `package.json` ([#1045](https://github.com/assurance-maladie-digital/design-system/pull/1045))
+  - **lerna:** Suppression des propriétés `gitHead` dans les fichiers `package.json` ([#1045](https://github.com/assurance-maladie-digital/design-system/pull/1045)) ([d941896](https://github.com/assurance-maladie-digital/design-system/commit/d94189622cc1fe5e03484472199336a86ba4404d))
 
 ## v2.0.0-beta.9
 

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/birthdate.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/birthdate.ts
@@ -1,7 +1,10 @@
+import dayjs from 'dayjs';
 import Vue from 'vue';
 import Component, { mixins } from 'vue-class-component';
 
 import { Refs } from '../../../types';
+
+import { INTERNAL_FORMAT } from './dateLogic';
 
 const Props = Vue.extend({
 	props: {
@@ -35,7 +38,7 @@ export class Birthdate extends MixinsDeclaration {
 	}>;
 
 	/** If birthdate is enabled, max is the current date */
-	max = this.birthdate ? new Date().toISOString().substr(0, 10) : null;
+	max = this.birthdate ? dayjs().format(INTERNAL_FORMAT) : null;
 
 	/** If birthdate is enabled, min is 01/01/1900 */
 	min = this.birthdate ? '1900-01-01' : null;

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
@@ -9,7 +9,7 @@ import { Options } from '../../../mixins/customizable';
 import { Refs } from '../../../types';
 
 /** Date format used internally */
-const INTERNAL_FORMAT = 'YYYY-MM-DD';
+export const INTERNAL_FORMAT = 'YYYY-MM-DD';
 
 const Props = Vue.extend({
 	props: {


### PR DESCRIPTION
## Description

Correction du calcul de la date maximale en mode `birthdate`.

On utilisait `new Date().toISOString()` pour calculer la date maximale, sauf que cette méthode ne prend pas en compte le fuseau horaire (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
