### PR TITLE
📝 docs: Use text instead of bash language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
   - **roadmap:** Mise à jour du lien pour créer une nouvelle demande et de la taille du bouton de demande ([#1720](https://github.com/assurance-maladie-digital/design-system/pull/1720)) ([07a053d](https://github.com/assurance-maladie-digital/design-system/commit/07a053da2a8c1134fff3651e60fdbc1b9472dd0d))
   - **components:** Suppression de la couleur de fond au survol des lignes ([#1750](https://github.com/assurance-maladie-digital/design-system/pull/1750)) ([4ed747b](https://github.com/assurance-maladie-digital/design-system/commit/4ed747baee69f72b0838da0479b4743763b4bf57))
   - **global:** Mise à jour des styles du composant `DocExpansionPanels` ([#1751](https://github.com/assurance-maladie-digital/design-system/pull/1751)) ([a784552](https://github.com/assurance-maladie-digital/design-system/commit/a784552e34a6f6ad557efadf4654b97146f1c1f1))
-  - **global:** Mise à jour des couleurs de fond ([#1752](https://github.com/assurance-maladie-digital/design-system/pull/1752))
+  - **global:** Mise à jour des couleurs de fond ([#1752](https://github.com/assurance-maladie-digital/design-system/pull/1752)) ([51924e7](https://github.com/assurance-maladie-digital/design-system/commit/51924e7770ac9c06572d73e5fd27e24fa1403acc))
 
 - 🔥 **Suppressions**
   - **introduction:** Suppression du titre secondaire ([#1716](https://github.com/assurance-maladie-digital/design-system/pull/1716)) ([e35d2c7](https://github.com/assurance-maladie-digital/design-system/commit/e35d2c7b401163ad4c6b7e7f7912d67e68f70825))
@@ -71,6 +71,7 @@
   - **explorer:** Mise à jour du content du fichier `base.css` ([#1714](https://github.com/assurance-maladie-digital/design-system/pull/1714)) ([d1ac04b](https://github.com/assurance-maladie-digital/design-system/commit/d1ac04b7c3a3182c301cfcd820c6c8bcd3b49335))
   - **components:** Ajout d'informations sur les propriétés transmises aux composants ([#1734](https://github.com/assurance-maladie-digital/design-system/pull/1734)) ([ce8da80](https://github.com/assurance-maladie-digital/design-system/commit/ce8da807adf8d4d10ddbed25f10c5d11c160ef80))
   - **UploadWorkflow:** Mise à jour de la description de la prop `customizable` ([#1740](https://github.com/assurance-maladie-digital/design-system/pull/1740)) ([f792763](https://github.com/assurance-maladie-digital/design-system/commit/f79276328582a2a9d776bad08c8a8c542e026e97))
+  - **global:** Utilisation de `text` à la place du langage `bash` pour représenter du texte ([#1753](https://github.com/assurance-maladie-digital/design-system/pull/1753))
 
 ### Interne
 

--- a/packages/docs/src/content/demarrer/contribuer.md
+++ b/packages/docs/src/content/demarrer/contribuer.md
@@ -183,11 +183,11 @@ Vous pouvez également utiliser [ts-node](https://www.npmjs.com/package/ts-node)
 
 Les messages de commit doivent suivre la convention `<gitmoji> <scope>: <message>`, par exemple :
 
-```bash
+```text
 ✨ vue-dot: Add DatePicker
 ```
 
-```bash
+```text
 🐛 vue-dash: Fix missing data-cy attributes
 ```
 

--- a/packages/docs/src/content/explorer/_browserslistrc.md
+++ b/packages/docs/src/content/explorer/_browserslistrc.md
@@ -10,7 +10,7 @@ Il n’est pas recommandé d’éditer ce fichier.
 
 Par défaut, le fichier contient la configuration suivante :
 
-```bash
+```text
 > 1%
 IE 11
 last 2 versions

--- a/packages/docs/src/content/explorer/public/robots.txt.md
+++ b/packages/docs/src/content/explorer/public/robots.txt.md
@@ -8,7 +8,7 @@ Il n’est pas recommandé d’éditer ce fichier.
 
 Par défaut, le fichier contient la configuration suivante :
 
-```bash
+```text
 User-agent: *
 Disallow:
 ```

--- a/packages/docs/src/content/guides/authentification-token.md
+++ b/packages/docs/src/content/guides/authentification-token.md
@@ -7,7 +7,7 @@ description: Récupération, stockage et utilisation d’un token d’authentifi
 
 Lorsque le token est passé à l’application via une URL de cette forme :
 
-```bash
+```text
 https://example.com#access_token=monToken
 ```
 

--- a/packages/docs/src/content/guides/nouvelle-page.md
+++ b/packages/docs/src/content/guides/nouvelle-page.md
@@ -13,7 +13,7 @@ Une page est une *Vue* qui contient des composants et qui sera affichée en alla
 
 Pour cela, vous pouvez créer un nouveau fichier `UserDeclaration.vue` dans le dossier `views` :
 
-```bash
+```text
 views/
 ├── tests/
 ├── About.vue


### PR DESCRIPTION
## Description

Utilisation de `text` à la place du langage `bash` pour représenter du texte dans la documentation.

## Type de changement

- Documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
