### PR TITLE
🎨 vue-dot: Use IndexObject instead of custom types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - 🔧 **Configuration**
   - **config:** Mise à jour de la taille maximale du build ([#1139](https://github.com/assurance-maladie-digital/design-system/pull/1139)) ([c9b445b](https://github.com/assurance-maladie-digital/design-system/commit/c9b445b153ea4dd896fa4d08d8615a8b22377259))
 
+- 🎨 **Qualité de code**
+  - **global:** Utilisation de l'interface `IndexedObject` au lieu de types personnalisés ([#1163](https://github.com/assurance-maladie-digital/design-system/pull/1163))
+
 ### FormBuilder
 
 - ✨ **Nouvelles fonctionnalités**
@@ -50,7 +53,7 @@
   - **vue:** Mise à jour vers la `v2.6.14` ([#1158](https://github.com/assurance-maladie-digital/design-system/pull/1158)) ([4b6f2b1](https://github.com/assurance-maladie-digital/design-system/commit/4b6f2b16133312702432b9531e5763dcdee17f6b))
   - **typescript-eslint:** Mise à jour du monorepo vers la `v4.26.1` ([#1159](https://github.com/assurance-maladie-digital/design-system/pull/1159)) ([9197f42](https://github.com/assurance-maladie-digital/design-system/commit/9197f42e14a4c3c10d38dd40eb636ca07d669d90))
   - **@types/node:** Mise à jour vers la `v14.17.3` ([#1160](https://github.com/assurance-maladie-digital/design-system/pull/1160)) ([c475144](https://github.com/assurance-maladie-digital/design-system/commit/c4751442b2803b156ac7501d5188bdb98fc33404))
-  - **@babel/core:** Mise à jour vers la `v7.14.5` ([#1161](https://github.com/assurance-maladie-digital/design-system/pull/1161))
+  - **@babel/core:** Mise à jour vers la `v7.14.5` ([#1161](https://github.com/assurance-maladie-digital/design-system/pull/1161)) ([58c1cb4](https://github.com/assurance-maladie-digital/design-system/commit/58c1cb4ee59ea5f7440984aa7eb17c312877f2b3))
 
 ## v2.0.0-beta.10
 

--- a/packages/vue-dot/src/helpers/registerComponents/index.ts
+++ b/packages/vue-dot/src/helpers/registerComponents/index.ts
@@ -1,8 +1,7 @@
+import { IndexedObject } from '../../types';
 import { VueConstructor } from 'vue';
 
-export interface Components {
-	[name: string]: VueConstructor;
-}
+export type Components = IndexedObject<VueConstructor>;
 
 /**
  * Register components in the global Vue instance

--- a/packages/vue-dot/src/mixins/widthable/index.ts
+++ b/packages/vue-dot/src/mixins/widthable/index.ts
@@ -1,6 +1,7 @@
 import Vue, { PropType } from 'vue';
 import Component, { mixins } from 'vue-class-component';
 
+import { IndexedObject } from '../../types';
 import { convertToUnit } from '../../helpers/convertToUnit';
 
 export type NumberOrNumberString = PropType<string | number | undefined>;
@@ -26,8 +27,8 @@ const MixinsDeclaration = mixins(Props);
 
 @Component
 export class Widthable extends MixinsDeclaration {
-	get widthStyles(): Record<string, string> {
-		const styles: Record<string, string> = {};
+	get widthStyles(): IndexedObject {
+		const styles: IndexedObject = {};
 
 		const minWidth = convertToUnit(this.minWidth);
 		const maxWidth = convertToUnit(this.maxWidth);


### PR DESCRIPTION
## Description

Utilisation de l'interface `IndexedObject` au lieu de types personnalisés

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
