### PR TITLE
♿️ vue-dot: Use aria-hidden in DataListLoading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,11 @@
 - ♿️ **Accessibilité**
   - **HeaderBar:** Ajout des attributs ARIA manquants ([#1844](https://github.com/assurance-maladie-digital/design-system/pull/1844)) ([7dbfced](https://github.com/assurance-maladie-digital/design-system/commit/7dbfceda3509cbc20921679be6cbff76a686ecf7))
   - **HeaderLoading:** Ajout de l'attribut `aria-hidden` ([#1850](https://github.com/assurance-maladie-digital/design-system/pull/1850)) ([e5c144b](https://github.com/assurance-maladie-digital/design-system/commit/e5c144bd8459b607e54a0c0fd3f2931342845c12))
+  - **DataListLoading:** Utilisation de l'attribut `aria-hidden` à la place des autres attributs ARIA ([#1872](https://github.com/assurance-maladie-digital/design-system/pull/1872))
 
 - 🔥 **Suppressions**
   - **tests:** Suppression des commentaires inutiles ([#1808](https://github.com/assurance-maladie-digital/design-system/pull/1808)) ([d2031dc](https://github.com/assurance-maladie-digital/design-system/commit/d2031dc218160ce70ccb3161f4bfe724f56abc57))
-  - **DataListLoading:** Suppression des styles inutiles ([#1871](https://github.com/assurance-maladie-digital/design-system/pull/1871))
+  - **DataListLoading:** Suppression des styles inutiles ([#1871](https://github.com/assurance-maladie-digital/design-system/pull/1871)) ([64f6fc8](https://github.com/assurance-maladie-digital/design-system/commit/64f6fc8b8170179c2ad351ec21fa1bd842298f0e))
 
 - ✅ **Tests**
   - **formatNir:** Correction d'une faute d'orthographe ([#1806](https://github.com/assurance-maladie-digital/design-system/pull/1806)) ([1efaa07](https://github.com/assurance-maladie-digital/design-system/commit/1efaa072dcc1c608e0782663deff78b365b2b5f4))

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/DataListLoading.vue
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/DataListLoading.vue
@@ -1,8 +1,6 @@
 <template>
 	<div
-		role="alert"
-		aria-busy="true"
-		aria-live="polite"
+		aria-hidden="true"
 		class="vd-data-list-loading"
 	>
 		<HeaderLoading

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/tests/__snapshots__/DataListLoading.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/tests/__snapshots__/DataListLoading.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataListLoading renders correctly 1`] = `
-<div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading" label="Test">
+<div aria-hidden="true" class="vd-data-list-loading" label="Test">
   <!---->
   <ul class="pl-0">
     <li class="vd-data-list-loading-item">
@@ -13,7 +13,7 @@ exports[`DataListLoading renders correctly 1`] = `
 `;
 
 exports[`DataListLoading renders correctly in row mode 1`] = `
-<div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
+<div aria-hidden="true" class="vd-data-list-loading">
   <!---->
   <ul class="pl-0">
     <li class="vd-data-list-loading-item mb-4">
@@ -33,7 +33,7 @@ exports[`DataListLoading renders correctly in row mode 1`] = `
 `;
 
 exports[`DataListLoading renders correctly with a header 1`] = `
-<div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
+<div aria-hidden="true" class="vd-data-list-loading">
   <headerloading-stub width="100px" height="1.5rem" class="mb-4"></headerloading-stub>
   <ul class="pl-0">
     <li class="vd-data-list-loading-item">
@@ -45,7 +45,7 @@ exports[`DataListLoading renders correctly with a header 1`] = `
 `;
 
 exports[`DataListLoading renders correctly with more items 1`] = `
-<div role="alert" aria-busy="true" aria-live="polite" class="vd-data-list-loading">
+<div aria-hidden="true" class="vd-data-list-loading">
   <!---->
   <ul class="pl-0">
     <li class="vd-data-list-loading-item mb-4">


### PR DESCRIPTION
## Description

Utilisation de l'attribut `aria-hidden` à la place des autres attributs ARIA dans le composant `DataListLoading`.

Voir https://adrianroselli.com/2020/11/more-accessible-skeletons.html

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
