### PR TITLE
🐛 vue-dot: Fix NotificationBar display on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Non publié
 
+### Vue Dot
+
+- 🐛 **Corrections de bugs**
+  - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675))
+
 ### Interne
 
 - ⬆️ **Dépendances**
@@ -7,7 +12,7 @@
   - **typescript:** Mise à jour vers la `v4.5.4` ([#1666](https://github.com/assurance-maladie-digital/design-system/pull/1666)) ([4348a53](https://github.com/assurance-maladie-digital/design-system/commit/4348a538c96f82a0767db953b04dabb110ad0166))
   - **@babel/core:** Mise à jour vers la `v7.16.5` ([#1667](https://github.com/assurance-maladie-digital/design-system/pull/1667)) ([5a4448b](https://github.com/assurance-maladie-digital/design-system/commit/5a4448bd84e5b02929d8265feffd2c314aa2f240))
   - **vue-input-facade:** Mise à jour vers la `v1.3.8` ([#1668](https://github.com/assurance-maladie-digital/design-system/pull/1668)) ([ecea62a](https://github.com/assurance-maladie-digital/design-system/commit/ecea62af4e0ed516d878d95639c874cc2efa1564))
-  - **eslint-plugin-jsdoc:** Mise à jour vers la `v37.2.2` ([#1672](https://github.com/assurance-maladie-digital/design-system/pull/1672))
+  - **eslint-plugin-jsdoc:** Mise à jour vers la `v37.2.2` ([#1672](https://github.com/assurance-maladie-digital/design-system/pull/1672)) ([8ac8368](https://github.com/assurance-maladie-digital/design-system/commit/8ac8368edcdfc1fc5139469389c634ff45a4041f))
 
 ## v2.2.0
 
@@ -290,7 +295,7 @@ Cette version majeure comporte l'ajout de guides et la complétion de la documen
 ### Vue Dot
 
 - 🐛 **Corrections de bugs**
-  - **TableToolbar:** Correction de l'affichage du composant sur les écrans mobiles ([#1347](https://github.com/assurance-maladie-digital/design-system/pull/1347)) ([f78383f](https://github.com/assurance-maladie-digital/design-system/commit/f78383f3b54edea2771ed089df96f77683939f37))
+  - **TableToolbar:** Correction de l'affichage sur les écrans mobiles ([#1347](https://github.com/assurance-maladie-digital/design-system/pull/1347)) ([f78383f](https://github.com/assurance-maladie-digital/design-system/commit/f78383f3b54edea2771ed089df96f77683939f37))
 
 - ♻️ **Refactoring**
   - **FranceConnectBtn:** Suppression de la valeur par défaut de la prop `href` ([#1333](https://github.com/assurance-maladie-digital/design-system/pull/1333)) ([a9f751c](https://github.com/assurance-maladie-digital/design-system/commit/a9f751c7b1e3bdebab5a23394f1557737d876260))

--- a/packages/docs/src/data/api/notification-bar.ts
+++ b/packages/docs/src/data/api/notification-bar.ts
@@ -14,7 +14,8 @@ export const api: Api = {
 			...customizable(`{
 	snackBar: 'VSnackbar',
 	icon: 'VIcon',
-	btn: 'VBtn'
+	btn: 'VBtn',
+	closeIcon: 'VIcon'
 }`)
 		]
 	}

--- a/packages/vue-dot/dev/main.ts
+++ b/packages/vue-dot/dev/main.ts
@@ -10,15 +10,26 @@ import './vue-dot';
 import App from './App.vue';
 
 import VueRouter from 'vue-router';
+import Vuex from 'vuex';
+import { RootState } from '../src/modules';
+import { notification } from '../src/modules/notification';
 
 Vue.use(VueRouter);
+Vue.use(Vuex);
 
 const router = new VueRouter({
 	mode: 'history'
 });
 
+const store = new Vuex.Store<RootState>({
+	modules: {
+		notification
+	}
+});
+
 new Vue({
 	vuetify,
 	router,
+	store,
 	render: (h) => h(App)
 }).$mount('#app');

--- a/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
+++ b/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
@@ -4,12 +4,14 @@
 		:value="Boolean(notification)"
 		:color="snackbarColor"
 		role="status"
+		class="vd-notification-bar"
 	>
 		<div
 			v-if="notification"
 			class="d-flex align-center"
 		>
 			<VIcon
+				v-if="!isMobile"
 				v-bind="options.icon"
 				class="vd-notification-icon"
 			>
@@ -25,9 +27,19 @@
 					...attrs,
 					...options.btn
 				}"
+				:icon="isMobile"
 				@click="clearNotification"
 			>
-				{{ closeBtnText }}
+				<span :class="{ 'd-sr-only': isMobile }">
+					{{ closeBtnText }}
+				</span>
+
+				<VIcon
+					v-if="isMobile"
+					v-bind="options.closeIcon"
+				>
+					{{ closeIcon }}
+				</VIcon>
 			</VBtn>
 		</template>
 	</VSnackbar>
@@ -51,7 +63,8 @@
 		mdiCheck,
 		mdiAlertCircle,
 		mdiInformation,
-		mdiAlert
+		mdiAlert,
+		mdiClose
 	} from '@mdi/js';
 
 	const Props = Vue.extend({
@@ -84,6 +97,8 @@
 		}
 	})
 	export default class NotificationBar extends MixinsDeclaration {
+		closeIcon = mdiClose;
+
 		// We need to declare these types since there is
 		// no Vuex instance when building the library
 		clearNotification!: () => void;
@@ -106,6 +121,10 @@
 			return this.notification.icon || this.iconMapping[this.notification.type];
 		}
 
+		get isMobile(): boolean {
+			return this.$vuetify.breakpoint.xs;
+		}
+
 		created() {
 			// Remove notification if present when the
 			// component is loaded the first time
@@ -122,8 +141,12 @@
 </script>
 
 <style lang="scss" scoped>
+	// Use min-width to avoid shrinking with flexbox
+	.vd-notification-bar ::v-deep .v-snack__wrapper {
+		min-width: 0;
+	}
+
 	.vd-notification-icon {
-		// Use min-width to avoid shrinking with flexbox
 		min-width: 24px;
 	}
 </style>

--- a/packages/vue-dot/src/patterns/NotificationBar/tests/__snapshots__/NotificationBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/NotificationBar/tests/__snapshots__/NotificationBar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotificationBar renders correctly 1`] = `
-<vsnackbar-stub tag="div" value="true" top="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status">
+<vsnackbar-stub tag="div" value="true" top="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status" class="vd-notification-bar">
   <div class="d-flex align-center">
     <vicon-stub color="white" class="vd-notification-icon mr-2">
       M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z
@@ -13,7 +13,7 @@ exports[`NotificationBar renders correctly 1`] = `
 `;
 
 exports[`NotificationBar renders correctly with a custom icon 1`] = `
-<vsnackbar-stub tag="div" value="true" top="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status">
+<vsnackbar-stub tag="div" value="true" top="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status" class="vd-notification-bar">
   <div class="d-flex align-center">
     <vicon-stub color="white" class="vd-notification-icon mr-2">
       test-icon


### PR DESCRIPTION
## Description

Correction de l'affichage du composant `NotificationBar` sur les écrans mobiles.

Avant :

![screenshot-localhost_8080-2021 12 16-16_46_27](https://user-images.githubusercontent.com/10298932/146409248-a11db2a0-54bb-41ad-84ec-5cc990f73ccf.png)

Après :

![screenshot-localhost_8080-2021 12 16-16_49_00](https://user-images.githubusercontent.com/10298932/146409281-6deced81-31df-4ed2-945b-e1b9aa0739f1.png)

## Playground

<details>

```vue
<template>
	<div>
		<NotificationBar />

		<VBtn
			color="primary"
			@click="notifyUser"
		>
			Envoyer une notification
		</VBtn>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { mapActions, mapState } from 'vuex';

	@Component({
		computed: mapState('notification', ['notification']),
		methods: mapActions('notification', ['addNotification'])
	})
	export default class Playground extends Vue {
		notifyUser(): void {
			this.addNotification({
				type: 'error',
				message: 'L’application est en maintenance, veuillez nous excuser pour la gêne occasionnée.'
			});
		}
	}
</script>
```

</details>

## Type de changement

- Correction de bug
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
