### PR TITLE
🐛 form-builder: Fix PeriodField display on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### FormBuilder
 
 - 🐛 **Corrections de bugs**
-  - **RangeField:** Correction de l'affichage sur les écrans mobiles et suppression du `VForm` à l'intérieur du champ ([#1680](https://github.com/assurance-maladie-digital/design-system/pull/1680))
+  - **RangeField:** Correction de l'affichage sur les écrans mobiles et suppression du `VForm` à l'intérieur du champ ([#1680](https://github.com/assurance-maladie-digital/design-system/pull/1680)) ([923d65c](https://github.com/assurance-maladie-digital/design-system/commit/923d65cc5ff0ff79487aa3a285ccffa60b4c3484))
+  - **PeriodField:** Correction de l'affichage sur les écrans mobiles ([#1681](https://github.com/assurance-maladie-digital/design-system/pull/1681))
 
 ### Interne
 

--- a/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -131,9 +131,9 @@ exports[`FormBuilder renders correctly 1`] = `
         <!---->
       </h4>
       <!---->
-      <div class="d-flex flex-wrap max-width-none mx-n3">
+      <div class="vd-period-field d-flex flex-wrap max-width-none mx-n3">
         <div class="v-menu">
-          <div class="v-input vd-date-picker-text-field theme--light v-text-field v-text-field--enclosed v-text-field--outlined vd-no-prepend-icon vd-form-input flex-grow-0 mx-3">
+          <div class="v-input vd-date-picker-text-field theme--light v-text-field v-text-field--enclosed v-text-field--outlined vd-no-prepend-icon vd-period-field-picker flex-grow-1 mx-3">
             <div class="v-input__prepend-outer"><button type="button" class="v-btn v-btn--icon v-btn--round theme--light v-size--default" aria-label="Ouvrir le calendrier" style="display: none;"><span class="v-btn__content"><span aria-hidden="true" class="v-icon notranslate theme--light" style="color: rgb(128, 128, 128); caret-color: #808080;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z"></path></svg></span></span></button></div>
             <div class="v-input__control">
               <div class="v-input__slot">
@@ -155,7 +155,7 @@ exports[`FormBuilder renders correctly 1`] = `
           <!---->
         </div>
         <div class="v-menu">
-          <div class="v-input vd-date-picker-text-field theme--light v-text-field v-text-field--enclosed v-text-field--outlined vd-no-prepend-icon vd-form-input flex-grow-0 mx-3">
+          <div class="v-input vd-date-picker-text-field theme--light v-text-field v-text-field--enclosed v-text-field--outlined vd-no-prepend-icon vd-period-field-picker flex-grow-1 mx-3">
             <div class="v-input__prepend-outer"><button type="button" class="v-btn v-btn--icon v-btn--round theme--light v-size--default" aria-label="Ouvrir le calendrier" style="display: none;"><span class="v-btn__content"><span aria-hidden="true" class="v-icon notranslate theme--light" style="color: rgb(128, 128, 128); caret-color: #808080;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z"></path></svg></span></span></button></div>
             <div class="v-input__control">
               <div class="v-input__slot">

--- a/packages/form-builder/src/components/FormField/fields/PeriodField.vue
+++ b/packages/form-builder/src/components/FormField/fields/PeriodField.vue
@@ -1,10 +1,10 @@
 <template>
-	<div class="d-flex flex-wrap max-width-none mx-n3">
+	<div class="vd-period-field d-flex flex-wrap max-width-none mx-n3">
 		<DatePicker
 			v-model="periodValue.from"
 			v-bind="fieldOptionsFrom"
 			:vuetify-options="fieldOptionsFrom"
-			text-field-class="vd-form-input flex-grow-0 mx-3"
+			text-field-class="vd-period-field-picker flex-grow-1 mx-3"
 			@change="dateUpdated"
 		/>
 
@@ -13,7 +13,7 @@
 			v-bind="fieldOptionsTo"
 			:vuetify-options="fieldOptionsTo"
 			:start-date="periodValue.from"
-			text-field-class="vd-form-input flex-grow-0 mx-3"
+			text-field-class="vd-period-field-picker flex-grow-1 mx-3"
 			@change="dateUpdated"
 		/>
 	</div>
@@ -94,3 +94,11 @@
 		}
 	}
 </script>
+
+<style lang="scss" scoped>
+	@import '@cnamts/design-tokens/dist/tokens';
+
+	.vd-period-field ::v-deep .vd-period-field-picker {
+		max-width: $vd-input-medium;
+	}
+</style>


### PR DESCRIPTION
## Description

Correction de l'affichage du composant `PeriodField` sur les écrans mobiles.

## Playground

<details>

```vue
<template>
	<div>
		<FormField v-model="periodField" />
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { Field } from '../src/components/FormField/types';

	@Component
	export default class Playground extends Vue {
		periodField: Field = {
			type: 'period',
			value: {
				from: null,
				to: null
			},
			fieldOptions: {
				from: {
					label: 'Début',
					outlined: true
				},
				to: {
					label: 'Fin',
					outlined: true
				}
			}
		};
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
