### PR TITLE
🐛 form-builder: Fix RangeField display on mobile & remove VForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 - 🐛 **Corrections de bugs**
   - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675)) ([b18214c](https://github.com/assurance-maladie-digital/design-system/commit/b18214ce5646382b281adb62fe96896b588f27df))
-  - **DatePicker:** Correction de l'affichage du menu avec la prop `text-field-activator` ([#1678](https://github.com/assurance-maladie-digital/design-system/pull/1678))
+  - **DatePicker:** Correction de l'affichage du menu avec la prop `text-field-activator` ([#1678](https://github.com/assurance-maladie-digital/design-system/pull/1678)) ([f50dad2](https://github.com/assurance-maladie-digital/design-system/commit/f50dad2c031536e2720fdf3d6b8bd3b5ecd5f1db))
+
+### FormBuilder
+
+- 🐛 **Corrections de bugs**
+  - **RangeField:** Correction de l'affichage sur les écrans mobiles et suppression du `VForm` à l'intérieur du champ ([#1680](https://github.com/assurance-maladie-digital/design-system/pull/1680))
 
 ### Interne
 

--- a/packages/form-builder/src/components/FormField/fields/RangeField.vue
+++ b/packages/form-builder/src/components/FormField/fields/RangeField.vue
@@ -1,37 +1,34 @@
 <template>
 	<div class="vd-filter-range">
-		<VForm class="d-flex">
-			<VCol
-				cols="12"
-				sm="6"
-			>
-				<VTextField
-					:value="rangeValue[0]"
-					:label="minLabel"
-					outlined
-					@input="updateMinValue"
-				/>
-			</VCol>
+		<div
+			:class="{ 'flex-column': isMobile }"
+			class="d-flex flex-wrap max-width-none ma-n3"
+		>
+			<VTextField
+				:value="rangeValue[0]"
+				:label="minLabel"
+				hide-details
+				outlined
+				class="ma-3"
+				@input="updateMinValue"
+			/>
 
-			<VCol
-				cols="12"
-				sm="6"
-			>
-				<VTextField
-					:value="rangeValue[1]"
-					:label="maxLabel"
-					outlined
-					@input="updateMaxValue"
-				/>
-			</VCol>
-		</VForm>
+			<VTextField
+				:value="rangeValue[1]"
+				:label="maxLabel"
+				hide-details
+				outlined
+				class="ma-3"
+				@input="updateMaxValue"
+			/>
+		</div>
 
 		<VRangeSlider
 			v-model="rangeValue"
 			:max="field.max"
 			:min="field.min"
 			hide-details
-			class="align-center mb-6"
+			class="align-center mt-2 mb-6"
 			@change="emitChangeEvent(rangeValue)"
 		>
 			<template #prepend>
@@ -80,6 +77,10 @@
 	})
 	export default class RangeField extends MixinsDeclaration {
 		rangeValue: number[] = [];
+
+		get isMobile(): boolean {
+			return this.$vuetify.breakpoint.xs;
+		}
 
 		get minLabel(): string {
 			return this.field.fieldOptions?.minFieldLabel as string || locales.minLabel;


### PR DESCRIPTION
## Description

Correction de l'affichage sur les écrans mobiles et suppression du `VForm` à l'intérieur du champ `RangeField`.

## Playground

<details>

```vue
<template>
	<div>
		<FormField v-model="rangeField" />
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { Field } from '../src/components/FormField/types';

	@Component
	export default class Playground extends Vue {
		rangeField: Field = {
			type: 'range',
			min: 0,
			max: 100,
			value: null,
			fieldOptions: {
				outlined: true
			}
		};
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
