### PR TITLE
🐛 vue-dot: Fix z-index value in ExternalLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   - **SubHeader:** Correction de l'événement `click:list-item` ne fonctionnant pas ([#1203](https://github.com/assurance-maladie-digital/design-system/pull/1203)) ([13056bb](https://github.com/assurance-maladie-digital/design-system/commit/13056bb354fc9860c9def9978630414d040b7f62))
   - **styles:** Correction de la position du curseur de redimensionnement dans les champs de formulaires ([#1212](https://github.com/assurance-maladie-digital/design-system/pull/1212)) ([2314b2e](https://github.com/assurance-maladie-digital/design-system/commit/2314b2eded1063ad9e746e46e5a201b72cece285))
   - **TableToolbar:** Correction de l'espacement du bouton *Ajouter* ([#1214](https://github.com/assurance-maladie-digital/design-system/pull/1214)) ([6cb82bc](https://github.com/assurance-maladie-digital/design-system/commit/6cb82bc01dc5ca913d304d4bc85a470f909b6279))
-  - **TableToolbar:** Correction de l'espacement de l'icône du bouton *Ajouter* ([#1215](https://github.com/assurance-maladie-digital/design-system/pull/1215))
+  - **TableToolbar:** Correction de l'espacement de l'icône du bouton *Ajouter* ([#1215](https://github.com/assurance-maladie-digital/design-system/pull/1215)) ([73e6152](https://github.com/assurance-maladie-digital/design-system/commit/73e61528b18aede1afd2385811f77c54323e1a08))
+  - **ExternalLinks:** Correction de la valeur de la propriété `z-index` du bouton ([#1216](https://github.com/assurance-maladie-digital/design-system/pull/1216))
 
 - ♻️ **Refactoring**
   - **PaginatedTable:** Modification de la valeur par défaut de la prop `suffix` à `undefined` ([#1205](https://github.com/assurance-maladie-digital/design-system/pull/1205)) ([8df8e55](https://github.com/assurance-maladie-digital/design-system/commit/8df8e55c59fe820e99f0c0722e243f25b5cd9ffc))

--- a/packages/vue-dot/src/elements/ExternalLinks/ExternalLinks.vue
+++ b/packages/vue-dot/src/elements/ExternalLinks/ExternalLinks.vue
@@ -73,7 +73,7 @@
 </template>
 
 <script lang='ts'>
-	import Vue , { PropType } from 'vue';
+	import Vue, { PropType } from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
 	import { config } from './config';
@@ -220,8 +220,8 @@
 			const left = this.left ? '0' : 'auto';
 			const right = this.right ? '0' : 'auto';
 
-			// Change z-index to avoid shadow bleeding (VMenu is 8)
-			const zIndex = this.top ? '8' : '9';
+			// Change z-index to avoid shadow bleeding (VMenu is set to 4)
+			const zIndex = this.top ? '4' : '5';
 
 			return {
 				transform,
@@ -274,7 +274,7 @@
 
 	@media only screen and (max-height: 340px) {
 		.vd-external-links-btn {
-			z-index: 8 !important;
+			z-index: 4 !important;
 		}
 	}
 </style>

--- a/packages/vue-dot/src/elements/ExternalLinks/config.ts
+++ b/packages/vue-dot/src/elements/ExternalLinks/config.ts
@@ -1,7 +1,8 @@
 export const config = {
 	menu: {
 		offsetY: true,
-		tile: true
+		tile: true,
+		zIndex: 4
 	},
 	btn: {
 		tile: true,

--- a/packages/vue-dot/src/elements/ExternalLinks/tests/__snapshots__/ExternalLinks.spec.ts.snap
+++ b/packages/vue-dot/src/elements/ExternalLinks/tests/__snapshots__/ExternalLinks.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ExternalLinks.vue renders correctly 1`] = `
-<vmenu-stub opendelay="0" closedelay="0" contentclass="vd-external-links-menu left-0" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" tile="true" closeonclick="true" closeoncontentclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition" class="vd-external-links">
+<vmenu-stub opendelay="0" closedelay="0" contentclass="vd-external-links-menu left-0" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" zindex="4" tile="true" closeonclick="true" closeoncontentclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition" class="vd-external-links">
   <vcard-stub loaderheight="4" tag="div" class="px-4 py-3">
     <p class="mb-0">
       Pas de données.


### PR DESCRIPTION
## Description

Correction de la valeur de la propriété `z-index` du bouton dans le composant `ExternalLinks`.

Le `z-index` était trop élevé par rapport à celui du composant `VAppBar`.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
