### PR TITLE
♻️ vue-dot: Remove href prop default value in FranceConnectBtn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Non publié
 
+### Vue Dot
+
+- ♻️ **Refactoring**
+  - **FranceConnectBtn:** Suppression de la valeur par défaut de la prop `href` ([#1333](https://github.com/assurance-maladie-digital/design-system/pull/1333))
+
 ### Documentation
 
 - 🐛 **Corrections de bugs**
@@ -10,7 +15,7 @@
   - **guides** Ajout du guide sur la gestion des variables d'environnement ([#1290](https://github.com/assurance-maladie-digital/design-system/pull/1290)) ([1d7def8](https://github.com/assurance-maladie-digital/design-system/commit/1d7def8c9a54db3c03faa82a9d85fc6d27e7a951))
   - **guides:** Ajout du guide sur les v-model personnalisés ([#1297](https://github.com/assurance-maladie-digital/design-system/pull/1297)) ([7d53155](https://github.com/assurance-maladie-digital/design-system/commit/7d5315561d525649d46e6d8855d59a8b9573424c))
   - **guides:** Ajout du guide sur la gestion des événements ([#1302](https://github.com/assurance-maladie-digital/design-system/pull/1302)) ([ad28235](https://github.com/assurance-maladie-digital/design-system/commit/ad2823551a9163c1162968352068a85521424ba7))
-  - **FranceConnectBtn:** Documentation du composant ([#1329](https://github.com/assurance-maladie-digital/design-system/pull/1329))
+  - **FranceConnectBtn:** Documentation du composant ([#1329](https://github.com/assurance-maladie-digital/design-system/pull/1329)) ([5766901](https://github.com/assurance-maladie-digital/design-system/commit/576690153394e1920f61a2f29ba8aa204059bbb9))
 
 ### Interne
 

--- a/packages/vue-dot/src/elements/FranceConnectBtn/FranceConnectBtn.vue
+++ b/packages/vue-dot/src/elements/FranceConnectBtn/FranceConnectBtn.vue
@@ -89,7 +89,12 @@
 
 	const Props = Vue.extend({
 		props: {
-			/** Title of the button */
+			/** Link URL */
+			href: {
+				type: String,
+				required: true
+			},
+			/** Label of the button */
 			iconText: {
 				type: String,
 				default: locales.btnText
@@ -103,11 +108,6 @@
 			height: {
 				type: [Number, String],
 				default: 78
-			},
-			/** Link URL */
-			href: {
-				type: String,
-				default: 'https://app.franceconnect.gouv.fr/'
 			}
 		}
 	});

--- a/packages/vue-dot/src/elements/FranceConnectBtn/tests/FranceConnectBtn.spec.ts
+++ b/packages/vue-dot/src/elements/FranceConnectBtn/tests/FranceConnectBtn.spec.ts
@@ -12,7 +12,11 @@ let wrapper: Wrapper<Vue>;
 describe('FranceConnectBtn', () => {
 	it('renders correctly', () => {
 		// Mount component
-		wrapper = mountComponent(FranceConnectBtn);
+		wrapper = mountComponent(FranceConnectBtn, {
+			propsData: {
+				href: 'https://app.franceconnect.gouv.fr/'
+			}
+		});
 
 		expect(html(wrapper)).toMatchSnapshot();
 	});


### PR DESCRIPTION
## Description

Suppression de la valeur par défaut de la prop `href` dans le composant `FranceConnectBtn`.

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
