### PR TITLE
♻️ vue-dot: Rename isDateBeforeValue function to isDateBefore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@
   - **rules:** Utilisation de la fonction `isDateBeforeValue` dans la règle de validation `notBeforeToday` ([#1827](https://github.com/assurance-maladie-digital/design-system/pull/1827)) ([35d4fb9](https://github.com/assurance-maladie-digital/design-system/commit/35d4fb90ecf882bb182e77d8894a2a78eac6a603))
   - **global:** Suppression et mise à jour des commentaires ([#1829](https://github.com/assurance-maladie-digital/design-system/pull/1829)) ([976df56](https://github.com/assurance-maladie-digital/design-system/commit/976df56d938c0fb8d8eb5d3b8f02a073c9a17c09))
   - **directives:** Refonte de la directive `debounce` ([#1830](https://github.com/assurance-maladie-digital/design-system/pull/1830)) ([2358e04](https://github.com/assurance-maladie-digital/design-system/commit/2358e045f6bc51b200b9f287f0267f52c65ec115))
-  - **functions:** Renommage de la function `isDateAfterValue` en `isDateAfter` ([#1847](https://github.com/assurance-maladie-digital/design-system/pull/1847))
+  - **functions:** Renommage de la function `isDateAfterValue` en `isDateAfter` ([#1847](https://github.com/assurance-maladie-digital/design-system/pull/1847)) ([2beaccb](https://github.com/assurance-maladie-digital/design-system/commit/2beaccbdf047eccbc0b453f6067b2d8254bfd6c2))
+  - **functions:** Renommage de la function `isDateBeforeValue` en `isDateBefore` ([#1848](https://github.com/assurance-maladie-digital/design-system/pull/1848))
 
 - ♿️ **Accessibilité**
   - **HeaderBar:** Ajout des attributs ARIA manquants ([#1844](https://github.com/assurance-maladie-digital/design-system/pull/1844)) ([7dbfced](https://github.com/assurance-maladie-digital/design-system/commit/7dbfceda3509cbc20921679be6cbff76a686ecf7))

--- a/packages/vue-dot/src/functions/isDateBeforeValue/index.ts
+++ b/packages/vue-dot/src/functions/isDateBeforeValue/index.ts
@@ -1,9 +1,0 @@
-import { parseDate } from '@cnamts/vue-dot/src/helpers/parseDate';
-
-/** Check that the date is before a value (date with DD/MM/YYYY format) */
-export function isDateBeforeValue(minDate: string, value: string): boolean {
-	const parsedValue = parseDate(value);
-	const parsedMinDate = parseDate(minDate);
-
-	return parsedValue.isBefore(parsedMinDate);
-}

--- a/packages/vue-dot/src/functions/validation/isDateBefore/index.ts
+++ b/packages/vue-dot/src/functions/validation/isDateBefore/index.ts
@@ -1,0 +1,9 @@
+import { parseDate } from '../../../helpers/parseDate';
+
+/** Check if a date is before another date (DD/MM/YYYY format) */
+export function isDateBefore(minDate: string, value: string): boolean {
+	const parsedValue = parseDate(value);
+	const parsedMinDate = parseDate(minDate);
+
+	return parsedValue.isBefore(parsedMinDate);
+}

--- a/packages/vue-dot/src/functions/validation/isDateBefore/tests/isDateBefore.spec.ts
+++ b/packages/vue-dot/src/functions/validation/isDateBefore/tests/isDateBefore.spec.ts
@@ -1,22 +1,22 @@
-import { isDateBeforeValue } from '../';
+import { isDateBefore } from '../';
 
 import dayjs from 'dayjs';
-import { formatDate } from '../../formatDate';
+import { formatDate } from '../../../formatDate';
 
-describe('isDateBeforeValue', () => {
+describe('isDateBefore', () => {
 	const today = formatDate(dayjs());
 	const pasteDate = formatDate(dayjs().subtract(1, 'year'));
 	const futureDate = formatDate(dayjs().add(1, 'year'));
 
 	it('returns true with a past date', () => {
-		expect(isDateBeforeValue(today, pasteDate)).toBeTruthy();
+		expect(isDateBefore(today, pasteDate)).toBeTruthy();
 	});
 
 	it('returns false with a future date', () => {
-		expect(isDateBeforeValue(today, futureDate)).toBeFalsy();
+		expect(isDateBefore(today, futureDate)).toBeFalsy();
 	});
 
 	it('returns false with the current date', () => {
-		expect(isDateBeforeValue(today, today)).toBeFalsy();
+		expect(isDateBefore(today, today)).toBeFalsy();
 	});
 });

--- a/packages/vue-dot/src/rules/notBeforeDate/index.ts
+++ b/packages/vue-dot/src/rules/notBeforeDate/index.ts
@@ -5,7 +5,7 @@ import { defaultErrorMessages } from './locales';
 
 import { parseDate } from '../../helpers/parseDate';
 import { formatDate } from '../../functions/formatDate';
-import { isDateBeforeValue } from '../../functions/isDateBeforeValue';
+import { isDateBefore } from '../../functions/validation/isDateBefore';
 
 /** Check that the value is not after the specified date (DD/MM/YYYY format) */
 export function notBeforeDate(date: string, errorMessages = defaultErrorMessages): ValidationRule {
@@ -16,6 +16,6 @@ export function notBeforeDate(date: string, errorMessages = defaultErrorMessages
 
 		const formattedValue = formatDate(parseDate(date));
 
-		return !isDateBeforeValue(date, value) || ruleMessage(errorMessages, 'default', [formattedValue]);
+		return !isDateBefore(date, value) || ruleMessage(errorMessages, 'default', [formattedValue]);
 	};
 }

--- a/packages/vue-dot/src/rules/notBeforeToday/index.ts
+++ b/packages/vue-dot/src/rules/notBeforeToday/index.ts
@@ -3,7 +3,7 @@ import { ValidationRule, ValidationResult, ErrorMessages, Value } from '../types
 
 import { defaultErrorMessages } from './locales';
 
-import { isDateBeforeValue } from '../../functions/isDateBeforeValue';
+import { isDateBefore } from '../../functions/validation/isDateBefore';
 import { TODAY } from '../../constants';
 
 /** Check that the value is not before today (DD/MM/YYYY format) */
@@ -13,7 +13,7 @@ export function notBeforeTodayFn(errorMessages: ErrorMessages = defaultErrorMess
 			return true;
 		}
 
-		return !isDateBeforeValue(TODAY, value) || ruleMessage(errorMessages, 'default');
+		return !isDateBefore(TODAY, value) || ruleMessage(errorMessages, 'default');
 	};
 }
 


### PR DESCRIPTION
## Description

Renommage de la function `isDateBeforeValue` en `isDateBefore`.

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
