### PR TITLE
🐛 vue-dash: Fix missing closing tag in About.vue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@
 
 - 🐛 **Corrections de bugs**
   - **template:** Correction de la dépendance `vuex` manquante ([#1071](https://github.com/assurance-maladie-digital/design-system/pull/1071)) ([02030c7](https://github.com/assurance-maladie-digital/design-system/commit/02030c7e9be765c5b0a8b45523a9bbd03f3109c8))
+  - **template:** Correction de la fermeture de la balise `VCard` dans le fichier `About.vue` ([#1073](https://github.com/assurance-maladie-digital/design-system/pull/1073))
 
 - ♻️ **Refactoring**
   - **template:** Utilisation du composant `PageContainer` à la place de `PageCard` ([#1069](https://github.com/assurance-maladie-digital/design-system/pull/1069)) ([d2c32f2](https://github.com/assurance-maladie-digital/design-system/commit/d2c32f21db04c2e77f04f63569dee038a2785dc7))
-  - **template:** Renommage du fichier `main.js` en `main.ts` ([#1072](https://github.com/assurance-maladie-digital/design-system/pull/1072))
+  - **template:** Renommage du fichier `main.js` en `main.ts` ([#1072](https://github.com/assurance-maladie-digital/design-system/pull/1072)) ([458e472](https://github.com/assurance-maladie-digital/design-system/commit/458e47210fd178dd72b5c2f177a7c1b3627b9f60))
 
 - 🔥 **Suppressions**
   - **config:** Suppression du composant `PageCard` pour le tree-shaking de VueDot ([#1070](https://github.com/assurance-maladie-digital/design-system/pull/1070)) ([66f63e7](https://github.com/assurance-maladie-digital/design-system/commit/66f63e7c25ca9f5956cf24aeea113fc298e4329c))

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/About.vue
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/About.vue
@@ -30,6 +30,7 @@
 
 				<% if (i18n) { %>{{ $t('views.about.backBtn.label') }}<% } else { %>Retour<% } %>
 			</VBtn>
+		</VCard>
 	</PageContainer>
 </template>
 


### PR DESCRIPTION
## Description

Correction de la fermeture de la balise `VCard` dans le fichier `About.vue` dans le Starter Kit.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
