### PR TITLE
✨ vue-dot: Add hide-actions prop in DialogBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - **DatePicker:** Ajout de la gestion de l'appui sur la touche *Entrée* ([#1648](https://github.com/assurance-maladie-digital/design-system/pull/1648)) ([#1647](https://github.com/assurance-maladie-digital/design-system/pull/1647)) ([2704190](https://github.com/assurance-maladie-digital/design-system/commit/2704190ed07d208fffcd33fc5d3ea80ea069c0dd))
   - **DatePicker:** Transmission des écouteurs d'événements ([#1649](https://github.com/assurance-maladie-digital/design-system/pull/1649)) ([1f12f67](https://github.com/assurance-maladie-digital/design-system/commit/1f12f67986a3f81c0b8e964d92278eee8cde4707))
   - **FooterBar:** Ajout d'un nouveau composant ([#1652](https://github.com/assurance-maladie-digital/design-system/pull/1652)) ([7c3b521](https://github.com/assurance-maladie-digital/design-system/commit/7c3b5214616f7d2ab61390f322a07c53a2b12126))
+  - **DialogBox:** Ajout de la prop `hide-actions` ([#1656](https://github.com/assurance-maladie-digital/design-system/pull/1656))
 
 - 🐛 **Corrections de bugs**
   - **Logo:** Correction du logo Risque Pro ([#1641](https://github.com/assurance-maladie-digital/design-system/pull/1641)) ([c678ffa](https://github.com/assurance-maladie-digital/design-system/commit/c678ffa04fe15cd760055c0887486383cdfba729))
@@ -25,7 +26,7 @@
 
 - ♻️ **Refactoring**
   - **template:** Mise à jour de la couleur de fond par défaut ([#1645](https://github.com/assurance-maladie-digital/design-system/pull/1645)) ([23389a0](https://github.com/assurance-maladie-digital/design-system/commit/23389a0f66761469a84bdb5654dcb4adc7fa3ffc))
-  - **template:** Mise à jour du favicon ([#1655](https://github.com/assurance-maladie-digital/design-system/pull/1655))
+  - **template:** Mise à jour du favicon ([#1655](https://github.com/assurance-maladie-digital/design-system/pull/1655)) ([956bfaa](https://github.com/assurance-maladie-digital/design-system/commit/956bfaa4b9598eb0f034cfe5f4bc8f48646bf484))
 
 - 🔥 **Suppressions**
   - **template:** Suppression du fichier `logo.svg` non utilisé ([#1638](https://github.com/assurance-maladie-digital/design-system/pull/1638)) ([ce3e0a5](https://github.com/assurance-maladie-digital/design-system/commit/ce3e0a55482c5a48fecc1bbb66882b18e2e9a53e))

--- a/packages/docs/src/content/composants/dialog-box.md
+++ b/packages/docs/src/content/composants/dialog-box.md
@@ -13,15 +13,21 @@ description: L’élément `DialogBox` est utilisé pour afficher une boîte de 
 
 ### Largeur
 
-Vous pouvez modifier la largeur de la boîte de dialogue avec la prop `width`.
+Vous pouvez modifier la largeur de la boîte de dialogue en utilisant la prop `width`.
 
 <doc-example file="dialog-box/width"></doc-example>
 
 ### Textes des boutons
 
-Vous pouvez modifier les textes par défaut des boutons d’actions avec les props `cancel-btn-text` et `confirm-btn-text`.
+Vous pouvez modifier les textes par défaut des boutons d’actions en utilisant les props `cancel-btn-text` et `confirm-btn-text`.
 
 <doc-example file="dialog-box/btn-text"></doc-example>
+
+### Boutons d’actions masqués
+
+Vous pouvez masquer les boutons d’actions en utilisant la prop `hide-actions`.
+
+<doc-example file="dialog-box/hide-actions"></doc-example>
 
 </doc-tab-item>
 

--- a/packages/docs/src/content/examples/dialog-box/hide-actions.vue
+++ b/packages/docs/src/content/examples/dialog-box/hide-actions.vue
@@ -1,0 +1,30 @@
+<template>
+	<div>
+		<VBtn
+			color="primary"
+			@click="dialog = true"
+		>
+			Afficher le composant
+		</VBtn>
+
+		<DialogBox
+			v-model="dialog"
+			title="Enregistrement"
+			hide-actions
+		>
+			<p class="mb-1">
+				Souhaitez-vous procéder à l’enregistrement ?
+			</p>
+		</DialogBox>
+	</div>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class DialogBoxHideActions extends Vue {
+		dialog = false;
+	}
+</script>

--- a/packages/docs/src/content/examples/dialog-box/usage.vue
+++ b/packages/docs/src/content/examples/dialog-box/usage.vue
@@ -43,6 +43,9 @@
 `;
 
 		options = {
+			booleans: [
+				'hideActions'
+			],
 			textFields: [
 				'title',
 				'width'

--- a/packages/docs/src/data/api/dialog-box.ts
+++ b/packages/docs/src/data/api/dialog-box.ts
@@ -34,6 +34,12 @@ export const api: Api = {
 				description: 'Le texte du bouton *Valider*.'
 			},
 			{
+				name: 'hide-actions',
+				type: 'boolean',
+				default: false,
+				description: 'Masque les boutons d’actions.'
+			},
+			{
 				name: 'vuetify-options',
 				type: 'Options',
 				default: 'undefined',

--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -31,6 +31,7 @@
 			<slot />
 
 			<div
+				v-if="!hideActions"
 				v-bind="options.actionsCtn"
 				class="vd-dialog-box-actions-ctn"
 			>
@@ -96,6 +97,11 @@
 			confirmBtnText: {
 				type: String,
 				default: locales.confirmBtn
+			},
+			/** Hide the action buttons */
+			hideActions: {
+				type: Boolean,
+				default: false
 			}
 		}
 	});

--- a/packages/vue-dot/src/patterns/FooterWrapper/FooterWrapper.vue
+++ b/packages/vue-dot/src/patterns/FooterWrapper/FooterWrapper.vue
@@ -21,6 +21,7 @@
 
 	/**
 	 * FooterWrapper is a component used to display a Footer
+	 *
 	 * @deprecated Use FooterBar instead
 	 */
 	@Component


### PR DESCRIPTION
## Description

Ajout de la prop `hide-actions` dans le composant `DialogBox`.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<div>
		<VBtn
			color="primary"
			@click="dialog = true"
		>
			Afficher le composant
		</VBtn>

		<DialogBox
			v-model="dialog"
			title="Enregistrement"
			hide-actions
		>
			<p class="mb-0">
				Souhaitez-vous procéder à l’enregistrement ?
			</p>
		</DialogBox>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		dialog = false;
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
