### PR TITLE
✨ docs: Add property validation in DocUsage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Documentation
 
+- ✨ **Nouvelles fonctionnalités**
+  - **DocUsage:** Ajout d'une validation sur le format des propriétés ([#1586](https://github.com/assurance-maladie-digital/design-system/pull/1586))
+
 - 🐛 **Corrections de bugs**
   - **DocMarkdown:** Correction de la compilation du HTML ([#1572](https://github.com/assurance-maladie-digital/design-system/pull/1572)) ([a22c280](https://github.com/assurance-maladie-digital/design-system/commit/a22c28031b45dc9a79625101126b90ba149f2725))
   - **global:** Correction des accents dans les ancres HTML ([#1583](https://github.com/assurance-maladie-digital/design-system/pull/1583)) ([3aa2e09](https://github.com/assurance-maladie-digital/design-system/commit/3aa2e096d4c7abc5e59391ccc0ccb860a76671c4))
@@ -22,7 +25,7 @@
 ### Interne
 
 - 🐛 **Corrections de bugs**
-  - **build:** Correction des fichiers de tests et de coverage publiés ([#1584](https://github.com/assurance-maladie-digital/design-system/pull/1584))
+  - **build:** Correction des fichiers de tests et de coverage publiés ([#1584](https://github.com/assurance-maladie-digital/design-system/pull/1584)) ([a10e1f2](https://github.com/assurance-maladie-digital/design-system/commit/a10e1f2c8d5919ec0b6ebdb07cf522dcce677e08))
 
 - 📝 **Documentation**
   - **README:** Mise à jour du badge npm ([#1582](https://github.com/assurance-maladie-digital/design-system/pull/1582)) ([853bc97](https://github.com/assurance-maladie-digital/design-system/commit/853bc97835c1e11e8be97e834bb2093631504f90))

--- a/packages/docs/src/components/global/DocUsage.vue
+++ b/packages/docs/src/components/global/DocUsage.vue
@@ -252,6 +252,7 @@
 
 	import { getUsageCode } from '../../functions/getUsageCode';
 	import { toKebabCase } from '../../functions/toKebabCase';
+	import { toCamelCase } from '../../functions/toCamelCase';
 
 	interface ImportedComponent extends VueClass<Vue> {
 		options: {
@@ -359,7 +360,11 @@
 			const defaults = this.$data.defaultProps as UsageProps;
 			const propsHiddenByDefault = (this.$data.propsHiddenByDefault || []) as string[];
 
+			this.validateProps(propsHiddenByDefault, 'propsHiddenByDefault');
+
 			if (defaults) {
+				this.validateProps(Object.keys(defaults), 'defaults');
+
 				const filteredDefaults: UsageProps = {};
 
 				Object
@@ -378,7 +383,24 @@
 
 			for (const [key, value] of Object.entries(this.options)) {
 				(this as unknown as IndexedObject<unknown>)[key] = value;
+
+				if (typeof value === 'object') {
+					this.validateProps(Object.keys(value), 'options');
+				}
+
+				if (Array.isArray(value)) {
+					this.validateProps(value, 'options');
+				}
 			}
+		}
+
+		validateProps(props: string[], location: string): void {
+			props.forEach((propName) => {
+				if (propName.match(/[^a-zA-Z0-9]+(.)/g)) {
+					// eslint-disable-next-line no-console
+					console.error(`Wrong format for the "${propName}" property in "${location}" object. Expected "${toCamelCase(propName)}".`);
+				}
+			});
 		}
 
 		toggleRadioProp(props: string[], toggled: string): void {

--- a/packages/docs/src/content/examples/copy-btn/usage.vue
+++ b/packages/docs/src/content/examples/copy-btn/usage.vue
@@ -35,7 +35,7 @@
 
 		options = {
 			booleans: [
-				'hide-tooltip'
+				'hideTooltip'
 			],
 			sliders: {
 				tooltipDuration: {

--- a/packages/docs/src/functions/toCamelCase.ts
+++ b/packages/docs/src/functions/toCamelCase.ts
@@ -1,0 +1,3 @@
+export function toCamelCase(str: string): string {
+	return str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+}


### PR DESCRIPTION
## Description

Ajout d'une validation sur le format des propriétés dans le composant `DocUsage`.

Lors de l'utilisation de ce composant, les propriétés doivent être écrites en camelCase afin d'assurer le bon fonctionnement du composant.

Exemple de message d'erreur : `Wrong format for the "hide-tooltip" property in "options" object. Expected "hideTooltip".`

## Type de changement

- Nouvelle fonctionnalité

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
