### PR TITLE
✨ vue-dot: Pass down event listeners in DatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - ✨ **Nouvelles fonctionnalités**
   - **HeaderBar:** Ajout d'un lien vers la page d'accueil sur le logo ([#1612](https://github.com/assurance-maladie-digital/design-system/pull/1612)) ([3f26bbd](https://github.com/assurance-maladie-digital/design-system/commit/3f26bbd928de6c591e72a1b614a633758242bf4b))
   - **DatePicker:** Ajout de la gestion du copier/coller ([#1647](https://github.com/assurance-maladie-digital/design-system/pull/1647)) ([4174305](https://github.com/assurance-maladie-digital/design-system/commit/417430545c22eeac16c02b84cb2ef986164a9c7c))
-  - **DatePicker:** Ajout de la gestion de l'appui sur la touche *Entrée* ([#1648](https://github.com/assurance-maladie-digital/design-system/pull/1648))
+  - **DatePicker:** Ajout de la gestion de l'appui sur la touche *Entrée* ([#1648](https://github.com/assurance-maladie-digital/design-system/pull/1648)) ([#1647](https://github.com/assurance-maladie-digital/design-system/pull/1647)) ([2704190](https://github.com/assurance-maladie-digital/design-system/commit/2704190ed07d208fffcd33fc5d3ea80ea069c0dd))
+  - **DatePicker:** Transmission des écouteurs d'événements ([#1649](https://github.com/assurance-maladie-digital/design-system/pull/1649))
 
 - 🐛 **Corrections de bugs**
   - **Logo:** Correction du logo Risque Pro ([#1641](https://github.com/assurance-maladie-digital/design-system/pull/1641)) ([c678ffa](https://github.com/assurance-maladie-digital/design-system/commit/c678ffa04fe15cd760055c0887486383cdfba729))

--- a/packages/docs/src/content/composants/date-picker.md
+++ b/packages/docs/src/content/composants/date-picker.md
@@ -22,7 +22,7 @@ Vous pouvez afficher le `VTextField` en mode `outlined` en utilisant la prop du 
 Vous pouvez permettre à l’utilisateur de sélectionner une date naissance plus facilement en utilisant la prop `birthdate`.
 
 <doc-alert type="info">
-L’utilisateur sélectionnera l’année en premier, puis le mois et enfin le jour et ne peut pas sélectionner une date future.
+L’utilisateur sélectionnera l’année en premier, puis le mois et enfin le jour et ne pourra pas sélectionner une date future.
 </doc-alert>
 
 <doc-example file="date-picker/birthdate"></doc-example>
@@ -67,15 +67,26 @@ Pour cela, vous pouvez utiliser les règles de validation inclues dans la librai
 - `notAfterToday`
 - `notBeforeToday`
 
-<doc-example file="date-picker/rules" /></doc-example>
+<doc-example file="date-picker/rules"></doc-example>
 
 </doc-tab-item>
 
 <doc-tab-item label="API">
+
+<doc-alert type="info">
+Les propriétés non définies dans la section API seront reportées directement sur le composant `VTextField`.
+</doc-alert>
+
 <doc-api name="date-picker"></doc-api>
 </doc-tab-item>
 
 <doc-tab-item label="Personnalisation">
+
+### Événements
+
+Vous pouvez écouter des événements directement sur le composant `VTextField`, pour par exemple ajouter un bouton réinitialiser.
+
+<doc-example file="date-picker/events"></doc-example>
 
 ### Composants Vuetify
 

--- a/packages/docs/src/content/examples/date-picker/events.vue
+++ b/packages/docs/src/content/examples/date-picker/events.vue
@@ -1,0 +1,17 @@
+<template>
+	<DatePicker
+		v-model="date"
+		clearable
+		@click:clear="date = null"
+	/>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class DatePickerEvents extends Vue {
+		date: string | null = null;
+	}
+</script>

--- a/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
@@ -9,19 +9,20 @@
 			<!-- TextField to enter date by hand -->
 			<VTextField
 				ref="input"
-				v-model="dateFormatted"
 				v-facade="maskValue"
 				v-bind="textFieldOptions"
+				:value="dateFormatted"
 				:outlined="outlined"
 				:class="textFieldClasses"
 				:success-messages="textFieldOptions.successMessages || successMessages"
 				:error.sync="internalErrorProp"
 				class="vd-date-picker-text-field"
-				@input="$emit('input', $event)"
 				@blur="textFieldBlur"
 				@click="textFieldClicked"
 				@paste.prevent="saveFromPasted"
 				@keydown.enter.prevent="saveFromTextField"
+				@change="dateFormatted = $event"
+				v-on="$listeners"
 			>
 				<template #prepend>
 					<VBtn


### PR DESCRIPTION
## Description

Transmission des écouteurs d'événements dans le composant `DatePicker`.

## Playground

<details>

```vue
<template>
	<DatePicker
		v-model="date"
		clearable
		@click:clear="date = null"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		date: string | null = null;
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
