### PR TITLE
♿️ vue-dot: Add aria-label on loading mode in DataList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@
 - ♿️ **Accessibilité**
   - **HeaderBar:** Ajout des attributs ARIA manquants ([#1844](https://github.com/assurance-maladie-digital/design-system/pull/1844)) ([7dbfced](https://github.com/assurance-maladie-digital/design-system/commit/7dbfceda3509cbc20921679be6cbff76a686ecf7))
   - **HeaderLoading:** Ajout de l'attribut `aria-hidden` ([#1850](https://github.com/assurance-maladie-digital/design-system/pull/1850)) ([e5c144b](https://github.com/assurance-maladie-digital/design-system/commit/e5c144bd8459b607e54a0c0fd3f2931342845c12))
-  - **DataListLoading:** Utilisation de l'attribut `aria-hidden` à la place des autres attributs ARIA ([#1872](https://github.com/assurance-maladie-digital/design-system/pull/1872))
+  - **DataListLoading:** Utilisation de l'attribut `aria-hidden` à la place des autres attributs ARIA ([#1872](https://github.com/assurance-maladie-digital/design-system/pull/1872)) ([bfcc97c](https://github.com/assurance-maladie-digital/design-system/commit/bfcc97c73c42affc8fbe46102d8a104cfbc9901b))
+  - **DataList:** Ajout de l'attribut `aria-label` en mode chargement ([#1873](https://github.com/assurance-maladie-digital/design-system/pull/1873))
 
 - 🔥 **Suppressions**
   - **tests:** Suppression des commentaires inutiles ([#1808](https://github.com/assurance-maladie-digital/design-system/pull/1808)) ([d2031dc](https://github.com/assurance-maladie-digital/design-system/commit/d2031dc218160ce70ccb3161f4bfe724f56abc57))

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -1,5 +1,6 @@
 <template>
 	<div
+		:aria-label="label"
 		:style="widthStyles"
 		class="vd-data-list"
 	>
@@ -115,6 +116,10 @@
 		}
 	})
 	export default class DataList extends MixinsDeclaration {
+		get label(): string | undefined {
+			return this.loading ? locales.loadingLabel : undefined;
+		}
+
 		getIcon(iconName?: string): string | null {
 			if (!iconName || !this.icons) {
 				return null;

--- a/packages/vue-dot/src/elements/DataList/locales.ts
+++ b/packages/vue-dot/src/elements/DataList/locales.ts
@@ -1,3 +1,4 @@
 export const locales = {
-	placeholder: '…'
+	placeholder: '…',
+	loadingLabel: 'Le contenu est en cours de chargement.'
 };

--- a/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DataList/tests/__snapshots__/DataList.spec.ts.snap
@@ -155,7 +155,7 @@ exports[`DataList renders correctly with an icon 1`] = `
 `;
 
 exports[`DataList renders loading state correctly 1`] = `
-<div class="vd-data-list" style="width: 100%;">
+<div aria-label="Le contenu est en cours de chargement." class="vd-data-list" style="width: 100%;">
   <vfadetransition-stub mode="out-in" origin="top center 0">
     <datalistloading-stub itemsnumber="3" heading="true" title-class="text-subtitle-1 font-weight-bold mb-3"></datalistloading-stub>
   </vfadetransition-stub>


### PR DESCRIPTION
## Description

Ajout de l'attribut `aria-label` en mode chargement dans le composant `DataList`.

Voir https://adrianroselli.com/2020/11/more-accessible-skeletons.html

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
