### PR TITLE
✨ vue-dot: Add FooterBar pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
   - **DatePicker:** Ajout de la gestion du copier/coller ([#1647](https://github.com/assurance-maladie-digital/design-system/pull/1647)) ([4174305](https://github.com/assurance-maladie-digital/design-system/commit/417430545c22eeac16c02b84cb2ef986164a9c7c))
   - **DatePicker:** Ajout de la gestion de l'appui sur la touche *Entrée* ([#1648](https://github.com/assurance-maladie-digital/design-system/pull/1648)) ([#1647](https://github.com/assurance-maladie-digital/design-system/pull/1647)) ([2704190](https://github.com/assurance-maladie-digital/design-system/commit/2704190ed07d208fffcd33fc5d3ea80ea069c0dd))
   - **DatePicker:** Transmission des écouteurs d'événements ([#1649](https://github.com/assurance-maladie-digital/design-system/pull/1649)) ([1f12f67](https://github.com/assurance-maladie-digital/design-system/commit/1f12f67986a3f81c0b8e964d92278eee8cde4707))
+  - **FooterBar:** Ajout d'un nouveau composant ([#1652](https://github.com/assurance-maladie-digital/design-system/pull/1652))
 
 - 🐛 **Corrections de bugs**
   - **Logo:** Correction du logo Risque Pro ([#1641](https://github.com/assurance-maladie-digital/design-system/pull/1641)) ([c678ffa](https://github.com/assurance-maladie-digital/design-system/commit/c678ffa04fe15cd760055c0887486383cdfba729))
   - **DatePicker:** Correction de la valeur mal réinitialisée sans `v-model` ([#1646](https://github.com/assurance-maladie-digital/design-system/pull/1646)) ([bcd5dc9](https://github.com/assurance-maladie-digital/design-system/commit/bcd5dc9779b0542b3d4855d27ae5b475b04e349f))
-  - **DatePicker:** Correction d'une erreur lors de la mise à jour de la prop `activePicker` en mode `birthdate` ([#1650](https://github.com/assurance-maladie-digital/design-system/pull/1650))
+  - **DatePicker:** Correction d'une erreur lors de la mise à jour de la prop `activePicker` en mode `birthdate` ([#1650](https://github.com/assurance-maladie-digital/design-system/pull/1650)) ([ab7e2df](https://github.com/assurance-maladie-digital/design-system/commit/ab7e2df3c5e572572c5d06d22711aaa1360f6fb9))
 
 - ♿️ **Accessibilité**
   - **HeaderBar:** Ajout d'un label sur le bouton pour fermer le menu de navigation ([#1574](https://github.com/assurance-maladie-digital/design-system/pull/1574)) ([19a0e62](https://github.com/assurance-maladie-digital/design-system/commit/19a0e620a9d940de03be1498a83f24a86752234a))

--- a/packages/docs/src/content/composants/footer-bar.md
+++ b/packages/docs/src/content/composants/footer-bar.md
@@ -1,0 +1,34 @@
+---
+title: FooterBar
+description: Le pattern `FooterBar` est utilisé pour afficher un pied de page.
+---
+
+<doc-tabs>
+
+<doc-tab-item label="Utilisation">
+
+<doc-usage name="footer-bar"></doc-usage>
+
+</doc-tab-item>
+
+<doc-tab-item label="API">
+<doc-api name="footer-bar"></doc-api>
+</doc-tab-item>
+
+<doc-tab-item label="Personnalisation">
+
+### Composants Vuetify
+
+Vous pouvez personnaliser les composants Vuetify contenus dans le pattern `FooterBar` en utilisant la prop `vuetify-options`.
+
+<doc-example file="footer-bar/options"></doc-example>
+
+### Slots
+
+Vous pouvez utiliser les slots `prepend` et `append` pour ajouter du contenu avant et après les liens du pied de page.
+
+<doc-example file="footer-bar/slots"></doc-example>
+
+</doc-tab-item>
+
+</doc-tabs>

--- a/packages/docs/src/content/composants/footer-wrapper.md
+++ b/packages/docs/src/content/composants/footer-wrapper.md
@@ -3,6 +3,12 @@ title: FooterWrapper
 description: Le pattern `FooterWrapper` est utilisé avec le composant `FooterBtn` pour afficher un pied de page.
 ---
 
+<doc-alert type="warning">
+
+Ce composant est déprécié en faveur du composant [`FooterBar`](/composants/footer-bar) depuis la [version 2.2.0](https://github.com/assurance-maladie-digital/design-system/releases/tag/v2.2.0) et sera supprimé dans la prochaine version majeure.
+
+</doc-alert>
+
 <doc-tabs>
 
 <doc-tab-item label="Utilisation">

--- a/packages/docs/src/content/examples/footer-bar/options.vue
+++ b/packages/docs/src/content/examples/footer-bar/options.vue
@@ -1,0 +1,17 @@
+<template>
+	<FooterBar :vuetify-options="vuetifyOptions" />
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class FooterBarOptions extends Vue {
+		vuetifyOptions = {
+			footer: {
+				color: '#eee'
+			}
+		};
+	}
+</script>

--- a/packages/docs/src/content/examples/footer-bar/slots.vue
+++ b/packages/docs/src/content/examples/footer-bar/slots.vue
@@ -1,0 +1,17 @@
+<template>
+	<FooterBar>
+		<template #append>
+			<p class="grey--text text--darken-1 my-3 mx-4">
+				Information partenaires
+			</p>
+		</template>
+	</FooterBar>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class FooterBarSlots extends Vue {}
+</script>

--- a/packages/docs/src/content/examples/footer-bar/usage.vue
+++ b/packages/docs/src/content/examples/footer-bar/usage.vue
@@ -1,0 +1,49 @@
+<template>
+	<div class="d-flex flex-wrap align-center justify-center w-100">
+		<FooterBar
+			v-bind="$attrs"
+			v-on="$listeners"
+			cgu-route="/"
+			legal-notice-route="/"
+			a11y-statement-route="/"
+		/>
+	</div>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	import { A11yComplianceEnum } from '@cnamts/vue-dot/src/patterns/FooterBar/A11yComplianceEnum';
+
+	@Component({
+		inheritAttrs: false
+	})
+	export default class FooterBarUsage extends Vue {
+		defaultProps = {
+			a11yCompliance: A11yComplianceEnum.NON_COMPLIANT
+		};
+
+		propsHiddenByDefault = [
+			'a11yCompliance'
+		];
+
+		options = {
+			selects: {
+				a11yCompliance: [
+					A11yComplianceEnum.NON_COMPLIANT,
+					A11yComplianceEnum.PARTIALLY_COMPLIANT,
+					A11yComplianceEnum.FULLY_COMPLIANT
+				]
+			},
+			booleans: [
+				'hideCguLink',
+				'hideLegalNoticeLink',
+				'hideA11yLink'
+			],
+			textFields: [
+				'version'
+			]
+		};
+	}
+</script>

--- a/packages/docs/src/data/api/footer-bar.ts
+++ b/packages/docs/src/data/api/footer-bar.ts
@@ -1,0 +1,76 @@
+import { Api } from '~/types';
+
+export const api: Api = {
+	FooterBar: {
+		props: [
+			{
+				name: 'a11y-compliance',
+				type: 'string',
+				default: `'non-compliant'`,
+				description: 'Le niveau de conformité aux règles d’accessibilité de l’application.<br>Cette mention est obligatoire, voir la [documentation du RGAA](https://www.numerique.gouv.fr/publications/rgaa-accessibilite/obligations/#d%C3%A9claration-daccessibilit%C3%A9).',
+				example: `'non-compliant' | 'partially-compliant' | 'fully-compliant'`
+			},
+			{
+				name: 'cgu-route',
+				type: 'RawLocation',
+				default: `{ name: 'cgu' }`,
+				description: 'La valeur de la prop `to` du lien vers les *Conditions générales d’utilisation*.'
+			},
+			{
+				name: 'legal-notice-route',
+				type: 'RawLocation',
+				default: `{ name: 'legalNotice' }`,
+				description: 'La valeur de la prop `to` du lien vers les *Mentions légales*.'
+			},
+			{
+				name: 'a11y-statement-route',
+				type: 'RawLocation',
+				default: `{ name: 'a11yStatement' }`,
+				description: 'La valeur de la prop `to` du lien vers la *Déclaration d’accessibilité*.'
+			},
+			{
+				name: 'hide-cgu-link',
+				type: 'boolean',
+				default: false,
+				description: 'Masque le lien vers les *Conditions générales d’utilisation*.'
+			},
+			{
+				name: 'hide-legal-notice-link',
+				type: 'boolean',
+				default: false,
+				description: 'Masque le lien vers les *Mentions légales*.'
+			},
+			{
+				name: 'hide-a11y-link',
+				type: 'boolean',
+				default: false,
+				description: 'Masque le lien vers la *Déclaration d’accessibilité*.'
+			},
+			{
+				name: 'version',
+				type: 'string',
+				default: 'undefined',
+				description: 'Le numéro de version de l’application.'
+			},
+			{
+				name: 'vuetify-options',
+				type: 'Options',
+				description: 'Personnalisation des composants Vuetify en utilisant la directive `customizable`.',
+				default: 'undefined',
+				example: `{
+	footer: 'VFooter'
+}`
+			}
+		],
+		slots: [
+			{
+				name: 'prepend',
+				description: 'Slot pour ajouter du contenu avant les liens du pied de page.'
+			},
+			{
+				name: 'append',
+				description: 'Slot pour ajouter du contenu après les liens du pied de page.'
+			}
+		]
+	}
+};

--- a/packages/docs/src/data/drawerItems.ts
+++ b/packages/docs/src/data/drawerItems.ts
@@ -84,6 +84,10 @@ export const drawerItems: DrawerItem[] = [
 				to: '/composants/filter-module'
 			},
 			{
+				title: 'FooterBar',
+				to: '/composants/footer-bar'
+			},
+			{
 				title: 'FooterWrapper',
 				to: '/composants/footer-wrapper'
 			},

--- a/packages/vue-dot/src/patterns/FooterBar/A11yComplianceEnum.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/A11yComplianceEnum.ts
@@ -1,0 +1,7 @@
+export enum A11yComplianceEnum {
+	NON_COMPLIANT = 'non-compliant',
+	PARTIALLY_COMPLIANT = 'partially-compliant',
+	FULLY_COMPLIANT = 'fully-compliant'
+}
+
+export const A11Y_COMPLIANCE_ENUM_VALUES = Object.values(A11yComplianceEnum);

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -1,0 +1,133 @@
+<template>
+	<VFooter
+		v-bind="options.footer"
+		min-height="40px"
+		class="vd-footer-bar text-center d-flex justify-center pa-0 w-100"
+	>
+		<slot name="prepend" />
+
+		<RouterLink
+			v-if="!hideCguLink"
+			:to="cguRoute"
+			class="my-3 mx-4"
+		>
+			{{ locales.cguLabel }}
+		</RouterLink>
+
+		<RouterLink
+			v-if="!hideLegalNoticeLink"
+			:to="legalNoticeRoute"
+			class="my-3 mx-4"
+		>
+			{{ locales.legalNoticeLabel }}
+		</RouterLink>
+
+		<RouterLink
+			v-if="!hideA11yLink && a11yComplianceLabel"
+			:to="a11yStatementRoute"
+			class="my-3 mx-4"
+		>
+			{{ a11yComplianceLabel }}
+		</RouterLink>
+
+		<p
+			v-if="version"
+			class="grey--text text--darken-1 my-3 mx-4"
+		>
+			{{ locales.versionLabel }} {{ version }}
+		</p>
+
+		<slot name="append" />
+	</VFooter>
+</template>
+
+<script lang="ts">
+	import Vue, { PropType } from 'vue';
+	import Component, { mixins } from 'vue-class-component';
+
+	import { RawLocation } from 'vue-router';
+
+	import { config } from './config';
+	import { locales } from './locales';
+	import { A11yComplianceEnum, A11Y_COMPLIANCE_ENUM_VALUES } from './A11yComplianceEnum';
+
+	import { propValidator } from '../../helpers/propValidator';
+
+	import { customizable } from '../../mixins/customizable';
+
+	const Props = Vue.extend({
+		props: {
+			a11yCompliance: {
+				type: String as PropType<A11yComplianceEnum>,
+				default: A11yComplianceEnum.NON_COMPLIANT,
+				validator: (value: A11yComplianceEnum) => propValidator('a11y-compliance', A11Y_COMPLIANCE_ENUM_VALUES, value)
+			},
+			cguRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'cgu' })
+			},
+			legalNoticeRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'legalNotice' })
+			},
+			a11yStatementRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'a11yStatement' })
+			},
+			hideCguLink: {
+				type: Boolean,
+				default: false
+			},
+			hideLegalNoticeLink: {
+				type: Boolean,
+				default: false
+			},
+			hideA11yLink: {
+				type: Boolean,
+				default: false
+			},
+			version: {
+				type: String,
+				default: undefined
+			}
+		}
+	});
+
+	const MixinsDeclaration = mixins(Props, customizable(config));
+
+	@Component
+	export default class FooterBar extends MixinsDeclaration {
+		locales = locales;
+
+		get a11yComplianceLabel(): string | null {
+			const complianceLabel = locales[this.a11yCompliance];
+
+			if (!complianceLabel) {
+				return null;
+			}
+
+			return locales.a11yLabel(complianceLabel);
+		}
+	}
+</script>
+
+<style lang="scss" scoped>
+	.vd-footer-bar {
+		a {
+			color: inherit;
+			transition: .15s;
+			text-decoration: none;
+			padding-top: 1px; // Add top padding to account for bottom border
+			border-bottom: 1px solid transparent;
+
+			&:hover,
+			&:focus {
+				border-color: currentColor;
+			}
+		}
+
+		p {
+			padding: 1px 0;
+		}
+	}
+</style>

