### PR TITLE
♻️ vue-dot: Rename isDateAfterValue function to isDateAfter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
   - **rules:** Utilisation de la fonction `isDateBeforeValue` dans la règle de validation `notBeforeToday` ([#1827](https://github.com/assurance-maladie-digital/design-system/pull/1827)) ([35d4fb9](https://github.com/assurance-maladie-digital/design-system/commit/35d4fb90ecf882bb182e77d8894a2a78eac6a603))
   - **global:** Suppression et mise à jour des commentaires ([#1829](https://github.com/assurance-maladie-digital/design-system/pull/1829)) ([976df56](https://github.com/assurance-maladie-digital/design-system/commit/976df56d938c0fb8d8eb5d3b8f02a073c9a17c09))
   - **directives:** Refonte de la directive `debounce` ([#1830](https://github.com/assurance-maladie-digital/design-system/pull/1830)) ([2358e04](https://github.com/assurance-maladie-digital/design-system/commit/2358e045f6bc51b200b9f287f0267f52c65ec115))
+  - **functions:** Renommage de la function `isDateAfterValue` en `isDateAfter` ([#1847](https://github.com/assurance-maladie-digital/design-system/pull/1847))
 
 - ♿️ **Accessibilité**
   - **HeaderBar:** Ajout des attributs ARIA manquants ([#1844](https://github.com/assurance-maladie-digital/design-system/pull/1844)) ([7dbfced](https://github.com/assurance-maladie-digital/design-system/commit/7dbfceda3509cbc20921679be6cbff76a686ecf7))
@@ -147,7 +148,7 @@
   - **DatePicker:** Mise à jour de la description de la prop `picker-date` ([#1768](https://github.com/assurance-maladie-digital/design-system/pull/1768)) ([be2dc4a](https://github.com/assurance-maladie-digital/design-system/commit/be2dc4a95a467e50d8d5f7dee71dc987035761a6))
   - **global:** Mise à jour de la page principes de design ([#1770](https://github.com/assurance-maladie-digital/design-system/pull/1770)) ([5f69694](https://github.com/assurance-maladie-digital/design-system/commit/5f69694625d94489d238b5d389f60ccdc2833fad))
   - **HeaderBar:** Mise à jour de l'exemple d'utilisation du slot par défaut ([#1838](https://github.com/assurance-maladie-digital/design-system/pull/1838)) ([8d921ef](https://github.com/assurance-maladie-digital/design-system/commit/8d921ef047a4553fc2c0026408e20842b748dc89))
-  - **HeaderBar:** Correction du nom du slot `secondary-logo` ([#1846](https://github.com/assurance-maladie-digital/design-system/pull/1846))
+  - **HeaderBar:** Correction du nom du slot `secondary-logo` ([#1846](https://github.com/assurance-maladie-digital/design-system/pull/1846)) ([0319f5f](https://github.com/assurance-maladie-digital/design-system/commit/0319f5f09b06739278a5c539277fae8860fa1ffc))
 
 ### Interne
 

--- a/packages/vue-dot/src/functions/isDateAfterValue/index.ts
+++ b/packages/vue-dot/src/functions/isDateAfterValue/index.ts
@@ -1,9 +1,0 @@
-import { parseDate } from '../../helpers/parseDate';
-
-/** Check that the date is after a value (date with DD/MM/YYYY format) */
-export function isDateAfterValue(maxDate: string, value: string): boolean {
-	const parsedValue = parseDate(value);
-	const parsedMaxDate = parseDate(maxDate);
-
-	return parsedValue.isAfter(parsedMaxDate);
-}

--- a/packages/vue-dot/src/functions/validation/isDateAfter/index.ts
+++ b/packages/vue-dot/src/functions/validation/isDateAfter/index.ts
@@ -1,0 +1,9 @@
+import { parseDate } from '../../../helpers/parseDate';
+
+/** Check if a date is after another date (DD/MM/YYYY format) */
+export function isDateAfter(maxDate: string, value: string): boolean {
+	const parsedValue = parseDate(value);
+	const parsedMaxDate = parseDate(maxDate);
+
+	return parsedValue.isAfter(parsedMaxDate);
+}

--- a/packages/vue-dot/src/functions/validation/isDateAfter/tests/isDateAfter.spec.ts
+++ b/packages/vue-dot/src/functions/validation/isDateAfter/tests/isDateAfter.spec.ts
@@ -1,18 +1,18 @@
-import { isDateAfterValue } from '../';
+import { isDateAfter } from '../';
 
 import dayjs from 'dayjs';
-import { formatDate } from '../../formatDate';
+import { formatDate } from '../../../formatDate';
 
-describe('isDateAfterValue', () => {
+describe('isDateAfter', () => {
 	const today = formatDate(dayjs());
 	const pasteDate = formatDate(dayjs().subtract(1, 'year'));
 	const futureDate = formatDate(dayjs().add(1, 'year'));
 
 	it('returns true with a future date', () => {
-		expect(isDateAfterValue(today, futureDate)).toBeTruthy();
+		expect(isDateAfter(today, futureDate)).toBeTruthy();
 	});
 
 	it('returns false with a past date', () => {
-		expect(isDateAfterValue(today, pasteDate)).toBeFalsy();
+		expect(isDateAfter(today, pasteDate)).toBeFalsy();
 	});
 });

--- a/packages/vue-dot/src/rules/notAfterDate/index.ts
+++ b/packages/vue-dot/src/rules/notAfterDate/index.ts
@@ -5,7 +5,7 @@ import { defaultErrorMessages } from './locales';
 
 import { parseDate } from '../../helpers/parseDate';
 import { formatDate } from '../../functions/formatDate';
-import { isDateAfterValue } from '../../functions/isDateAfterValue';
+import { isDateAfter } from '../../functions/validation/isDateAfter';
 
 /** Check that the value is not after the specified date (DD/MM/YYYY format) */
 export function notAfterDate(date: string, errorMessages = defaultErrorMessages): ValidationRule {
@@ -16,6 +16,6 @@ export function notAfterDate(date: string, errorMessages = defaultErrorMessages)
 
 		const formattedValue = formatDate(parseDate(date));
 
-		return !isDateAfterValue(date, value) || ruleMessage(errorMessages, 'default', [formattedValue]);
+		return !isDateAfter(date, value) || ruleMessage(errorMessages, 'default', [formattedValue]);
 	};
 }

--- a/packages/vue-dot/src/rules/notAfterToday/index.ts
+++ b/packages/vue-dot/src/rules/notAfterToday/index.ts
@@ -3,7 +3,7 @@ import { ValidationRule, ValidationResult, ErrorMessages, Value } from '../types
 
 import { defaultErrorMessages } from './locales';
 
-import { isDateAfterValue } from '../../functions/isDateAfterValue';
+import { isDateAfter } from '../../functions/validation/isDateAfter';
 import { TODAY } from '../../constants';
 
 /*** Check that the value is not after today (DD/MM/YYYY format) */
@@ -13,7 +13,7 @@ export function notAfterTodayFn(errorMessages: ErrorMessages = defaultErrorMessa
 			return true;
 		}
 
-		return !isDateAfterValue(TODAY, value) || ruleMessage(errorMessages, 'default');
+		return !isDateAfter(TODAY, value) || ruleMessage(errorMessages, 'default');
 	};
 }
 


### PR DESCRIPTION
## Description

Renommage de la function `isDateAfterValue` en `isDateAfter`.

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
