### PR TITLE
✨ vue-dot: Add ignoreSpaces option to maxLength rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   - **notification:** Ajout de l'interface `NotificationModule` ([#1771](https://github.com/assurance-maladie-digital/design-system/pull/1771)) ([418732a](https://github.com/assurance-maladie-digital/design-system/commit/418732ab41c44f412eac476405a5c3604264599f))
   - **FranceConnectBtn:** Ajout d'une transition sur la couleur de fond ([#1779](https://github.com/assurance-maladie-digital/design-system/pull/1779)) ([8086b3d](https://github.com/assurance-maladie-digital/design-system/commit/8086b3d21c48746dc0312697aa25bcd28a2bdbd3))
   - **types:** Ajout de la propriété `resetValidation` à l'interface `VForm` ([#1812](https://github.com/assurance-maladie-digital/design-system/pull/1812)) ([ac7ab8f](https://github.com/assurance-maladie-digital/design-system/commit/ac7ab8f83fc2d49e9d9734991f719aea1a4b9df3))
-  - **rules:** Ajout de l'option `ignoreSpaces` à la règle de validation `minLength` ([#1815](https://github.com/assurance-maladie-digital/design-system/pull/1815))
+  - **rules:** Ajout de l'option `ignoreSpaces` à la règle de validation `minLength` ([#1815](https://github.com/assurance-maladie-digital/design-system/pull/1815)) ([f8583ba](https://github.com/assurance-maladie-digital/design-system/commit/f8583bacd2503031fd1c66af4a1bf7c81085f004))
+  - **rules:** Ajout de l'option `ignoreSpaces` à la règle de validation `maxLength` ([#1816](https://github.com/assurance-maladie-digital/design-system/pull/1816))
 
 - 🐛 **Corrections de bugs**
   - **NotificationBar:** Correction de l'affichage sur les écrans mobiles ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675)) ([b18214c](https://github.com/assurance-maladie-digital/design-system/commit/b18214ce5646382b281adb62fe96896b588f27df))

--- a/packages/docs/src/content/regles-validation/max-length.md
+++ b/packages/docs/src/content/regles-validation/max-length.md
@@ -26,7 +26,7 @@ rules = [
 Vous pouvez modifier les messages d’erreur par défaut en passant en argument un objet contenant les messages d’erreur utilisés par cette règle de validation :
 
 ```ts
-maxLengthRule = maxLength(lengthValue, {
+maxLengthRule = maxLength(lengthValue, ignoreSpaces, {
 	default: (max: number) => `La longueur maximale du champ doit être de ${max} caractères.`
 });
 ```

--- a/packages/docs/src/data/api/rules/max-length.ts
+++ b/packages/docs/src/data/api/rules/max-length.ts
@@ -10,6 +10,12 @@ export const api: Api = {
 				description: 'La longueur maximale du champ.',
 				required: true
 			},
+			{
+				name: 'ignoreSpaces',
+				type: 'boolean',
+				description: 'Ignore les espaces dans le calcul de la longueur.',
+				default: false
+			},
 			...ruleMessages(`{
 	default: (max: number) => \`La longueur maximale du champ doit être de \${max} caractères.\`
 }`)

--- a/packages/vue-dot/src/rules/maxLength/index.ts
+++ b/packages/vue-dot/src/rules/maxLength/index.ts
@@ -7,14 +7,19 @@ import { defaultErrorMessages } from './locales';
  * Check that the field does not exceeds the max length
  *
  * @param {number} max Maximum length
+ * @param {boolean} ignoreSpaces Don't count spaces in value
  * @param {ErrorMessages} [errorMessages] Custom error messages
  * @returns {ValidationRule} Validation result
  */
-export function maxLengthFn(max: number, errorMessages: ErrorMessages<number> = defaultErrorMessages): ValidationRule {
+export function maxLengthFn(max: number, ignoreSpaces = false, errorMessages: ErrorMessages<number> = defaultErrorMessages): ValidationRule {
 	return (value: Value): ValidationResult => {
 		// If the value is empty, return true (valid)
 		if (!value) {
 			return true;
+		}
+
+		if (ignoreSpaces) {
+			value = value.replace(/\s/g, '');
 		}
 
 		return value.length <= max || ruleMessage(errorMessages, 'default', [max]);

--- a/packages/vue-dot/src/rules/maxLength/tests/maxLength.spec.ts
+++ b/packages/vue-dot/src/rules/maxLength/tests/maxLength.spec.ts
@@ -7,7 +7,7 @@ describe('maxLength', () => {
 		expect(typeof rule('0123')).toBe('string');
 	});
 
-	it('returns true when the value is shorter than maximum', () => {
+	it('returns true when the value is shorter than the maximum', () => {
 		const rule = maxLength(10);
 
 		expect(rule('012345')).toBe(true);
@@ -19,6 +19,12 @@ describe('maxLength', () => {
 		expect(rule('0123456789')).toBe(true);
 	});
 
+	it('returns true when the value is shorter than the maximum without counting spaces', () => {
+		const rule = maxLength(10, true);
+
+		expect(rule('0 1 2 3 4 5')).toBe(true);
+	});
+
 	it('returns true if the value is falsy', () => {
 		const rule = maxLength(10);
 
@@ -26,7 +32,7 @@ describe('maxLength', () => {
 	});
 
 	it('works with custom error messages', () => {
-		const rule = maxLength(1, {
+		const rule = maxLength(1, false, {
 			default: 'test'
 		});
 

--- a/packages/vue-dot/src/rules/minLength/tests/minLength.spec.ts
+++ b/packages/vue-dot/src/rules/minLength/tests/minLength.spec.ts
@@ -7,7 +7,7 @@ describe('minLength', () => {
 		expect(typeof rule('0')).toBe('string');
 	});
 
-	it('returns true when the value is longer than minimum', () => {
+	it('returns true when the value is longer than the minimum', () => {
 		const rule = minLength(10);
 
 		expect(rule('012345678910')).toBe(true);


### PR DESCRIPTION
## Description

Ajout de l'option `ignoreSpaces` à la règle de validation `maxLength`.

## Type de changement

- Nouvelle fonctionnalité
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
