### PR TITLE
🐛 vue-dot: Fix menu display with text-field-activator in DatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Vue Dot
 
 - 🐛 **Corrections de bugs**
-  - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675))
+  - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675)) ([b18214c](https://github.com/assurance-maladie-digital/design-system/commit/b18214ce5646382b281adb62fe96896b588f27df))
+  - **DatePicker:** Correction de l'affichage du menu avec la prop `text-field-activator` ([#1678](https://github.com/assurance-maladie-digital/design-system/pull/1678))
 
 ### Interne
 

--- a/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
@@ -18,7 +18,7 @@
 				:error.sync="internalErrorProp"
 				class="vd-date-picker-text-field"
 				@blur="textFieldBlur"
-				@click="textFieldClicked"
+				@click.native="textFieldClicked"
 				@paste.prevent="saveFromPasted"
 				@keydown.enter.prevent="saveFromTextField"
 				@change="dateFormatted = $event"


### PR DESCRIPTION
## Description

Correction de l'affichage du menu avec la prop `text-field-activator`.

Actuellement, avec la prop `text-field-activator`, seul la zone bleue de gauche affiche le menu.
Avec ce correctif, toute la zone bleue et la zone verte affichent maintenant le menu.

![Capture d’écran 2021-12-17 144338](https://user-images.githubusercontent.com/10298932/146553454-bc034973-41c9-48cc-83ad-7d430e3e7d25.png)

## Playground

<details>

```vue
<template>
	<DatePicker
		outlined
		text-field-activator
		text-field-class="vd-form-input"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
