### PR TITLE
♻️ vue-dot: Use PageContainer in ErrorPage

### DIFF
--- a/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
+++ b/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
@@ -1,43 +1,42 @@
 <template>
-	<PageCard
-		width="680"
-		card-class="px-5"
-	>
-		<span
-			v-if="code"
-			class="font-weight-bold primary--text vd-code"
-		>
-			{{ code }}
-		</span>
-
-		<h2
-			:class="{
-				'text-h4': !code,
-				'mb-4': !code,
-				'text-h6': code
-			}"
-			class="mb-2 font-weight-bold"
-		>
-			{{ pageTitle }}
-		</h2>
-
-		<p>{{ message }}</p>
-
-		<VLayout
-			v-if="!noBtn && btnText && btnRoute"
-			class="mt-6"
-		>
-			<VSpacer />
-
-			<VBtn
-				:to="btnRoute"
-				color="primary"
-				exact
+	<PageContainer size="s">
+		<VCard class="pa-8">
+			<span
+				v-if="code"
+				class="font-weight-bold primary--text vd-code"
 			>
-				{{ btnText }}
-			</VBtn>
-		</VLayout>
-	</PageCard>
+				{{ code }}
+			</span>
+
+			<h2
+				:class="{
+					'text-h4': !code,
+					'mb-4': !code,
+					'text-h6': code
+				}"
+				class="mb-2 font-weight-bold"
+			>
+				{{ pageTitle }}
+			</h2>
+
+			<p>{{ message }}</p>
+
+			<div
+				v-if="!noBtn && btnText && btnRoute"
+				class="d-flex mt-6"
+			>
+				<VSpacer />
+
+				<VBtn
+					:to="btnRoute"
+					color="primary"
+					exact
+				>
+					{{ btnText }}
+				</VBtn>
+			</div>
+		</VCard>
+	</PageContainer>
 </template>
 
 <script lang="ts">

--- a/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
@@ -5,9 +5,9 @@ import { mountComponent } from '@/tests';
 import { html } from '@/tests/utils/html';
 
 import ErrorPage from '../';
-import PageCard from '../../../elements/PageCard';
+import PageContainer from '../../../elements/PageContainer';
 
-Vue.component('PageCard', PageCard);
+Vue.component('PageContainer', PageContainer);
 
 let wrapper: Wrapper<Vue>;
 

--- a/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
@@ -1,17 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ErrorPage renders correctly 1`] = `
-<pagecard-stub cardclass="px-5" cardpadding="px-6 py-4" width="680">
-  <!---->
-  <h2 class="mb-2 font-weight-bold text-h4 mb-4">
-    Error
-  </h2>
-  <p>Error message</p>
-  <vlayout-stub tag="div" class="mt-6">
-    <vspacer-stub></vspacer-stub>
-    <vbtn-stub color="primary" tag="button" activeclass="" exact="true" to="[object Object]" type="button">
-      Retour à l'accueil
-    </vbtn-stub>
-  </vlayout-stub>
-</pagecard-stub>
+<pagecontainer-stub size="s" color="transparent">
+  <vcard-stub loaderheight="4" tag="div" class="pa-8">
+    <!---->
+    <h2 class="mb-2 font-weight-bold text-h4 mb-4">
+      Error
+    </h2>
+    <p>Error message</p>
+    <div class="d-flex mt-6">
+      <vspacer-stub></vspacer-stub>
+      <vbtn-stub color="primary" tag="button" activeclass="" exact="true" to="[object Object]" type="button">
+        Retour à l'accueil
+      </vbtn-stub>
+    </div>
+  </vcard-stub>
+</pagecontainer-stub>
 `;


### PR DESCRIPTION
## Description

Utilisation du composant `PageContainer` dans le template `ErrorPage`.

J'ai aussi supprimé l'utilisation du composant `VLayout` car il est déprécié.

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
