### PR TITLE
🐛 vue-dot: Fix menu display in ExternalLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Non publié
 
+### Vue Dot
+
+- 🐛 **Corrections de bugs**
+  - **ExternalLinks:** Correction de l'affichage du menu ([#1675](https://github.com/assurance-maladie-digital/design-system/pull/1675))
+
 ### Documentation
 
 - 📝 **Documentation**
@@ -10,7 +15,7 @@
 
 - ⬆️ **Dépendances**
   - **eslint-plugin-jsdoc:** Mise à jour vers la `v38.1.4` ([#1878](https://github.com/assurance-maladie-digital/design-system/pull/1878)) ([272bf1d](https://github.com/assurance-maladie-digital/design-system/commit/272bf1d5973cb0fd6505be4964eb20864adf4b6e))
-  - **@mdi/js:** Mise à jour vers la `v6.6.96` ([#1879](https://github.com/assurance-maladie-digital/design-system/pull/1879))
+  - **@mdi/js:** Mise à jour vers la `v6.6.96` ([#1879](https://github.com/assurance-maladie-digital/design-system/pull/1879)) ([c0664dd](https://github.com/assurance-maladie-digital/design-system/commit/c0664ddd88f5bf6e62dad269f32fc6158ece1ed5))
 
 ## v2.3.0
 

--- a/packages/docs/src/content/examples/external-links/btn-text.vue
+++ b/packages/docs/src/content/examples/external-links/btn-text.vue
@@ -1,6 +1,6 @@
 <template>
 	<VCard
-		min-height="200px"
+		min-height="248px"
 		class="mx-auto overflow-hidden"
 	>
 		<ExternalLinks

--- a/packages/docs/src/content/examples/external-links/usage.vue
+++ b/packages/docs/src/content/examples/external-links/usage.vue
@@ -17,7 +17,7 @@
 
 	import { ExternalLink } from '@cnamts/vue-dot/src/elements/ExternalLinks/types';
 
-	const items: ExternalLink[] = [
+	const links: ExternalLink[] = [
 		{
 			href: 'https://ameli.fr/',
 			text: 'Ameli'
@@ -33,7 +33,7 @@
 	})
 	export default class ExternalLinksUsage extends Vue {
 		defaultProps = {
-			items,
+			items: links,
 			position: 'top left',
 			nudgeTop: 0,
 			nudgeBottom: 0

--- a/packages/vue-dot/src/elements/ExternalLinks/ExternalLinks.vue
+++ b/packages/vue-dot/src/elements/ExternalLinks/ExternalLinks.vue
@@ -4,7 +4,7 @@
 		v-model="menu"
 		v-bind="options.menu"
 		:top="bottom"
-		:content-class="menuClass"
+		attach
 		class="vd-external-links"
 	>
 		<template #activator="{ on, attrs }">
@@ -13,11 +13,11 @@
 					...attrs,
 					...options.btn
 				}"
+				ref="btn"
 				:style="btnStyle"
 				class="vd-external-links-btn"
 				@mouseenter="hover = true"
 				@mouseleave="hover = false"
-				@click="setMenuPosition"
 				v-on="on"
 			>
 				<span
@@ -83,8 +83,8 @@
 
 	import { PositionEnum } from './PositionEnum';
 
-	import { ExternalLink, Position, StylesField } from './types';
-	import { IndexedObject, Refs } from '../../types';
+	import { ExternalLink, Position } from './types';
+	import { IndexedObject } from '../../types';
 
 	import { customizable } from '../../mixins/customizable';
 
@@ -144,13 +144,6 @@
 
 	@Component
 	export default class ExternalLinks extends MixinsDeclaration {
-		$refs!: Refs<{
-			menu: {
-				pageWidth: string;
-				styles: StylesField;
-			};
-		}>;
-
 		locales = locales;
 
 		linkIcon = mdiOpenInNew;
@@ -244,54 +237,8 @@
 
 			return iconMapping[this.computedPosition.x];
 		}
-
-		setMenuClass(): void {
-			const VUETIFY_THRESHOLD = 12;
-			const position = this.computedPosition.x;
-			let positionClass = '';
-
-			if (position === PositionEnum.LEFT) {
-				const nudge = parseInt(this.$refs.menu.styles.left);
-
-				if (nudge <= VUETIFY_THRESHOLD) {
-					positionClass = ' left-0';
-				}
-			}
-
-			if (position === PositionEnum.RIGHT) {
-				const pageWidth = parseInt(this.$refs.menu.pageWidth, 10);
-				const left = parseInt(this.$refs.menu.styles.left, 10);
-				const minWidth = parseInt(this.$refs.menu.styles.minWidth, 10);
-				const nudge = pageWidth - left - minWidth;
-
-				if (nudge <= VUETIFY_THRESHOLD) {
-					positionClass = ' right-0';
-				}
-			}
-
-			this.menuClass = 'vd-external-links-menu' + positionClass;
-		}
-
-		setMenuPosition(): void {
-			// Wait until the menu is rendered
-			setTimeout(() => this.setMenuClass(), 100);
-		}
 	}
 </script>
-
-<style lang="scss">
-	.vd-external-links-menu {
-		// Use CSS since Vuetify forces a 12px minimum spacing
-		&.left-0 {
-			left: 0 !important;
-		}
-
-		&.right-0 {
-			left: auto !important; // Override Vuetify computation
-			right: 0 !important;
-		}
-	}
-</style>
 
 <style lang="scss" scoped>
 	$list-max-height: 248px;

--- a/packages/vue-dot/src/elements/ExternalLinks/tests/__snapshots__/ExternalLinks.spec.ts.snap
+++ b/packages/vue-dot/src/elements/ExternalLinks/tests/__snapshots__/ExternalLinks.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ExternalLinks renders correctly 1`] = `
-<vmenu-stub opendelay="0" closedelay="0" tile="true" openonclick="true" contentclass="" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" zindex="4" closeonclick="true" closeoncontentclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition" class="vd-external-links">
+<vmenu-stub opendelay="0" closedelay="0" tile="true" openonclick="true" attach="" contentclass="" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" zindex="4" closeonclick="true" closeoncontentclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition" class="vd-external-links">
   <vsheet-stub elevation="0" tag="div" class="px-4 py-3">
     <p class="mb-0">
       Pas de données.

--- a/packages/vue-dot/src/elements/ExternalLinks/types.d.ts
+++ b/packages/vue-dot/src/elements/ExternalLinks/types.d.ts
@@ -7,8 +7,3 @@ export interface Position {
 	x: string;
 	y: string;
 }
-
-export interface StylesField {
-	left: string
-	minWidth: string
-}


### PR DESCRIPTION
## Description

Correction de l'affichage du menu dans le composant `ExternalLinks` :

![screenshot-digital-design-system netlify app-2022 04 05-16_11_08](https://user-images.githubusercontent.com/10298932/161773825-db813976-d988-46c9-9194-01317d18d856.png)

En utilisant la prop `attach` sans argument, le contenu du menu est positionné au niveau du composant dans le DOM (contrairement à la fin de la page par défaut).
Cela permet de résoudre le problème de positionnement et améliore également l'accessibilité.

## Playground

<details>

```vue
<template>
	<ExternalLinks
		:items="items"
		position="top left"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { ExternalLink } from '@cnamts/vue-dot/src/elements/ExternalLinks/types';

	@Component
	export default class Playground extends Vue {
		items: ExternalLink[] = [
			{
				href: 'https://ameli.fr/',
				text: 'Ameli'
			},
			{
				href: 'https://espacepro.ameli.fr/',
				text: 'Ameli Pro'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
