### PR TITLE
🐛 vue-dot: Fix TableToolbar display on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 - 🐛 **Corrections de bugs**
   - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675)) ([b18214c](https://github.com/assurance-maladie-digital/design-system/commit/b18214ce5646382b281adb62fe96896b588f27df))
   - **DatePicker:** Correction de l'affichage du menu avec la prop `text-field-activator` ([#1678](https://github.com/assurance-maladie-digital/design-system/pull/1678)) ([f50dad2](https://github.com/assurance-maladie-digital/design-system/commit/f50dad2c031536e2720fdf3d6b8bd3b5ecd5f1db))
+  - **TableToolbar:** Correction de l'affichage sur les écrans mobiles ([#1682](https://github.com/assurance-maladie-digital/design-system/pull/1682))
 
 ### FormBuilder
 
 - 🐛 **Corrections de bugs**
   - **RangeField:** Correction de l'affichage sur les écrans mobiles et suppression du `VForm` à l'intérieur du champ ([#1680](https://github.com/assurance-maladie-digital/design-system/pull/1680)) ([923d65c](https://github.com/assurance-maladie-digital/design-system/commit/923d65cc5ff0ff79487aa3a285ccffa60b4c3484))
-  - **PeriodField:** Correction de l'affichage sur les écrans mobiles ([#1681](https://github.com/assurance-maladie-digital/design-system/pull/1681))
+  - **PeriodField:** Correction de l'affichage sur les écrans mobiles ([#1681](https://github.com/assurance-maladie-digital/design-system/pull/1681)) ([ae36361](https://github.com/assurance-maladie-digital/design-system/commit/ae36361bd4e045184262e97deedb03e8db16135c))
 
 ### Interne
 

--- a/packages/vue-dot/src/patterns/TableToolbar/TableToolbar.vue
+++ b/packages/vue-dot/src/patterns/TableToolbar/TableToolbar.vue
@@ -129,7 +129,11 @@
 		}
 
 		get textFieldClasses(): string {
-			const fieldClass = this.$vuetify.breakpoint.xs ? 'vd-form-input-s' : 'vd-form-input';
+			let fieldClass = this.$vuetify.breakpoint.xs ? 'vd-form-input-s' : 'vd-form-input';
+
+			if (this.showAddBtn) {
+				fieldClass += ' mr-6';
+			}
 
 			return `${fieldClass} flex-grow-0`;
 		}
@@ -138,6 +142,7 @@
 
 <style lang="scss" scoped>
 	.vd-table-toolbar ::v-deep .v-toolbar__content {
+		width: 100%;
 		flex-wrap: wrap;
 	}
 </style>

--- a/packages/vue-dot/src/patterns/TableToolbar/config.ts
+++ b/packages/vue-dot/src/patterns/TableToolbar/config.ts
@@ -1,12 +1,15 @@
 export const config = {
 	toolbar: {
 		flat: true,
-		color: 'white'
+		color: 'white',
+		height: 'auto',
+		minHeight: '56px',
+		class: 'd-flex'
 	},
 	addBtn: {
 		outlined: true,
 		color: 'primary',
-		class: 'px-2 px-md-4 ml-6',
+		class: 'my-1 px-2 px-md-4',
 		minWidth: '44px'
 	},
 	addIconLabel: {

--- a/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/TableToolbar/tests/__snapshots__/TableToolbar.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableToolbar renders correctly 1`] = `
-<vtoolbar-stub color="white" tag="header" extensionheight="48" flat="true" src="" class="vd-table-toolbar">
+<vtoolbar-stub color="white" height="auto" minheight="56px" tag="header" extensionheight="48" flat="true" src="" class="vd-table-toolbar d-flex">
   <p class="mb-0 font-weight-bold mr-4">
     1/2 lignes
   </p>
   <vspacer-stub tag="div"></vspacer-stub>
-  <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0"></vtextfield-stub>
-  <vbtn-stub color="primary" minwidth="44px" outlined="true" tag="button" activeclass="" type="button" class="px-2 px-md-4 ml-6">
+  <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input mr-6 flex-grow-0"></vtextfield-stub>
+  <vbtn-stub color="primary" minwidth="44px" outlined="true" tag="button" activeclass="" type="button" class="my-1 px-2 px-md-4">
     <vicon-stub>
       M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z
     </vicon-stub> <span class="mr-1">
@@ -18,8 +18,8 @@ exports[`TableToolbar renders correctly 1`] = `
 `;
 
 exports[`TableToolbar renders correctly when loading 1`] = `
-<header class="vd-table-toolbar v-sheet theme--light v-toolbar v-toolbar--flat white" style="height: 64px;">
-  <div class="v-toolbar__content" style="height: 64px;">
+<header class="vd-table-toolbar v-sheet theme--light v-toolbar v-toolbar--flat white d-flex" style="min-height: 56px;">
+  <div class="v-toolbar__content">
     <p class="mb-0 font-weight-bold mr-4">
       0/1 ligne
     </p>
@@ -43,8 +43,8 @@ exports[`TableToolbar renders correctly when loading 1`] = `
 `;
 
 exports[`TableToolbar renders correctly with content slot 1`] = `
-<header class="vd-table-toolbar v-sheet theme--light v-toolbar v-toolbar--flat white" style="height: 64px;">
-  <div class="v-toolbar__content" style="height: 64px;">
+<header class="vd-table-toolbar v-sheet theme--light v-toolbar v-toolbar--flat white d-flex" style="min-height: 56px;">
+  <div class="v-toolbar__content">
     <p class="mb-0 font-weight-bold mr-4">
       0/1 ligne
     </p>
@@ -68,7 +68,7 @@ exports[`TableToolbar renders correctly with content slot 1`] = `
 `;
 
 exports[`TableToolbar renders correctly with no items 1`] = `
-<vtoolbar-stub color="white" tag="header" extensionheight="48" flat="true" src="" class="vd-table-toolbar">
+<vtoolbar-stub color="white" height="auto" minheight="56px" tag="header" extensionheight="48" flat="true" src="" class="vd-table-toolbar d-flex">
   <!---->
   <vspacer-stub tag="div"></vspacer-stub>
   <vtextfield-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" appendicon="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z" backgroundcolor="" hidedetails="true" label="Rechercher" loaderheight="2" clearable="true" clearicon="$clear" singleline="true" type="text" class="vd-form-input flex-grow-0"></vtextfield-stub>


### PR DESCRIPTION
## Description

Correction de l'affichage du composant `TableToolbar` sur les écrans mobiles.

## Playground

<details>

```vue
<template>
	<VDataTable
		:headers="headers"
		:items="items"
		:search="search"
		hide-default-footer
	>
		<template #top>
			<TableToolbar
				v-model="search"
				:nb-total="items.length"
				show-add-btn
			/>
		</template>
	</VDataTable>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { DataTableHeader } from 'vuetify';

	@Component
	export default class Playground extends Vue {
		search: string | null = null;

		headers: DataTableHeader[] = [
			{
				text: 'Nom',
				value: 'lastname'
			},
			{
				text: 'Prénom',
				value: 'firstname'
			},
			{
				text: 'Email',
				value: 'email'
			}
		];

		items = [
			{
				firstname: 'Virginie',
				lastname: 'Beauchesne',
				email: 'virginie.beauchesne@example.com'
			},
			{
				firstname: 'Étienne',
				lastname: 'Salois',
				email: 'etienne.salois@example.com'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
