### PR TITLE
♻️ vue-dash: Use NotificationModule interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - **FooterBar:** Transmission des attributs au composant ([#1733](https://github.com/assurance-maladie-digital/design-system/pull/1733)) ([0e0f810](https://github.com/assurance-maladie-digital/design-system/commit/0e0f8101e2c68838b2195887bcbef1233ab3be84))
   - **FooterWrapper/FooterBtn:** Ajout de logs de dépréciation ([#1767](https://github.com/assurance-maladie-digital/design-system/pull/1767)) ([432b93a](https://github.com/assurance-maladie-digital/design-system/commit/432b93a95f0f10ea8e9635532ace6235cfa0074e))
   - **types:** Ajout de l'interface `VForm` ([#1769](https://github.com/assurance-maladie-digital/design-system/pull/1769)) ([68ec7ee](https://github.com/assurance-maladie-digital/design-system/commit/68ec7ee6f67b5577bf16948a0ea75445dc29fe2c))
-  - **notification:** Ajout de l'interface `NotificationModule` ([#1771](https://github.com/assurance-maladie-digital/design-system/pull/1771))
+  - **notification:** Ajout de l'interface `NotificationModule` ([#1771](https://github.com/assurance-maladie-digital/design-system/pull/1771)) ([418732a](https://github.com/assurance-maladie-digital/design-system/commit/418732ab41c44f412eac476405a5c3604264599f))
 
 - 🐛 **Corrections de bugs**
   - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675)) ([b18214c](https://github.com/assurance-maladie-digital/design-system/commit/b18214ce5646382b281adb62fe96896b588f27df))
@@ -35,6 +35,7 @@
 
 - ♻️ **Refactoring**
   - **template:** Utilisation de TypeScript pour la configuration de Jest ([#1684](https://github.com/assurance-maladie-digital/design-system/pull/1684)) ([189652b](https://github.com/assurance-maladie-digital/design-system/commit/189652b335249b359d8c50af3b646c5a0cd30a77))
+  - **template:** Utilisation de l'interface `NotificationModule` ([#1772](https://github.com/assurance-maladie-digital/design-system/pull/1772))
 
 - ✅ **Tests**
   - **template:** Ajout d'un test sur `AppHeader` ([#1683](https://github.com/assurance-maladie-digital/design-system/pull/1683)) ([e18f57c](https://github.com/assurance-maladie-digital/design-system/commit/e18f57cb69c0214fe73ee6dd381a92efd623bbc5))

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/global.d.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/global.d.ts
@@ -1,7 +1,8 @@
+import { NotificationModule } from '@cnamts/vue-dot/src/modules/notification/types';
 import { VuexBindings } from './store/types';
 
 declare module 'vue/types/vue' {
-	interface Vue extends VuexBindings {
+	interface Vue extends VuexBindings, NotificationModule {
 		// Here you can add types for plugins
 		// that don't have typings
 		$maintenanceEnabled: boolean;

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/store/types.d.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/store/types.d.ts
@@ -1,15 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 export interface RootState {}
 
-import { NotificationObj } from '@cnamts/vue-dot/src/modules/notification';
-
 /**
  * This is used to properly type components using mappers from Vuex
- * see https://github.com/vuejs/vuex/pull/1121
+ * @see https://github.com/vuejs/vuex/pull/1121
  */
-export interface VuexBindings {
-	// modules/notification
-	addNotification: (notification: NotificationObj) => void;
-	clearNotification: () => void;
-	notification: NotificationObj | null;
-}
+export interface VuexBindings {}


### PR DESCRIPTION
## Description

Utilisation de l'interface `NotificationModule` dans le template du Starter Kit.

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