--- a/packages/vue-dot/src/patterns/FooterBar/config.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/config.ts
@@ -1,0 +1,6 @@
+export const config = {
+	footer: {
+		elevation: 3,
+		color: '#fff'
+	}
+};

--- a/packages/vue-dot/src/patterns/FooterBar/index.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/index.ts
@@ -1,0 +1,3 @@
+import FooterBar from './FooterBar.vue';
+
+export default FooterBar;

--- a/packages/vue-dot/src/patterns/FooterBar/locales.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/locales.ts
@@ -1,0 +1,11 @@
+import { A11yComplianceEnum } from './A11yComplianceEnum';
+
+export const locales = {
+	cguLabel: 'Conditions générales d’utilisation',
+	legalNoticeLabel: 'Mentions légales',
+	versionLabel: 'Version',
+	[A11yComplianceEnum.NON_COMPLIANT]: 'non conforme',
+	[A11yComplianceEnum.PARTIALLY_COMPLIANT]: 'partiellement conforme',
+	[A11yComplianceEnum.FULLY_COMPLIANT]: 'totalement conforme',
+	a11yLabel: (complianceLabel: string): string => `Accessibilité\xa0: ${complianceLabel}`
+};

--- a/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
@@ -1,0 +1,20 @@
+import Vue from 'vue';
+
+import { Wrapper } from '@vue/test-utils';
+
+import { mountComponent } from '@/tests';
+import { html } from '@/tests/utils/html';
+
+import FooterBar from '../';
+
+let wrapper: Wrapper<Vue>;
+
+describe('FooterBar', () => {
+	it('renders correctly', () => {
+		wrapper = mountComponent(FooterBar, {
+			stubs: ['RouterLink']
+		});
+
+		expect(html(wrapper)).toMatchSnapshot();
+	});
+});

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FooterBar renders correctly 1`] = `
+<vfooter-stub color="#fff" elevation="3" height="auto" minheight="40px" tag="footer" class="vd-footer-bar text-center d-flex justify-center pa-0 w-100">
+  <routerlink-stub to="[object Object]" class="my-3 mx-4">
+    Conditions générales d’utilisation
+  </routerlink-stub>
+  <routerlink-stub to="[object Object]" class="my-3 mx-4">
+    Mentions légales
+  </routerlink-stub>
+  <routerlink-stub to="[object Object]" class="my-3 mx-4">
+    Accessibilité&nbsp;: non conforme
+  </routerlink-stub>
+  <!---->
+</vfooter-stub>
+`;

--- a/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/FooterBtn.vue
+++ b/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/FooterBtn.vue
@@ -29,7 +29,10 @@
 
 	const MixinsDeclaration = mixins(Props);
 
-	/** FooterBtn is a component used to display a button in Footer */
+	/**
+	 * FooterBtn is a component used to display a button in Footer
+	 * @deprecated Use FooterBar instead
+	 */
 	@Component({
 		inheritAttrs: false
 	})

--- a/packages/vue-dot/src/patterns/FooterWrapper/FooterWrapper.vue
+++ b/packages/vue-dot/src/patterns/FooterWrapper/FooterWrapper.vue
@@ -19,7 +19,10 @@
 	import Vue from 'vue';
 	import Component from 'vue-class-component';
 
-	/** FooterWrapper is a component used to display a Footer */
+	/**
+	 * FooterWrapper is a component used to display a Footer
+	 * @deprecated Use FooterBar instead
+	 */
 	@Component
 	export default class FooterWrapper extends Vue {}
 </script>

--- a/packages/vue-dot/src/patterns/index.ts
+++ b/packages/vue-dot/src/patterns/index.ts
@@ -2,6 +2,7 @@ import DataListGroup from './DataListGroup';
 import DatePicker from './DatePicker';
 import FileUpload from './FileUpload';
 import FilterModule from './FilterModule';
+import FooterBar from './FooterBar';
 import FooterWrapper from './FooterWrapper';
 import LangBtn from './LangBtn';
 import HeaderBar from './HeaderBar';
@@ -16,6 +17,7 @@ export const patterns = {
 	DatePicker,
 	FileUpload,
 	FilterModule,
+	FooterBar,
 	FooterWrapper,
 	LangBtn,
 	HeaderBar,

--- a/packages/vue-dot/tests/integration/__snapshots__/libTheme.spec.ts.snap
+++ b/packages/vue-dot/tests/integration/__snapshots__/libTheme.spec.ts.snap
@@ -14,6 +14,7 @@ Object {
     "ExternalLinks",
     "FileUpload",
     "FilterModule",
+    "FooterBar",
     "FooterWrapper",
     "FranceConnectBtn",
     "HeaderBar",

--- a/packages/vue-dot/tests/integration/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vue-dot/tests/integration/__snapshots__/plugin.spec.ts.snap
@@ -14,6 +14,7 @@ Object {
     "ExternalLinks",
     "FileUpload",
     "FilterModule",
+    "FooterBar",
     "FooterWrapper",
     "FranceConnectBtn",
     "HeaderBar",

--- a/packages/vue-dot/tests/integration/__snapshots__/registerAllComponents.spec.ts.snap
+++ b/packages/vue-dot/tests/integration/__snapshots__/registerAllComponents.spec.ts.snap
@@ -13,6 +13,7 @@ Array [
   "ExternalLinks",
   "FileUpload",
   "FilterModule",
+  "FooterBar",
   "FooterWrapper",
   "FranceConnectBtn",
   "HeaderBar",


### PR DESCRIPTION
## Description

Ajout du nouveau composant `FooterBar`.

Ce composant remplace les composants `FooterWrapper` et `FooterBtn` qui comportaient des problèmes d'accessibilité et d'utilisation.

## Playground

<details>

```vue
<template>
	<FooterBar version="1.2.0" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
