### PR TITLE
🐛 form-builder: Fix v-messages display when no hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - 🐛 **Corrections de bugs**
   - **RangeField:** Correction de l'affichage sur les écrans mobiles et suppression du `VForm` à l'intérieur du champ ([#1680](https://github.com/assurance-maladie-digital/design-system/pull/1680)) ([923d65c](https://github.com/assurance-maladie-digital/design-system/commit/923d65cc5ff0ff79487aa3a285ccffa60b4c3484))
   - **PeriodField:** Correction de l'affichage sur les écrans mobiles ([#1681](https://github.com/assurance-maladie-digital/design-system/pull/1681)) ([ae36361](https://github.com/assurance-maladie-digital/design-system/commit/ae36361bd4e045184262e97deedb03e8db16135c))
+  - **ChoiceButtonField:** Correction du paragraphe `v-messages` affiché même sans texte informatif ([#1841](https://github.com/assurance-maladie-digital/design-system/pull/1841))
 
 - ♻️ **Refactoring**
   - **FormField:** Utilisation de la couleur primaire au lieu de la couleur d'accent ([#1691](https://github.com/assurance-maladie-digital/design-system/pull/1691)) ([4c9c89a](https://github.com/assurance-maladie-digital/design-system/commit/4c9c89a106cf2ada43a4e8d9444f99fed2718768))
@@ -83,7 +84,7 @@
   - **global:** Suppression et mise à jour des commentaires ([#1837](https://github.com/assurance-maladie-digital/design-system/pull/1837)) ([dcfb95e](https://github.com/assurance-maladie-digital/design-system/commit/dcfb95e309c50a0082192cba662d293fdb7e5cb2))
 
 - ♿️ **Accessibilité**
-  - **ChoiceButtonField:** Ajout des attributs ARIA manquants ([#1840](https://github.com/assurance-maladie-digital/design-system/pull/1840))
+  - **ChoiceButtonField:** Ajout des attributs ARIA manquants ([#1840](https://github.com/assurance-maladie-digital/design-system/pull/1840)) ([29a95e7](https://github.com/assurance-maladie-digital/design-system/commit/29a95e7fea39f1315d39e161aabc26ca02ab2936))
 
 - 🔥 **Suppressions**
   - **tests:** Suppression des commentaires inutiles ([#1810](https://github.com/assurance-maladie-digital/design-system/pull/1810)) ([bef7321](https://github.com/assurance-maladie-digital/design-system/commit/bef7321ca310887d2db2851d46b4feeb31a7178b))

--- a/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -443,9 +443,7 @@ exports[`FormBuilder renders correctly 1`] = `
 			</span>
               <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate white--text flex-shrink-0 ml-1 theme--light" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
             </button></div>
-          <p class="v-messages px-3 mt-2 mb-0 theme--light">
-            <!---->
-          </p>
+          <!---->
         </div>
         <!---->
       </div>
@@ -466,9 +464,7 @@ exports[`FormBuilder renders correctly 1`] = `
 			</span>
               <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate white--text flex-shrink-0 ml-1 theme--light" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
             </button></div>
-          <p class="v-messages px-3 mt-2 mb-0 theme--light">
-            <!---->
-          </p>
+          <!---->
         </div>
         <!---->
       </div>
@@ -499,9 +495,7 @@ exports[`FormBuilder renders correctly 1`] = `
 			</span>
               <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate white--text flex-shrink-0 ml-1 theme--light" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
             </button></div>
-          <p class="v-messages px-3 mt-2 mb-0 theme--light">
-            <!---->
-          </p>
+          <!---->
         </div>
         <div class="v-input vd-form-input v-input--is-label-active v-input--is-dirty v-input--dense theme--dark v-text-field v-text-field--enclosed v-text-field--outlined v-text-field--placeholder">
           <div class="v-input__control">

--- a/packages/form-builder/src/components/FormField/fields/ChoiceButtonField.vue
+++ b/packages/form-builder/src/components/FormField/fields/ChoiceButtonField.vue
@@ -55,7 +55,7 @@
 		</template>
 
 		<p
-			v-else
+			v-else-if="showHint"
 			:class="$vuetify.theme.dark ? 'theme--dark' : 'theme--light'"
 			class="v-messages px-3 mt-2 mb-0"
 		>


### PR DESCRIPTION
## Description

Correction du paragraphe `v-messages` affiché même sans texte informatif dans le composant `ChoiceButtonField`.
## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
