### PR TITLE
♻️ vue-dot: Remove deprecated VLayout usage in FileList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - ♻️ **Refactoring**
   - **ErrorPage:** Utilisation du composant `PageContainer` à la place de `PageCard` ([#1062](https://github.com/assurance-maladie-digital/design-system/pull/1062)) ([4877246](https://github.com/assurance-maladie-digital/design-system/commit/4877246872e45a0fb5d5840d339444f1ed59c166))
   - **PageContainer:** Ajout d'un conteneur interne et correction de l'espacement interne ([#1067](https://github.com/assurance-maladie-digital/design-system/pull/1067)) ([4b5a40e](https://github.com/assurance-maladie-digital/design-system/commit/4b5a40e1a2f251c1e64e21703689bde43df7aec9))
-  - **DataListItem:** Suppression de l'utilisation du composant `VLayout` déprécié ([#1075](https://github.com/assurance-maladie-digital/design-system/pull/1075))
+  - **DataListItem:** Suppression de l'utilisation du composant `VLayout` déprécié ([#1075](https://github.com/assurance-maladie-digital/design-system/pull/1075)) ([214c4f2](https://github.com/assurance-maladie-digital/design-system/commit/214c4f22cbc163865c63b71694bef6d2824ba1f4))
+  - **FileList:** Suppression de l'utilisation du composant `VLayout` déprécié ([#1076](https://github.com/assurance-maladie-digital/design-system/pull/1076))
 
 - 🔥 **Suppressions**
   - **PageCard:** Suppression du composant ([#1066](https://github.com/assurance-maladie-digital/design-system/pull/1066)) ([1175200](https://github.com/assurance-maladie-digital/design-system/commit/11752004fcd5a70876e9c759a294d588ef46097a))

--- a/packages/vue-dot/src/patterns/UploadWorkflow/FileList/FileList.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/FileList/FileList.vue
@@ -49,62 +49,60 @@
 
 				<!-- Action buttons -->
 				<VListItemAction v-bind="options.listItemAction">
-					<VLayout v-bind="options.layout">
-						<VBtn
-							v-if="file.state === 'initial'"
-							v-bind="options.uploadBtn"
-							:aria-label="locales.uploadFile"
-							@click="$emit('upload', file.id)"
+					<VBtn
+						v-if="file.state === 'initial'"
+						v-bind="options.uploadBtn"
+						:aria-label="locales.uploadFile"
+						@click="$emit('upload', file.id)"
+					>
+						<VIcon
+							v-bind="options.icon"
+							:color="iconColor"
 						>
-							<VIcon
-								v-bind="options.icon"
-								:color="iconColor"
-							>
-								{{ uploadIcon }}
-							</VIcon>
-						</VBtn>
+							{{ uploadIcon }}
+						</VIcon>
+					</VBtn>
 
-						<VBtn
-							v-if="file.state === 'error'"
-							v-bind="options.retryBtn"
-							:aria-label="locales.uploadFile"
-							@click="$emit('retry', file.id)"
+					<VBtn
+						v-if="file.state === 'error'"
+						v-bind="options.retryBtn"
+						:aria-label="locales.uploadFile"
+						@click="$emit('retry', file.id)"
+					>
+						<VIcon
+							v-bind="options.icon"
+							:color="iconColor"
 						>
-							<VIcon
-								v-bind="options.icon"
-								:color="iconColor"
-							>
-								{{ refreshIcon }}
-							</VIcon>
-						</VBtn>
+							{{ refreshIcon }}
+						</VIcon>
+					</VBtn>
 
-						<VBtn
-							v-if="showViewBtn && file.state === 'success'"
-							v-bind="options.viewFileBtn"
-							:aria-label="locales.viewFile"
-							@click="$emit('view-file', file)"
+					<VBtn
+						v-if="showViewBtn && file.state === 'success'"
+						v-bind="options.viewFileBtn"
+						:aria-label="locales.viewFile"
+						@click="$emit('view-file', file)"
+					>
+						<VIcon
+							v-bind="options.icon"
+							:color="iconColor"
 						>
-							<VIcon
-								v-bind="options.icon"
-								:color="iconColor"
-							>
-								{{ eyeIcon }}
-							</VIcon>
-						</VBtn>
+							{{ eyeIcon }}
+						</VIcon>
+					</VBtn>
 
-						<VBtn
-							v-if="file.state !== 'initial'"
-							v-bind="options.deleteFileBtn"
-							@click="$emit('delete-file', file.id)"
+					<VBtn
+						v-if="file.state !== 'initial'"
+						v-bind="options.deleteFileBtn"
+						@click="$emit('delete-file', file.id)"
+					>
+						<VIcon
+							v-bind="options.icon"
+							:color="iconColor"
 						>
-							<VIcon
-								v-bind="options.icon"
-								:color="iconColor"
-							>
-								{{ deleteIcon }}
-							</VIcon>
-						</VBtn>
-					</VLayout>
+							{{ deleteIcon }}
+						</VIcon>
+					</VBtn>
 				</VListItemAction>
 			</VListItem>
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/FileList/config.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/FileList/config.ts
@@ -1,12 +1,15 @@
 export const config = {
+	listItem: {
+		class: 'flex-wrap'
+	},
 	listItemAvatarIcon: {
 		size: 24
 	},
 	listItemTitle: {
 		class: 'text-wrap'
 	},
-	layout: {
-		justifyEnd: true
+	listItemAction: {
+		class: 'flex-row'
 	},
 	divider: {
 		inset: true

--- a/packages/vue-dot/src/patterns/UploadWorkflow/FileList/tests/__snapshots__/FileList.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/FileList/tests/__snapshots__/FileList.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`FileList renders correctly 1`] = `
 <vlist-stub tag="div" class="vd-file-list" style="width: 100%;">
-  <vlistitem-stub activeclass="" tag="div">
+  <vlistitem-stub activeclass="" tag="div" class="flex-wrap">
     <vlistitemavatar-stub size="40">
       <vicon-stub color="success" size="24">
         M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z
@@ -15,17 +15,15 @@ exports[`FileList renders correctly 1`] = `
       <!---->
       <!---->
     </vlistitemcontent-stub>
-    <vlistitemaction-stub>
-      <vlayout-stub tag="div" justifyend="true">
-        <!---->
-        <!---->
-        <!---->
-        <vbtn-stub tag="button" activeclass="" icon="true" type="button">
-          <vicon-stub color="grey darken-1">
-            M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z
-          </vicon-stub>
-        </vbtn-stub>
-      </vlayout-stub>
+    <vlistitemaction-stub class="flex-row">
+      <!---->
+      <!---->
+      <!---->
+      <vbtn-stub tag="button" activeclass="" icon="true" type="button">
+        <vicon-stub color="grey darken-1">
+          M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z
+        </vicon-stub>
+      </vbtn-stub>
     </vlistitemaction-stub>
   </vlistitem-stub>
   <vdivider-stub inset="true"></vdivider-stub>


### PR DESCRIPTION
## Description

Suppression de l'utilisation du composant `VLayout` déprécié dans le composant `FileList`.

## Playground

<details>

```vue
<template>
	<div>
		<UploadWorkflow
			v-model="files"
			:vuetify-options="vuetifyOptions"
		/>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		files = [
			{
				id: 'rib',
				title: 'RIB'
			},
			{
				id: 'idCard',
				title: 'Carte d\'identité recto / verso'
			},
			{
				id: 'passport',
				title: 'Passeport'
			}
		];

		vuetifyOptions = {
			fileList: {
				showViewBtn: true
			}
		};
	}
</script>

```

</details>

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
