### PR TITLE
♻️ vue-dot: Refactor menu button on mobile in HeaderNavigationBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - ✨ **Nouvelles fonctionnalités**
   - **ErrorPage:** Affichage de l'ID de support ([#1724](https://github.com/assurance-maladie-digital/design-system/pull/1724)) ([a362e5d](https://github.com/assurance-maladie-digital/design-system/commit/a362e5d28791e7c53608bc7bf7b27cbcc0003594))
 
+- ♻️ **Refactoring**
+  - **HeaderBar:** Refonte du bouton pour activer le menu sur les écrans mobiles ([#1726](https://github.com/assurance-maladie-digital/design-system/pull/1726))
+
 - 🐛 **Corrections de bugs**
   - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675)) ([b18214c](https://github.com/assurance-maladie-digital/design-system/commit/b18214ce5646382b281adb62fe96896b588f27df))
   - **DatePicker:** Correction de l'affichage du menu avec la prop `text-field-activator` ([#1678](https://github.com/assurance-maladie-digital/design-system/pull/1678)) ([f50dad2](https://github.com/assurance-maladie-digital/design-system/commit/f50dad2c031536e2720fdf3d6b8bd3b5ecd5f1db))
@@ -13,10 +16,10 @@
 ### Vue Dash
 
 - 🐛 **Corrections de bugs**
-  - **template:** Correction du hook de qualité manquant ([#1725](https://github.com/assurance-maladie-digital/design-system/pull/1725))
+  - **template:** Correction du hook de qualité manquant ([#1725](https://github.com/assurance-maladie-digital/design-system/pull/1725)) ([d06aca0](https://github.com/assurance-maladie-digital/design-system/commit/d06aca0703cdacf61da6ce5958f168f9615a00f8))
 
 - ♻️ **Refactoring**
-  - **jest:** Utilisation de TypeScript pour la configuration de Jest ([#1684](https://github.com/assurance-maladie-digital/design-system/pull/1684)) ([189652b](https://github.com/assurance-maladie-digital/design-system/commit/189652b335249b359d8c50af3b646c5a0cd30a77))
+  - **template:** Utilisation de TypeScript pour la configuration de Jest ([#1684](https://github.com/assurance-maladie-digital/design-system/pull/1684)) ([189652b](https://github.com/assurance-maladie-digital/design-system/commit/189652b335249b359d8c50af3b646c5a0cd30a77))
 
 - ✅ **Tests**
   - **template:** Ajout d'un test sur `AppHeader` ([#1683](https://github.com/assurance-maladie-digital/design-system/pull/1683)) ([e18f57c](https://github.com/assurance-maladie-digital/design-system/commit/e18f57cb69c0214fe73ee6dd381a92efd623bbc5))

--- a/packages/docs/src/components/DocHeader.vue
+++ b/packages/docs/src/components/DocHeader.vue
@@ -14,23 +14,16 @@
 				<VBtn
 					:aria-label="menuBtnActionLabel"
 					:elevation="0"
-					width="36px"
-					height="36px"
-					icon
+					color="transparent"
 					class="mx-n2"
 					@click="emitDrawerEvent"
 				>
-					<VIcon>
+					<VIcon class="mr-2">
 						{{ menuIcon }}
 					</VIcon>
-				</VBtn>
 
-				<h2
-					v-if="menuBtnLabel"
-					class="text-body-2 text-sm-subtitle-1 ml-4"
-				>
-					{{ menuBtnLabel }}
-				</h2>
+					Menu
+				</VBtn>
 			</div>
 		</template>
 	</HeaderBar>
@@ -47,10 +40,6 @@
 			drawer: {
 				type: Boolean,
 				default: false
-			},
-			menuBtnLabel: {
-				type: String,
-				default: undefined
 			}
 		}
 	});

--- a/packages/docs/src/pages/_.vue
+++ b/packages/docs/src/pages/_.vue
@@ -1,9 +1,6 @@
 <template>
 	<VApp>
-		<DocHeader
-			:drawer.sync="drawer"
-			:menu-btn-label="document.title"
-		/>
+		<DocHeader :drawer.sync="drawer" />
 
 		<DocDrawer v-model="drawer" />
 

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/HeaderNavigationBar.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/HeaderNavigationBar.vue
@@ -22,14 +22,9 @@
 						<VIcon v-bind="options.menuIcon">
 							{{ menuIcon }}
 						</VIcon>
-					</VBtn>
 
-					<h2
-						v-if="activeTabLabel"
-						class="text-body-2 text-sm-subtitle-1 ml-4"
-					>
-						{{ activeTabLabel }}
-					</h2>
+						{{ locales.menu }}
+					</VBtn>
 				</div>
 
 				<VTabs
@@ -57,7 +52,6 @@
 	import Vue, { PropType } from 'vue';
 	import Component, { mixins } from 'vue-class-component';
 
-	import { RawLocation } from 'vue-router';
 	import { mdiClose, mdiMenu } from '@mdi/js';
 
 	import { NavigationItem } from '../types';
@@ -115,49 +109,10 @@
 			return colorMapping[this.theme];
 		}
 
-		get activeTabLabel(): string | undefined {
-			if (this.tab === null) {
-				return undefined;
-			}
-
-			let item: NavigationItem | undefined;
-
-			if (typeof this.tab === 'string') {
-				item = this.findItemByPath(this.tab);
-			} else {
-				item = this.items[this.tab];
-			}
-
-			return item?.label;
-		}
-
 		get menuBtnActionLabel(): string {
 			const action = this.drawer ? locales.close : locales.open;
 
 			return locales.menuBtnLabel(action);
-		}
-
-		findItemByPath(tab: string): NavigationItem | undefined {
-			return this.items.find((item) => tab === this.getItemPath(item));
-		}
-
-		/**
-		 * Get item by path using Vuetify resolution algorithm
-		 *
-		 * @see https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VTabs/VTab.ts#L51
-		 */
-		getItemPath(item: NavigationItem): string {
-			let path: string;
-
-			if (item.to && typeof item.to === 'object') {
-				const resolve = this.$router.resolve(item.to as RawLocation, this.$route);
-				path = resolve.href;
-			} else {
-				const itemTo = item.to as unknown as string;
-				path = itemTo || item.href || '';
-			}
-
-			return path.replace('#', '');
 		}
 
 		toggleDrawer(value: boolean): void {

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/config.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/config.ts
@@ -8,11 +8,12 @@ export const config = {
 		color: 'transparent'
 	},
 	menuBtn: {
-		width: 36,
-		height: 36,
-		icon: true,
 		elevation: 0,
-		class: 'mx-n2'
+		class: 'px-2 mx-n2',
+		color: 'transparent'
+	},
+	menuIcon: {
+		class: 'mr-2'
 	},
 	tabs: {
 		backgroundColor: 'transparent'

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/locales.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/locales.ts
@@ -1,5 +1,6 @@
 export const locales = {
 	menuBtnLabel: (action: string): string => `${action} le menu`,
 	open: 'Ouvrir',
-	close: 'Fermer'
+	close: 'Fermer',
+	menu: 'Menu'
 };


### PR DESCRIPTION
## Description

Refonte du bouton pour activer le menu sur les écrans mobiles dans le composant `HeaderNavigationBar`.

## Playground

<details>

```vue
<template>
	<HeaderBar :navigation-items="navigationItems" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { NavigationItem } from '@cnamts/vue-dot/src/patterns/HeaderBar/types';

	@Component
	export default class Playground extends Vue {
		navigationItems: NavigationItem[] = [
			{
				label: 'Accueil'
			},
			{
				label: 'Mes projets'
			},
			{
				label: 'Mes outils'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
