### PR TITLE
♻️ vue-dot: Fix border radius when no data in ExternalLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   - **styles:** Correction de la position du curseur de redimensionnement dans les champs de formulaires ([#1212](https://github.com/assurance-maladie-digital/design-system/pull/1212)) ([2314b2e](https://github.com/assurance-maladie-digital/design-system/commit/2314b2eded1063ad9e746e46e5a201b72cece285))
   - **TableToolbar:** Correction de l'espacement du bouton *Ajouter* ([#1214](https://github.com/assurance-maladie-digital/design-system/pull/1214)) ([6cb82bc](https://github.com/assurance-maladie-digital/design-system/commit/6cb82bc01dc5ca913d304d4bc85a470f909b6279))
   - **TableToolbar:** Correction de l'espacement de l'icône du bouton *Ajouter* ([#1215](https://github.com/assurance-maladie-digital/design-system/pull/1215)) ([73e6152](https://github.com/assurance-maladie-digital/design-system/commit/73e61528b18aede1afd2385811f77c54323e1a08))
-  - **ExternalLinks:** Correction de la valeur de la propriété `z-index` du bouton ([#1216](https://github.com/assurance-maladie-digital/design-system/pull/1216))
+  - **ExternalLinks:** Correction de la valeur de la propriété `z-index` du bouton ([#1216](https://github.com/assurance-maladie-digital/design-system/pull/1216)) ([74c7aaf](https://github.com/assurance-maladie-digital/design-system/commit/74c7aaf050806f75e6fd17fefe467756912b033b))
+  - **ExternalLinks:** Correction de l'arrondi lorsqu'il n'y a pas de données ([#1217](https://github.com/assurance-maladie-digital/design-system/pull/1217))
 
 - ♻️ **Refactoring**
   - **PaginatedTable:** Modification de la valeur par défaut de la prop `suffix` à `undefined` ([#1205](https://github.com/assurance-maladie-digital/design-system/pull/1205)) ([8df8e55](https://github.com/assurance-maladie-digital/design-system/commit/8df8e55c59fe820e99f0c0722e243f25b5cd9ffc))

--- a/packages/vue-dot/src/elements/ExternalLinks/ExternalLinks.vue
+++ b/packages/vue-dot/src/elements/ExternalLinks/ExternalLinks.vue
@@ -61,14 +61,14 @@
 			</VListItem>
 		</VList>
 
-		<VCard
+		<VSheet
 			v-else
-			v-bind="options.card"
+			v-bind="options.sheet"
 		>
 			<p class="mb-0">
 				{{ locales.noData }}
 			</p>
-		</VCard>
+		</VSheet>
 	</VMenu>
 </template>
 

--- a/packages/vue-dot/src/elements/ExternalLinks/config.ts
+++ b/packages/vue-dot/src/elements/ExternalLinks/config.ts
@@ -21,7 +21,8 @@ export const config = {
 		target: '_blank',
 		rel: 'noopener noreferrer'
 	},
-	card: {
+	sheet: {
+		elevation: 0,
 		class: 'px-4 py-3'
 	}
 };

--- a/packages/vue-dot/src/elements/ExternalLinks/tests/__snapshots__/ExternalLinks.spec.ts.snap
+++ b/packages/vue-dot/src/elements/ExternalLinks/tests/__snapshots__/ExternalLinks.spec.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`ExternalLinks.vue renders correctly 1`] = `
 <vmenu-stub opendelay="0" closedelay="0" contentclass="vd-external-links-menu left-0" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" zindex="4" tile="true" closeonclick="true" closeoncontentclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition" class="vd-external-links">
-  <vcard-stub loaderheight="4" tag="div" class="px-4 py-3">
+  <vsheet-stub elevation="0" tag="div" class="px-4 py-3">
     <p class="mb-0">
       Pas de données.
     </p>
-  </vcard-stub>
+  </vsheet-stub>
 </vmenu-stub>
 `;


### PR DESCRIPTION
## Description

Correction de l'arrondi lorsqu'il n'y a pas de données dans le composant `ExternalLinks`.

![screenshot-localhost_3000-2021 07 05-17_44_18](https://user-images.githubusercontent.com/10298932/124497162-c1cc9d80-ddba-11eb-9111-eeffcf08a476.png)
![screenshot-localhost_3000-2021 07 05-17_45_37](https://user-images.githubusercontent.com/10298932/124497197-ca24d880-ddba-11eb-958f-1d59c5f330e3.png)

On utilise `VSheet` plutôt que `VCard` pour corriger le bug car c'est plus adapté à notre utilisation.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
