### PR TITLE
🔥 vue-dot: Remove useless layout options in SubHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - 🔥 **Suppressions**
   - **PageCard:** Suppression du composant ([#1066](https://github.com/assurance-maladie-digital/design-system/pull/1066)) ([1175200](https://github.com/assurance-maladie-digital/design-system/commit/11752004fcd5a70876e9c759a294d588ef46097a))
+  - **SubHeader:** Suppression des options `layout` inutiles ([#1078](https://github.com/assurance-maladie-digital/design-system/pull/1078))
 
 ### Vue Dash
 
@@ -41,7 +42,7 @@
 
 - 🔥 **Suppressions**
   - **lerna:** Suppression des propriétés `gitHead` dans les fichiers `package.json` ([#1045](https://github.com/assurance-maladie-digital/design-system/pull/1045)) ([d941896](https://github.com/assurance-maladie-digital/design-system/commit/d94189622cc1fe5e03484472199336a86ba4404d))
-  - **playground:** Suppression d'une `div` inutile ([#1077](https://github.com/assurance-maladie-digital/design-system/pull/1077))
+  - **playground:** Suppression d'une `div` inutile ([#1077](https://github.com/assurance-maladie-digital/design-system/pull/1077)) ([dbd9878](https://github.com/assurance-maladie-digital/design-system/commit/dbd987889a8b09bbe71988076ede8c24ebc8b1ea))
 
 - 📝 **Documentation**
   - **pull-requests:** Mise à jour du template ([#1074](https://github.com/assurance-maladie-digital/design-system/pull/1074)) ([b8da289](https://github.com/assurance-maladie-digital/design-system/commit/b8da289b6d3ec4e0313483795df5227160de9fed))

--- a/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
@@ -34,10 +34,7 @@
 			</VFadeTransition>
 		</slot>
 
-		<div
-			v-bind="options.contentLayout"
-			class="vd-sub-header-content d-flex justify-space-between"
-		>
+		<div class="vd-sub-header-content d-flex justify-space-between">
 			<div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
 				<slot name="title">
 					<VFadeTransition mode="out-in">

--- a/packages/vue-dot/src/patterns/SubHeader/config.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/config.ts
@@ -4,11 +4,5 @@ export const config = {
 		small: true,
 		depressed: true,
 		class: 'text-none font-weight-regular white--text mx-n4'
-	},
-	contentLayout: {
-		class: 'justify-space-between'
-	},
-	dataListsLayout: {
-		class: 'pl-10 pr-8'
 	}
 };

--- a/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`SubHeader renders correctly 1`] = `
       Retour
     </vbtn-stub>
   </vfadetransition-stub>
-  <div class="vd-sub-header-content d-flex justify-space-between justify-space-between">
+  <div class="vd-sub-header-content d-flex justify-space-between">
     <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
       <vfadetransition-stub mode="out-in" origin="top center 0">
         <h2 class="text-h5 font-weight-bold">
@@ -34,7 +34,7 @@ exports[`SubHeader renders loading state correctly 1`] = `
       <div class="v-skeleton-loader__button v-skeleton-loader__bone"></div>
     </div>
   </transition-stub>
-  <div class="vd-sub-header-content d-flex justify-space-between justify-space-between">
+  <div class="vd-sub-header-content d-flex justify-space-between">
     <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
       <transition-stub name="fade-transition" mode="out-in">
         <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader vd-header-loading v-skeleton-loader--is-loading theme--dark" style="height: 2rem; width: 300px;">


### PR DESCRIPTION
## Description

Suppression des options `layout` inutiles dans le composant `SubHeeader`.

## Playground

<details>

```vue
<template>
	<div>
		<SubHeader :data-list-group-items="dataLists" />
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		dataLists = [
			{
				title: 'Informations patient',
				items: [
					{
						key: 'Date de naissance',
						value: '24/09/1970'
					}
				]
			},
			{
				title: 'Médecin traitant',
				items: [
					{
						key: 'Nom du praticien',
						value: 'Gérard Leblanc'
					}
				]
			},
			{
				title: 'Autres informations',
				items: [
					{
						key: 'Dernière modification',
						value: '04/06/2020'
					}
				]
			}
		];
	}
</script>
```

</details>

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
