### PR TITLE
🐛 vue-dot: Fix add button icon spacing in TableToolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - 🐛 **Corrections de bugs**
   - **SubHeader:** Correction de l'événement `click:list-item` ne fonctionnant pas ([#1203](https://github.com/assurance-maladie-digital/design-system/pull/1203)) ([13056bb](https://github.com/assurance-maladie-digital/design-system/commit/13056bb354fc9860c9def9978630414d040b7f62))
   - **styles:** Correction de la position du curseur de redimensionnement dans les champs de formulaires ([#1212](https://github.com/assurance-maladie-digital/design-system/pull/1212)) ([2314b2e](https://github.com/assurance-maladie-digital/design-system/commit/2314b2eded1063ad9e746e46e5a201b72cece285))
-  - **TableToolbar:** Correction de l'espacement du bouton *Ajouter* ([#1214](https://github.com/assurance-maladie-digital/design-system/pull/1214))
+  - **TableToolbar:** Correction de l'espacement du bouton *Ajouter* ([#1214](https://github.com/assurance-maladie-digital/design-system/pull/1214)) ([6cb82bc](https://github.com/assurance-maladie-digital/design-system/commit/6cb82bc01dc5ca913d304d4bc85a470f909b6279))
+  - **TableToolbar:** Correction de l'espacement de l'icône du bouton *Ajouter* ([#1215](https://github.com/assurance-maladie-digital/design-system/pull/1215))
 
 - ♻️ **Refactoring**
   - **PaginatedTable:** Modification de la valeur par défaut de la prop `suffix` à `undefined` ([#1205](https://github.com/assurance-maladie-digital/design-system/pull/1205)) ([8df8e55](https://github.com/assurance-maladie-digital/design-system/commit/8df8e55c59fe820e99f0c0722e243f25b5cd9ffc))

--- a/packages/vue-dot/src/patterns/TableToolbar/config.ts
+++ b/packages/vue-dot/src/patterns/TableToolbar/config.ts
@@ -8,6 +8,9 @@ export const config = {
 		color: 'primary',
 		class: 'ml-6'
 	},
+	addIcon: {
+		class: 'mr-1'
+	},
 	textField: {
 		clearable: true,
 		singleLine: true,

--- a/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`TableToolbar renders correctly 1`] = `
   <vspacer-stub></vspacer-stub>
   <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0"></vtextfield-stub>
   <vbtn-stub color="primary" outlined="true" tag="button" activeclass="" type="button" class="ml-6">
-    <vicon-stub>
+    <vicon-stub class="mr-1">
       M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z
     </vicon-stub>
 


### PR DESCRIPTION
## Description

Correction de l'espacement de l'icône du bouton *Ajouter* dans le composant `TableToolbar`.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
