### PR TITLE
🔥 vue-dot: Remove unnecessary placeholder prop default value in DataList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,12 @@
   - **HeaderBar:** Ajout des attributs ARIA manquants ([#1844](https://github.com/assurance-maladie-digital/design-system/pull/1844)) ([7dbfced](https://github.com/assurance-maladie-digital/design-system/commit/7dbfceda3509cbc20921679be6cbff76a686ecf7))
   - **HeaderLoading:** Ajout de l'attribut `aria-hidden` ([#1850](https://github.com/assurance-maladie-digital/design-system/pull/1850)) ([e5c144b](https://github.com/assurance-maladie-digital/design-system/commit/e5c144bd8459b607e54a0c0fd3f2931342845c12))
   - **DataListLoading:** Utilisation de l'attribut `aria-hidden` à la place des autres attributs ARIA ([#1872](https://github.com/assurance-maladie-digital/design-system/pull/1872)) ([bfcc97c](https://github.com/assurance-maladie-digital/design-system/commit/bfcc97c73c42affc8fbe46102d8a104cfbc9901b))
-  - **DataList:** Ajout de l'attribut `aria-label` en mode chargement ([#1873](https://github.com/assurance-maladie-digital/design-system/pull/1873))
+  - **DataList:** Ajout de l'attribut `aria-label` en mode chargement ([#1873](https://github.com/assurance-maladie-digital/design-system/pull/1873)) ([c0c802f](https://github.com/assurance-maladie-digital/design-system/commit/c0c802f8d81439af22892558057430015c9965eb)
 
 - 🔥 **Suppressions**
   - **tests:** Suppression des commentaires inutiles ([#1808](https://github.com/assurance-maladie-digital/design-system/pull/1808)) ([d2031dc](https://github.com/assurance-maladie-digital/design-system/commit/d2031dc218160ce70ccb3161f4bfe724f56abc57))
   - **DataListLoading:** Suppression des styles inutiles ([#1871](https://github.com/assurance-maladie-digital/design-system/pull/1871)) ([64f6fc8](https://github.com/assurance-maladie-digital/design-system/commit/64f6fc8b8170179c2ad351ec21fa1bd842298f0e))
+  - **DataList:** Suppression de la valeur par défaut inutile de la prop `placeholder` ([#1874](https://github.com/assurance-maladie-digital/design-system/pull/1874)))
 
 - ✅ **Tests**
   - **formatNir:** Correction d'une faute d'orthographe ([#1806](https://github.com/assurance-maladie-digital/design-system/pull/1806)) ([1efaa07](https://github.com/assurance-maladie-digital/design-system/commit/1efaa072dcc1c608e0782663deff78b365b2b5f4))

--- a/packages/docs/src/data/api/data-list.ts
+++ b/packages/docs/src/data/api/data-list.ts
@@ -50,8 +50,8 @@ export const api: Api = {
 			{
 				name: 'placeholder',
 				type: 'string',
-				default: `'…'`,
-				description: 'Le texte à afficher lorsqu’il n’y a pas de valeur.'
+				default: undefined,
+				description: 'Le texte à afficher lorsqu’il n’y a pas de valeur.<br>Par défaut, la valeur est celle de la prop du composant `DataListItem`.'
 			},
 			{
 				name: 'loading',

--- a/packages/vue-dot/src/elements/DataList/DataList.vue
+++ b/packages/vue-dot/src/elements/DataList/DataList.vue
@@ -86,7 +86,7 @@
 			},
 			placeholder: {
 				type: String,
-				default: locales.placeholder
+				default: undefined
 			},
 			loading: {
 				type: Boolean,

--- a/packages/vue-dot/src/elements/DataList/locales.ts
+++ b/packages/vue-dot/src/elements/DataList/locales.ts
@@ -1,4 +1,3 @@
 export const locales = {
-	placeholder: '…',
 	loadingLabel: 'Le contenu est en cours de chargement.'
 };


### PR DESCRIPTION
## Description

Suppression de la valeur par défaut inutile de la prop `placeholder` dans le composant `DataList`.

## Type de changement

- Refactoring
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
