### PR TITLE
♻️ vue-dot: Remove deprecated VLayout usage in DataListItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - ♻️ **Refactoring**
   - **ErrorPage:** Utilisation du composant `PageContainer` à la place de `PageCard` ([#1062](https://github.com/assurance-maladie-digital/design-system/pull/1062)) ([4877246](https://github.com/assurance-maladie-digital/design-system/commit/4877246872e45a0fb5d5840d339444f1ed59c166))
   - **PageContainer:** Ajout d'un conteneur interne et correction de l'espacement interne ([#1067](https://github.com/assurance-maladie-digital/design-system/pull/1067)) ([4b5a40e](https://github.com/assurance-maladie-digital/design-system/commit/4b5a40e1a2f251c1e64e21703689bde43df7aec9))
+  - **DataListItem:** Suppression de l'utilisation du composant `VLayout` déprécié ([#1075](https://github.com/assurance-maladie-digital/design-system/pull/1075))
 
 - 🔥 **Suppressions**
   - **PageCard:** Suppression du composant ([#1066](https://github.com/assurance-maladie-digital/design-system/pull/1066)) ([1175200](https://github.com/assurance-maladie-digital/design-system/commit/11752004fcd5a70876e9c759a294d588ef46097a))
@@ -41,7 +42,7 @@
   - **lerna:** Suppression des propriétés `gitHead` dans les fichiers `package.json` ([#1045](https://github.com/assurance-maladie-digital/design-system/pull/1045)) ([d941896](https://github.com/assurance-maladie-digital/design-system/commit/d94189622cc1fe5e03484472199336a86ba4404d))
 
 - 📝 **Documentation**
-  - **pull-requests:** Mise à jour du template ([#1074](https://github.com/assurance-maladie-digital/design-system/pull/1074))
+  - **pull-requests:** Mise à jour du template ([#1074](https://github.com/assurance-maladie-digital/design-system/pull/1074)) ([b8da289](https://github.com/assurance-maladie-digital/design-system/commit/b8da289b6d3ec4e0313483795df5227160de9fed))
 
 - ⬆️ **Dépendances**
   - **eslint:** Mise à jour vers la `v7.25.0` ([#1051](https://github.com/assurance-maladie-digital/design-system/pull/1051) ([ce1d298](https://github.com/assurance-maladie-digital/design-system/commit/ce1d298e9c08920585d6ba33ca020964a5693cad))

--- a/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/DataListItem.vue
@@ -1,9 +1,5 @@
 <template>
-	<VLayout
-		v-bind="options.layout"
-		class="vd-data-list-item flex-grow-0"
-		tag="li"
-	>
+	<li class="vd-data-list-item d-flex flex-wrap">
 		<slot name="icon">
 			<VIcon
 				v-if="icon"
@@ -61,7 +57,7 @@
 				</VBtn>
 			</slot>
 		</div>
-	</VLayout>
+	</li>
 </template>
 
 <script lang="ts">

--- a/packages/vue-dot/src/elements/DataList/DataListItem/config.ts
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/config.ts
@@ -1,7 +1,4 @@
 export const config = {
-	layout: {
-		wrap: true
-	},
 	icon: {
 		size: 24,
 		class: 'mr-4 mt-2'

--- a/packages/vue-dot/src/elements/DataList/DataListItem/tests/__snapshots__/DataListItem.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/tests/__snapshots__/DataListItem.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataListItem renders correctly 1`] = `
-<vlayout-stub tag="li" wrap="true" class="vd-data-list-item flex-grow-0">
+<li class="vd-data-list-item d-flex flex-wrap">
   <!---->
   <div class="vd-data-list-item-content">
     <div class="">
@@ -12,11 +12,11 @@ exports[`DataListItem renders correctly 1`] = `
     </div>
     <!---->
   </div>
-</vlayout-stub>
+</li>
 `;
 
 exports[`DataListItem renders correctly in row mode 1`] = `
-<vlayout-stub tag="li" wrap="true" class="vd-data-list-item flex-grow-0">
+<li class="vd-data-list-item d-flex flex-wrap">
   <!---->
   <div class="vd-data-list-item-content">
     <div class="vd-row">
@@ -29,11 +29,11 @@ exports[`DataListItem renders correctly in row mode 1`] = `
       Action
     </vbtn-stub>
   </div>
-</vlayout-stub>
+</li>
 `;
 
 exports[`DataListItem renders correctly value in a chip 1`] = `
-<vlayout-stub tag="li" wrap="true" class="vd-data-list-item flex-grow-0">
+<li class="vd-data-list-item d-flex flex-wrap">
   <!---->
   <div class="vd-data-list-item-content">
     <div class="">
@@ -48,11 +48,11 @@ exports[`DataListItem renders correctly value in a chip 1`] = `
     </div>
     <!---->
   </div>
-</vlayout-stub>
+</li>
 `;
 
 exports[`DataListItem renders correctly with a value 1`] = `
-<vlayout-stub tag="li" wrap="true" class="vd-data-list-item flex-grow-0">
+<li class="vd-data-list-item d-flex flex-wrap">
   <!---->
   <div class="vd-data-list-item-content">
     <div class="">
@@ -63,11 +63,11 @@ exports[`DataListItem renders correctly with a value 1`] = `
     </div>
     <!---->
   </div>
-</vlayout-stub>
+</li>
 `;
 
 exports[`DataListItem renders correctly with an action 1`] = `
-<vlayout-stub tag="li" wrap="true" class="vd-data-list-item flex-grow-0">
+<li class="vd-data-list-item d-flex flex-wrap">
   <!---->
   <div class="vd-data-list-item-content">
     <div class="">
@@ -80,5 +80,5 @@ exports[`DataListItem renders correctly with an action 1`] = `
       action
     </vbtn-stub>
   </div>
-</vlayout-stub>
+</li>
 `;

--- a/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
@@ -53,7 +53,7 @@ exports[`DataList renders correctly with an action 1`] = `
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0">
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
+        <li class="vd-data-list-item d-flex flex-wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -65,7 +65,7 @@ exports[`DataList renders correctly with an action 1`] = `
             <!---->
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
+        <li class="vd-data-list-item d-flex flex-wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -78,7 +78,7 @@ exports[`DataList renders correctly with an action 1`] = `
 			</span></button>
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1">
+        <li class="vd-data-list-item d-flex flex-wrap vd-data-list-item text-body-1">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -113,7 +113,7 @@ exports[`DataList renders correctly with an icon 1`] = `
     <div>
       <!---->
       <ul class="vd-data-list-field pl-0">
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2">
+        <li class="vd-data-list-item d-flex flex-wrap vd-data-list-item text-body-1 mb-2">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">
@@ -125,7 +125,7 @@ exports[`DataList renders correctly with an icon 1`] = `
             <!---->
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1 mb-2"><i aria-hidden="true" class="v-icon notranslate material-icons theme--light mr-4 mt-2" style="font-size: 24px;">test</i>
+        <li class="vd-data-list-item d-flex flex-wrap vd-data-list-item text-body-1 mb-2"><i aria-hidden="true" class="v-icon notranslate material-icons theme--light mr-4 mt-2" style="font-size: 24px;">test</i>
           <div class="vd-data-list-item-content">
             <div class="">
               <div class="vd-data-list-item-label text-caption" style="color: rgba(0, 0, 0, 0.6);">
@@ -136,7 +136,7 @@ exports[`DataList renders correctly with an icon 1`] = `
             <!---->
           </div>
         </li>
-        <li class="layout vd-data-list-item flex-grow-0 wrap vd-data-list-item text-body-1">
+        <li class="vd-data-list-item d-flex flex-wrap vd-data-list-item text-body-1">
           <!---->
           <div class="vd-data-list-item-content">
             <div class="">


### PR DESCRIPTION
## Description

Suppression de l'utilisation du composant `VLayout` déprécié dans le composant `DataListItem`.

## Playground

<details>

```vue
<template>
	<div>
		<DataList
			:items="items"
			:icons="icons"
		/>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { mdiAlert } from '@mdi/js';

	@Component
	export default class Playground extends Vue {
		items = [
			{
				key: 'Civility',
				value: ''
			},
			{
				key: 'Name',
				value: 'Dupont',
				icon: 'alert'
			},
			{
				key: 'First name',
				value: 'Paul'
			}
		];

		icons = {
			alert: mdiAlert
		};
	}
</script>

```

</details>

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
