### PR TITLE
🐛 form-builder: Fix tick styles in ChoiceSliderField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 
 ### FormBuilder
 
+- 🐛 **Corrections de bugs**
+  - **ChoiceSliderField:** Correction des styles pour l'affichage des étiquettes ([#1194](https://github.com/assurance-maladie-digital/design-system/pull/1194))
+
 - ♻️ **Refactoring**
-  - **ChoiceSliderField:** Refonte du composant ([#1193](https://github.com/assurance-maladie-digital/design-system/pull/1193))
+  - **ChoiceSliderField:** Refonte du composant ([#1193](https://github.com/assurance-maladie-digital/design-system/pull/1193)) ([8252ccf](https://github.com/assurance-maladie-digital/design-system/commit/8252ccfd3bf8637c20bf52b06e5e8c7f856d796e))
 
 ## v2.0.0-beta.11
 

--- a/packages/form-builder/src/components/FormField/fields/ChoiceSliderField.vue
+++ b/packages/form-builder/src/components/FormField/fields/ChoiceSliderField.vue
@@ -118,7 +118,9 @@
 <style lang="scss" scoped>
 	@import '@cnamts/design-tokens/dist/tokens';
 
-	.vd-choice-slider-field.thumb-label {
+	// Increase min-height when using tick labels with hide-details
+	// to make up for the additional space
+	.vd-choice-slider-field:not(.thumb-label) {
 		&.v-input--hide-details {
 			min-height: 40px;
 		}


### PR DESCRIPTION
## Description

Correction des styles pour l'affichage des étiquettes dans `ChoiceSliderField`.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements --->

<details>

```vue
<template>
	<FormField v-model="field" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { Field } from '../src/components/FormField/types';

	@Component
	export default class Playground extends Vue {
		field: Field = {
			type: 'select',
			items: [
				{
					text: 'Email',
					value: 'email'
				},
				{
					text: 'Courrier',
					value: 'mail'
				},
				{
					text: 'SMS',
					value: 'sms'
				}
			],
			value: null,
			fieldOptions: {
				type: 'choiceSlider',
				label: 'Moyen de contact',
				hideDetails: true,
				outlined: true
			}
		};
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
