### PR TITLE
🔥 docs: Remove secondary title in introduction page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,13 @@
 
 - 🐛 **Corrections de bugs**
   - **global:** Correction du décalage pour les ancres HTML ([#1712](https://github.com/assurance-maladie-digital/design-system/pull/1712)) ([28fa1a8](https://github.com/assurance-maladie-digital/design-system/commit/28fa1a864c2fe88d39c1a8126440a309c7070adf))
-  - **introduction:** Correction de l'affichage de la date de dernière publication ([#1715](https://github.com/assurance-maladie-digital/design-system/pull/1715))
+  - **introduction:** Correction de l'affichage de la date de dernière publication ([#1715](https://github.com/assurance-maladie-digital/design-system/pull/1715)) ([29922af](https://github.com/assurance-maladie-digital/design-system/commit/29922af2786eee6be12c5a17a30637102b408e62))
 
 - ♻️ **Refactoring**
   - **accessibility:** Désactivation du tri sur la colonne "Critère" ([#1713](https://github.com/assurance-maladie-digital/design-system/pull/1713)) ([a943d5e](https://github.com/assurance-maladie-digital/design-system/commit/a943d5eb540c704f2a47564d0dfa810cb3e2354d))
+
+- 🔥 **Suppressions**
+  - **introduction:** Suppression du titre secondaire ([#1716](https://github.com/assurance-maladie-digital/design-system/pull/1716))
 
 - 📝 **Documentation**
   - **global:** Ajout de la page accessibilité ([#1707](https://github.com/assurance-maladie-digital/design-system/pull/1707)) ([648bccf](https://github.com/assurance-maladie-digital/design-system/commit/648bccfa69d4da8766f5dc53506df94ce881dddd))

--- a/packages/docs/src/components/global/DocHomePageHeader.vue
+++ b/packages/docs/src/components/global/DocHomePageHeader.vue
@@ -49,10 +49,6 @@
 				</div>
 			</div>
 		</div>
-
-		<h2 class="secondary--text text-md-h3 text-sm-h4 text-h5 mb-10">
-			Introduction
-		</h2>
 	</div>
 </template>
 

--- a/packages/docs/src/content/demarrer/introduction.md
+++ b/packages/docs/src/content/demarrer/introduction.md
@@ -13,7 +13,7 @@ Notre Design System est un **référentiel** au service des produits digitaux de
 
 Ce Design System est un **produit vivant**, voué à évoluer. Disponible en ***open source***, il a pour ambition d’être généralisé le plus largement possible à l’ensemble des services de l’Assurance Maladie, afin d’offrir la meilleure **expérience utilisateur** aux assurés, professionnels de santé, employeurs et agents.
 
-### À quoi sert le Design System ?
+## À quoi sert le Design System ?
 
 <doc-indent>
 
@@ -25,7 +25,7 @@ L’intérêt d’utiliser notre Design System répond à trois principaux besoi
 
 En accord avec la démarche centrée sur les utilisateurs, notre Design System est pensé pour répondre continuellement aux besoins des utilisateurs tout en respectant les réalités industrielles et économiques. **Depuis 2017, plus de 20 produits et services numériques ont été développés avec notre Design System faisant de lui une référence en tant que Design System pour répondre aux enjeux du secteur de la santé**.
 
-### Qui peut l’utiliser ?
+## Qui peut l’utiliser ?
 
 <doc-indent>
 


### PR DESCRIPTION
## Description

Suppression du titre secondaire dans la page d'introduction de la documentation.

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
