### PR TITLE
🐛 form-builder: Fix null default value in ChoiceSliderField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Vue Dot
 
 - 🐛 **Corrections de bugs**
-  - **SubHeader:** Correction de l'événement `click:list-item` ne fonctionnant pas ([#1203](https://github.com/assurance-maladie-digital/design-system/pull/1203))
+  - **SubHeader:** Correction de l'événement `click:list-item` ne fonctionnant pas ([#1203](https://github.com/assurance-maladie-digital/design-system/pull/1203)) ([13056bb](https://github.com/assurance-maladie-digital/design-system/commit/13056bb354fc9860c9def9978630414d040b7f62))
 
 - 🔧 **Configuration**
   - **config:** Mise à jour de la taille maximale du build ([#1183](https://github.com/assurance-maladie-digital/design-system/pull/1183)) ([cd82a69](https://github.com/assurance-maladie-digital/design-system/commit/cd82a69f9f284592bdb805aec359ae78080a97db))
@@ -12,6 +12,7 @@
 
 - 🐛 **Corrections de bugs**
   - **ChoiceSliderField:** Correction des styles pour l'affichage des étiquettes ([#1194](https://github.com/assurance-maladie-digital/design-system/pull/1194)) ([3707e4b](https://github.com/assurance-maladie-digital/design-system/commit/3707e4bcfc163983b527cd7ca5fbb26485bb057a))
+  - **ChoiceSliderField:** Correction de la valeur à `null` par défaut ([#1204](https://github.com/assurance-maladie-digital/design-system/pull/1204))
 
 - ♻️ **Refactoring**
   - **ChoiceSliderField:** Refonte du composant ([#1193](https://github.com/assurance-maladie-digital/design-system/pull/1193)) ([8252ccf](https://github.com/assurance-maladie-digital/design-system/commit/8252ccfd3bf8637c20bf52b06e5e8c7f856d796e))

--- a/packages/form-builder/src/components/FormField/fields/ChoiceSliderField.vue
+++ b/packages/form-builder/src/components/FormField/fields/ChoiceSliderField.vue
@@ -33,7 +33,19 @@
 	type ThumbLabelValue = boolean | string | undefined;
 
 	/** Choice field type slider */
-	@Component
+	@Component<ChoiceSliderField>({
+		watch: {
+			value: {
+				handler(value: FieldValue): void {
+					// If the value is null, set it to the first item
+					if (value === null) {
+						this.valueUpdated(0);
+					}
+				},
+				immediate: true
+			}
+		}
+	})
 	export default class ChoiceSliderField extends MixinsDeclaration {
 		/**
 		 * Get the index of the selected item by value


### PR DESCRIPTION
## Description

Correction de la valeur à `null` par défaut dans le champ `ChoiceSliderField`.

## Playground

<details>

```vue
<template>
	<FormField v-model="field" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { Field } from '@cnamts/form-builder/src/components/FormField/types';

	@Component
	export default class FormFieldSlider extends Vue {
		field: Field = {
			type: 'select',
			items: [
				{
					text: '1 an',
					value: 1
				},
				{
					text: '2 ans',
					value: 2
				},
				{
					text: '3 ans',
					value: 3
				},
				{
					text: '4 ans',
					value: 4
				}
			],
			value: null,
			fieldOptions: {
				type: 'choiceSlider',
				label: 'Durée',
				hideDetails: true
			}
		};
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
