### PR TITLE
🐛 vue-dot: Fix headers name in DownloadBtn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Vue Dot
 
 - 🐛 **Corrections de bugs**
-  - **DatePicker:** Correction du calcul de la date maximale en mode `birthdate` ([#1046](https://github.com/assurance-maladie-digital/design-system/pull/1046))
+  - **DatePicker:** Correction du calcul de la date maximale en mode `birthdate` ([#1046](https://github.com/assurance-maladie-digital/design-system/pull/1046)) ([7fcbd97](https://github.com/assurance-maladie-digital/design-system/commit/7fcbd97bef15a903b65e6d5bfc07febca8a10f40))
+  - **DownloadBtn:** Correction du nom des headers ([#1047](https://github.com/assurance-maladie-digital/design-system/pull/1047))
 
 ### Interne
 

--- a/packages/vue-dot/src/elements/DownloadBtn/ContentHeadersEnum.ts
+++ b/packages/vue-dot/src/elements/DownloadBtn/ContentHeadersEnum.ts
@@ -1,0 +1,4 @@
+export enum ContentHeadersEnum {
+	TYPE = 'content-type',
+	DISPOSITION = 'content-disposition'
+}

--- a/packages/vue-dot/src/elements/DownloadBtn/DownloadBtn.vue
+++ b/packages/vue-dot/src/elements/DownloadBtn/DownloadBtn.vue
@@ -33,6 +33,7 @@
 
 	import { STATE_ENUM } from '../../constants/enums/StateEnum';
 	import { IndexedObject } from '../../types';
+	import { ContentHeadersEnum } from './ContentHeadersEnum';
 	import { FileInfo } from './types';
 
 	import { config } from './config';
@@ -84,8 +85,8 @@
 		}
 
 		getFileInfo(headers: IndexedObject): FileInfo {
-			const contentType = headers['Content-Type'];
-			const contentDispositionHeader = headers['Content-Disposition'] as string;
+			const contentType = headers[ContentHeadersEnum.TYPE];
+			const contentDispositionHeader = headers[ContentHeadersEnum.DISPOSITION] as string;
 			const filename = contentDisposition.parse(contentDispositionHeader).parameters.filename;
 
 			return {

--- a/packages/vue-dot/src/elements/DownloadBtn/tests/data/filePromise.ts
+++ b/packages/vue-dot/src/elements/DownloadBtn/tests/data/filePromise.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from 'axios';
+import { ContentHeadersEnum } from '../../ContentHeadersEnum';
 
 /** Returns a promise that returns a file */
 export function filePromise(): Promise<AxiosResponse<string>> {
@@ -8,8 +9,8 @@ export function filePromise(): Promise<AxiosResponse<string>> {
 			status: 200,
 			statusText: 'OK',
 			headers: {
-				'Content-Disposition': 'attachment; filename="attestation.txt"',
-				'Content-Type': 'text/plain'
+				[ContentHeadersEnum.TYPE]: 'text/plain',
+				[ContentHeadersEnum.DISPOSITION]: 'attachment; filename="attestation.txt"'
 			},
 			config: {}
 		});


### PR DESCRIPTION
## Description

Correction du nom des headers dans le composant `DownloadBtn`.

Les headers sont case insensitive et sont transformés en minuscules par axios.
J'en ai profité pour extraire ces valeurs dans une enum `ContentHeadersEnum`.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
