### PR TITLE
🐛 vue-dot: Fix add button spacing in TableToolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - 🐛 **Corrections de bugs**
   - **SubHeader:** Correction de l'événement `click:list-item` ne fonctionnant pas ([#1203](https://github.com/assurance-maladie-digital/design-system/pull/1203)) ([13056bb](https://github.com/assurance-maladie-digital/design-system/commit/13056bb354fc9860c9def9978630414d040b7f62))
-  - **styles:** Correction de la position du curseur de redimensionnement dans les champs de formulaires ([#1212](https://github.com/assurance-maladie-digital/design-system/pull/1212))
+  - **styles:** Correction de la position du curseur de redimensionnement dans les champs de formulaires ([#1212](https://github.com/assurance-maladie-digital/design-system/pull/1212)) ([2314b2e](https://github.com/assurance-maladie-digital/design-system/commit/2314b2eded1063ad9e746e46e5a201b72cece285))
+  - **TableToolbar:** Correction de l'espacement du bouton *Ajouter* ([#1214](https://github.com/assurance-maladie-digital/design-system/pull/1214))
 
 - ♻️ **Refactoring**
   - **PaginatedTable:** Modification de la valeur par défaut de la prop `suffix` à `undefined` ([#1205](https://github.com/assurance-maladie-digital/design-system/pull/1205)) ([8df8e55](https://github.com/assurance-maladie-digital/design-system/commit/8df8e55c59fe820e99f0c0722e243f25b5cd9ffc))

--- a/packages/vue-dot/src/patterns/TableToolbar/config.ts
+++ b/packages/vue-dot/src/patterns/TableToolbar/config.ts
@@ -5,12 +5,13 @@ export const config = {
 	},
 	addBtn: {
 		outlined: true,
-		color: 'primary'
+		color: 'primary',
+		class: 'ml-6'
 	},
 	textField: {
 		clearable: true,
 		singleLine: true,
 		hideDetails: true,
-		class: 'vd-form-input flex-grow-0 mr-4'
+		class: 'vd-form-input flex-grow-0'
 	}
 };

--- a/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
@@ -6,8 +6,8 @@ exports[`TableToolbar renders correctly 1`] = `
     1/2 lignes
   </p>
   <vspacer-stub></vspacer-stub>
-  <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0 mr-4"></vtextfield-stub>
-  <vbtn-stub color="primary" outlined="true" tag="button" activeclass="" type="button">
+  <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0"></vtextfield-stub>
+  <vbtn-stub color="primary" outlined="true" tag="button" activeclass="" type="button" class="ml-6">
     <vicon-stub>
       M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z
     </vicon-stub>
@@ -24,7 +24,7 @@ exports[`TableToolbar renders correctly when loading 1`] = `
       0/1 ligne
     </p>
     <div class="spacer"></div>
-    <div class="v-input v-input--hide-details v-input--is-disabled theme--light v-text-field v-text-field--single-line vd-form-input flex-grow-0 mr-4">
+    <div class="v-input v-input--hide-details v-input--is-disabled theme--light v-text-field v-text-field--single-line vd-form-input flex-grow-0">
       <div class="v-input__control">
         <div class="v-input__slot">
           <div class="v-text-field__slot"><label for="input-8" class="v-label v-label--is-disabled theme--light" style="left: 0px; position: absolute;">Rechercher</label><input disabled="disabled" id="input-8" type="text"></div>
@@ -49,7 +49,7 @@ exports[`TableToolbar renders correctly with content slot 1`] = `
       0/1 ligne
     </p>
     <div class="spacer"></div>
-    <div class="v-input v-input--hide-details theme--light v-text-field v-text-field--single-line vd-form-input flex-grow-0 mr-4">
+    <div class="v-input v-input--hide-details theme--light v-text-field v-text-field--single-line vd-form-input flex-grow-0">
       <div class="v-input__control">
         <div class="v-input__slot">
           <div class="v-text-field__slot"><label for="input-13" class="v-label theme--light" style="left: 0px; position: absolute;">Rechercher</label><input id="input-13" type="text"></div>
@@ -71,7 +71,7 @@ exports[`TableToolbar renders correctly with no items 1`] = `
 <vtoolbar-stub color="white" tag="header" extensionheight="48" flat="true" src="">
   <!---->
   <vspacer-stub></vspacer-stub>
-  <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0 mr-4"></vtextfield-stub>
+  <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0"></vtextfield-stub>
   <!---->
 </vtoolbar-stub>
 `;


### PR DESCRIPTION
## Description

Correction de l'espacement du bouton *Ajouter* dans le composant `TableToolbar`.

## Playground

<details>

```vue
<template>
	<TableToolbar
		v-model="search"
		:nb-total="items.length"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { DataTableHeader } from 'vuetify';

	@Component
	export default class TableToolbarAddBtn extends Vue {
		search: string | null = null;
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
