### PR TITLE
🐛 vue-dot: Fix resize cursor position in textarea fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - 🐛 **Corrections de bugs**
   - **SubHeader:** Correction de l'événement `click:list-item` ne fonctionnant pas ([#1203](https://github.com/assurance-maladie-digital/design-system/pull/1203)) ([13056bb](https://github.com/assurance-maladie-digital/design-system/commit/13056bb354fc9860c9def9978630414d040b7f62))
+  - **styles:** Correction de la position du curseur de redimensionnement dans les champs de formulaires ([#1212](https://github.com/assurance-maladie-digital/design-system/pull/1212))
 
 - ♻️ **Refactoring**
   - **PaginatedTable:** Modification de la valeur par défaut de la prop `suffix` à `undefined` ([#1205](https://github.com/assurance-maladie-digital/design-system/pull/1205)) ([8df8e55](https://github.com/assurance-maladie-digital/design-system/commit/8df8e55c59fe820e99f0c0722e243f25b5cd9ffc))
@@ -17,7 +18,7 @@
   - **ChoiceSliderField:** Correction des styles pour l'affichage des étiquettes ([#1194](https://github.com/assurance-maladie-digital/design-system/pull/1194)) ([3707e4b](https://github.com/assurance-maladie-digital/design-system/commit/3707e4bcfc163983b527cd7ca5fbb26485bb057a))
   - **ChoiceSliderField:** Correction de la valeur par défaut manquante ([#1204](https://github.com/assurance-maladie-digital/design-system/pull/1204)) ([350e9e5](https://github.com/assurance-maladie-digital/design-system/commit/350e9e56ef8c0f88875299368d4a33de53758bda))
   - **PeriodField:** Correction de la largeur des champs ([#1208](https://github.com/assurance-maladie-digital/design-system/pull/1208)) ([a1ef419](https://github.com/assurance-maladie-digital/design-system/commit/a1ef41997c998905911afc32bbae35baa7199b3e))
-  - **ChoiceButtonField:** Correction de l'espacement interne ([#1211](https://github.com/assurance-maladie-digital/design-system/pull/1211))
+  - **ChoiceButtonField:** Correction de l'espacement interne ([#1211](https://github.com/assurance-maladie-digital/design-system/pull/1211)) ([f6d4795](https://github.com/assurance-maladie-digital/design-system/commit/f6d4795afae962d373d4dc31dc5d0f2fa9b46f65))
 
 - ♻️ **Refactoring**
   - **ChoiceSliderField:** Refonte du composant ([#1193](https://github.com/assurance-maladie-digital/design-system/pull/1193)) ([8252ccf](https://github.com/assurance-maladie-digital/design-system/commit/8252ccfd3bf8637c20bf52b06e5e8c7f856d796e))

--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -9,11 +9,18 @@
 .v-ripple__container *,
 .v-tabs__container,
 .v-input--selection-controls__ripple,
+.v-textarea.v-text-field--enclosed .v-text-field__slot,
 .v-simple-checkbox svg,
 .v-slide-group__content,
 .v-slider__tick-label,
 .v-slider__thumb-container * {
 	max-width: none;
+}
+
+// Fix resize cursor position in textarea fields
+.v-textarea.v-text-field--enclosed .v-text-field__slot textarea {
+	margin-top: 10px;
+	min-height: 46px;
 }
 
 // Change font


### PR DESCRIPTION
## Description

Correction de la position du curseur de redimensionnement dans les champs de formulaires.

Avant :

![screenshot-localhost_3000-2021 07 05-11_55_16](https://user-images.githubusercontent.com/10298932/124458009-c4b09980-dd8c-11eb-922d-36afefc81d69.png)
![screenshot-localhost_3000-2021 07 05-12_25_14](https://user-images.githubusercontent.com/10298932/124458016-c7ab8a00-dd8c-11eb-9a83-c460edbb8394.png)

Après :

![screenshot-localhost_3000-2021 07 05-12_25_50](https://user-images.githubusercontent.com/10298932/124458034-cda16b00-dd8c-11eb-8ecf-30832557370a.png)
![screenshot-localhost_3000-2021 07 05-12_25_37](https://user-images.githubusercontent.com/10298932/124458039-cf6b2e80-dd8c-11eb-998c-2201d5346c34.png)


## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<FormField v-model="field" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { Field } from '@cnamts/form-builder/src/components/FormField/types';

	@Component
	export default class FormFieldTextarea extends Vue {
		field: Field = {
			type: 'textarea',
			value: null,
			fieldOptions: {
				label: 'Vos symptômes',
				hideDetails: true,
				outlined: true
			}
		};
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
