### PR TITLE
🐛 vue-dot: Fix TableToolbar display on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Vue Dot
 
+- 🐛 **Corrections de bugs**
+  - **TableToolbar:** Correction de l'affichage du composant en mobile ([#1347](https://github.com/assurance-maladie-digital/design-system/pull/1347))
+
 - ♻️ **Refactoring**
   - **FranceConnectBtn:** Suppression de la valeur par défaut de la prop `href` ([#1333](https://github.com/assurance-maladie-digital/design-system/pull/1333)) ([a9f751c](https://github.com/assurance-maladie-digital/design-system/commit/a9f751c7b1e3bdebab5a23394f1557737d876260))
 
@@ -14,7 +17,7 @@
   - **prompts:** Ajout de l'option Jenkins files ([#1315](https://github.com/assurance-maladie-digital/design-system/pull/1315)) ([de25e11](https://github.com/assurance-maladie-digital/design-system/commit/de25e118bb672007470a3e083f7a372e8153c42c))
 
 - 🎨 **Qualité de code**
-  - **tests:** Mise à jour des labels des blocs `describe` ([#1346](https://github.com/assurance-maladie-digital/design-system/pull/1346))
+  - **tests:** Mise à jour des labels des blocs `describe` ([#1346](https://github.com/assurance-maladie-digital/design-system/pull/1346)) ([c973a62](https://github.com/assurance-maladie-digital/design-system/commit/c973a6230eb0acf4c1cdc78230b856a4a58efcd0))
 
 ### Documentation
 

--- a/packages/vue-dot/src/patterns/TableToolbar/TableToolbar.vue
+++ b/packages/vue-dot/src/patterns/TableToolbar/TableToolbar.vue
@@ -1,5 +1,8 @@
 <template>
-	<VToolbar v-bind="options.toolbar">
+	<VToolbar
+		v-bind="options.toolbar"
+		class="vd-table-toolbar"
+	>
 		<p
 			v-if="showRowsNumber"
 			class="mb-0 font-weight-bold mr-4"
@@ -17,6 +20,7 @@
 			:disabled="loading"
 			:append-icon="searchIcon"
 			:label="searchLabel"
+			:class="textFieldClasses"
 			@input="$emit('search', $event)"
 		/>
 
@@ -30,7 +34,12 @@
 				{{ addIcon }}
 			</VIcon>
 
-			{{ addBtnLabel }}
+			<span
+				v-show="$vuetify.breakpoint.mdAndUp"
+				v-bind="options.addIconLabel"
+			>
+				{{ addBtnLabel }}
+			</span>
 		</VBtn>
 	</VToolbar>
 </template>
@@ -118,5 +127,17 @@
 
 			return locales.rowText(this.rowText, plural);
 		}
+
+		get textFieldClasses(): string {
+			const fieldClass = this.$vuetify.breakpoint.xs ? 'vd-form-input-s' : 'vd-form-input';
+
+			return `${fieldClass} flex-grow-0`;
+		}
 	}
 </script>
+
+<style lang="scss" scoped>
+	.vd-table-toolbar ::v-deep .v-toolbar__content {
+		flex-wrap: wrap;
+	}
+</style>

--- a/packages/vue-dot/src/patterns/TableToolbar/config.ts
+++ b/packages/vue-dot/src/patterns/TableToolbar/config.ts
@@ -6,15 +6,15 @@ export const config = {
 	addBtn: {
 		outlined: true,
 		color: 'primary',
-		class: 'ml-6'
+		class: 'px-2 px-md-4 ml-6',
+		minWidth: '44px'
 	},
-	addIcon: {
+	addIconLabel: {
 		class: 'mr-1'
 	},
 	textField: {
 		clearable: true,
 		singleLine: true,
-		hideDetails: true,
-		class: 'vd-form-input flex-grow-0'
+		hideDetails: true
 	}
 };

--- a/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableToolbar renders correctly 1`] = `
-<vtoolbar-stub color="white" tag="header" extensionheight="48" flat="true" src="">
+<vtoolbar-stub color="white" tag="header" extensionheight="48" flat="true" src="" class="vd-table-toolbar">
   <p class="mb-0 font-weight-bold mr-4">
     1/2 lignes
   </p>
   <vspacer-stub></vspacer-stub>
   <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0"></vtextfield-stub>
-  <vbtn-stub color="primary" outlined="true" tag="button" activeclass="" type="button" class="ml-6">
-    <vicon-stub class="mr-1">
+  <vbtn-stub color="primary" minwidth="44px" outlined="true" tag="button" activeclass="" type="button" class="px-2 px-md-4 ml-6">
+    <vicon-stub>
       M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z
-    </vicon-stub>
-
-    Ajouter
+    </vicon-stub> <span class="mr-1">
+			Ajouter
+		</span>
   </vbtn-stub>
 </vtoolbar-stub>
 `;
 
 exports[`TableToolbar renders correctly when loading 1`] = `
-<header class="v-sheet theme--light v-toolbar v-toolbar--flat white" style="height: 64px;">
+<header class="vd-table-toolbar v-sheet theme--light v-toolbar v-toolbar--flat white" style="height: 64px;">
   <div class="v-toolbar__content" style="height: 64px;">
     <p class="mb-0 font-weight-bold mr-4">
       0/1 ligne
@@ -43,7 +43,7 @@ exports[`TableToolbar renders correctly when loading 1`] = `
 `;
 
 exports[`TableToolbar renders correctly with content slot 1`] = `
-<header class="v-sheet theme--light v-toolbar v-toolbar--flat white" style="height: 64px;">
+<header class="vd-table-toolbar v-sheet theme--light v-toolbar v-toolbar--flat white" style="height: 64px;">
   <div class="v-toolbar__content" style="height: 64px;">
     <p class="mb-0 font-weight-bold mr-4">
       0/1 ligne
@@ -68,7 +68,7 @@ exports[`TableToolbar renders correctly with content slot 1`] = `
 `;
 
 exports[`TableToolbar renders correctly with no items 1`] = `
-<vtoolbar-stub color="white" tag="header" extensionheight="48" flat="true" src="">
+<vtoolbar-stub color="white" tag="header" extensionheight="48" flat="true" src="" class="vd-table-toolbar">
   <!---->
   <vspacer-stub></vspacer-stub>
   <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0"></vtextfield-stub>


### PR DESCRIPTION
## Description

Correction de l'affichage du composant `TableToolbar` en mobile.

Fixes #1320 

## Playground

<details>

```vue
<template>
	<VDataTable
		:headers="headers"
		:items="items"
		:search="search"
		hide-default-footer
	>
		<template #top>
			<TableToolbar
				v-model="search"
				:nb-total="items.length"
				show-add-btn
			/>
		</template>
	</VDataTable>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { DataTableHeader } from 'vuetify';

	@Component
	export default class Playground extends Vue {
		search: string | null = null;

		headers: DataTableHeader[] = [
			{
				text: 'Nom',
				value: 'lastname'
			},
			{
				text: 'Prénom',
				value: 'firstname'
			},
			{
				text: 'Email',
				value: 'email'
			}
		];

		items = [
			{
				firstname: 'Virginie',
				lastname: 'Beauchesne',
				email: 'virginie.beauchesne@example.com'
			},
			{
				firstname: 'Étienne',
				lastname: 'Salois',
				email: 'etienne.salois@example.com'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
