### PR TITLE
🐛 vue-dot: Fix deepCopy not copying falsy values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 ## Non publié
 
+### Vue Dot
+
+- 🐛 **Corrections de bugs**
+  - **functions:** Correction de la copie des valeurs fausses dans la fonction `deepCopy` ([#1138](https://github.com/assurance-maladie-digital/design-system/pull/1138))
+
 ### FormBuilder
 
 - ✨ **Nouvelles fonctionnalités**
   - **RangeField:** Ajout d'un nouveau champ ([#1112](https://github.com/assurance-maladie-digital/design-system/pull/1112)) ([f21d0f5](https://github.com/assurance-maladie-digital/design-system/commit/f21d0f52e0336b0d4ca58951da4fa912cf895c6c))
 
 - 🐛 **Corrections de bugs**
-  - **fields:** Correction de la réinitialisation de la valeur de certains champs ([#1136](https://github.com/assurance-maladie-digital/design-system/pull/1136))
+  - **fields:** Correction de la réinitialisation de la valeur de certains champs ([#1136](https://github.com/assurance-maladie-digital/design-system/pull/1136)) ([41ac4eb](https://github.com/assurance-maladie-digital/design-system/commit/41ac4ebb1f935e9b1ca14fbe7be2953cd6de07cf))
 
 - 🔧 **Configuration**
   - **config:** Mise à jour de la taille maximale du build ([#1123](https://github.com/assurance-maladie-digital/design-system/pull/1123)) ([ea78c19](https://github.com/assurance-maladie-digital/design-system/commit/ea78c197d8fc026c648c5e46e828e2da19f12c8e))

--- a/packages/vue-dot/src/helpers/deepCopy/index.ts
+++ b/packages/vue-dot/src/helpers/deepCopy/index.ts
@@ -15,7 +15,7 @@ export function deepCopy<T = any>(o: UnknownValue): T {
 		copy = Object.prototype.toString.call(o) === '[object Array]' ? [] : {};
 
 		for (k in o) {
-			if (o[k]) {
+			if (o[k] !== undefined) {
 				copy[k] = deepCopy(o[k]);
 			}
 		}

--- a/packages/vue-dot/src/helpers/deepCopy/tests/deepCopy.spec.ts
+++ b/packages/vue-dot/src/helpers/deepCopy/tests/deepCopy.spec.ts
@@ -13,7 +13,6 @@ describe('deepCopy', () => {
 
 		copiedObj.a.b = 'test';
 
-		expect(copiedObj.a.b).toBe('test');
 		expect(objToCopy.a.b).toBe('b');
 	});
 
@@ -24,8 +23,25 @@ describe('deepCopy', () => {
 
 		copiedArray[0][0] = 'test';
 
-		expect(copiedArray[0][0]).toBe('test');
 		expect(arrayToCopy[0][0]).toBe('a');
+	});
+
+	it('should copy an array containing falsy values', () => {
+		const arrayToCopy = [[false, null, 0]];
+
+		const copiedArray = deepCopy(arrayToCopy);
+
+		expect(copiedArray[0][0]).toBe(false);
+		expect(copiedArray[0][1]).toBeNull();
+		expect(copiedArray[0][2]).toBe(0);
+
+		copiedArray[0][0] = 'test';
+		copiedArray[0][1] = 'test';
+		copiedArray[0][2] = 'test';
+
+		expect(arrayToCopy[0][0]).toBe(false);
+		expect(arrayToCopy[0][1]).toBeNull();
+		expect(arrayToCopy[0][2]).toBe(0);
 	});
 
 	it('should copy an array containing undefined', () => {
@@ -37,7 +53,6 @@ describe('deepCopy', () => {
 
 		copiedArray[0][0] = 'test';
 
-		expect(copiedArray[0][0]).toBe('test');
 		expect(arrayToCopy[0][0]).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Description

Correction de la copie des valeurs fausses dans la fonction `deepCopy`.

Fixes #1137 

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
