### PR TITLE
🐛 cli-helpers: Fix missing @types/figlet dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
 ### CLI Helpers
 
 - 🐛 **Corrections de bugs**
-  - **build:** Correction du dossier `src` non listé dans la liste des ressources à publier ([#1392](https://github.com/assurance-maladie-digital/design-system/pull/1392))
+  - **build:** Correction du dossier `src` non listé dans la liste des ressources à publier ([#1392](https://github.com/assurance-maladie-digital/design-system/pull/1392)) ([e6ef1fe](https://github.com/assurance-maladie-digital/design-system/commit/e6ef1fec4094d3bc83b428614528c77e448959d0))
+  - **dependencies:** Correction de la dépendance `@types/figlet` manquante ([#1393](https://github.com/assurance-maladie-digital/design-system/pull/1393))
 
 ### Documentation
 

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -32,10 +32,10 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"figlet": "^1.3.0"
+		"figlet": "^1.3.0",
+		"@types/figlet": "1.5.4"
 	},
 	"devDependencies": {
-		"@types/figlet": "1.5.4",
 		"jest-mock-process": "1.4.1"
 	},
 	"lint-staged": {


### PR DESCRIPTION
## Description

Correction de la dépendance `@types/figlet` manquante dans le package CLI Helpers.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
