### PR TITLE
♻️ vue-dot: Use addEventListener in debounce directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@
   - **PageContainer:** Ajout d'un conteneur interne et correction de l'espacement interne ([#1067](https://github.com/assurance-maladie-digital/design-system/pull/1067)) ([4b5a40e](https://github.com/assurance-maladie-digital/design-system/commit/4b5a40e1a2f251c1e64e21703689bde43df7aec9))
   - **DataListItem:** Suppression de l'utilisation du composant `VLayout` déprécié ([#1075](https://github.com/assurance-maladie-digital/design-system/pull/1075)) ([214c4f2](https://github.com/assurance-maladie-digital/design-system/commit/214c4f22cbc163865c63b71694bef6d2824ba1f4))
   - **FileList:** Suppression de l'utilisation du composant `VLayout` déprécié ([#1076](https://github.com/assurance-maladie-digital/design-system/pull/1076)) ([142e27d](https://github.com/assurance-maladie-digital/design-system/commit/142e27d5b40693daec7623f9dfe8ff45bc02340b))
+  - **debounce:** Utilisation de `addEventListener` dans la directive ([#1079](https://github.com/assurance-maladie-digital/design-system/pull/1079))
 
 - 🔥 **Suppressions**
   - **PageCard:** Suppression du composant ([#1066](https://github.com/assurance-maladie-digital/design-system/pull/1066)) ([1175200](https://github.com/assurance-maladie-digital/design-system/commit/11752004fcd5a70876e9c759a294d588ef46097a))
-  - **SubHeader:** Suppression des options `layout` inutiles ([#1078](https://github.com/assurance-maladie-digital/design-system/pull/1078))
+  - **SubHeader:** Suppression des options `layout` inutiles ([#1078](https://github.com/assurance-maladie-digital/design-system/pull/1078)) ([024c1ad](https://github.com/assurance-maladie-digital/design-system/commit/024c1ad115d66d3c1b8152509b5d4a0b35e9a173))
 
 ### Vue Dash
 

--- a/packages/vue-dot/src/directives/debounce/index.ts
+++ b/packages/vue-dot/src/directives/debounce/index.ts
@@ -23,8 +23,7 @@ export const debounce: DirectiveOptions = {
 		// The first modifier is the time
 		const time = modifiers[0] !== undefined ? parseInt(modifiers[0], 10) : undefined;
 
-		// Change debounce only if interval has changed
-		el.oninput = debounceFn(() => {
+		const inputHandler = debounceFn(() => {
 			// If the value is a function (for usage with custom inputs),
 			// call it with the input value
 			if (typeof binding.value === 'function') {
@@ -36,5 +35,7 @@ export const debounce: DirectiveOptions = {
 				el.dispatchEvent(new Event('change'));
 			}
 		}, time);
+
+		el.addEventListener('input', inputHandler);
 	}
 };


### PR DESCRIPTION
## Description

Utilisation de `addEventListener` dans la directive `debounce`.

## Playground

<details>

```vue
<template>
	<div>
		<VTextField
			v-debounce="e => search = e"
			:value="search"
			outlined
			clearable
			hide-details
			class="vd-form-input"
			label="Rechercher"
			@click:clear="search = ''"
		/>

		<p
			v-if="search"
			class="mb-0"
		>
			Votre recherche :

			<span class="font-italic">
				{{ search }}
			</span>
		</p>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		search = '';
	}
</script>

```

</details>

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
