### PR TITLE
♿️ vue-dot: Add aria-label on close button in DialogBox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 
+
 orbs:
   codecov: codecov/codecov@3.2.2
   jq: circleci/jq@2.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2.1
 
-
 orbs:
   codecov: codecov/codecov@3.2.2
   jq: circleci/jq@2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 - 🐛 **Corrections de bugs**
   - **ExternalLinks:** Correction de l'affichage du menu ([#1889](https://github.com/assurance-maladie-digital/design-system/pull/1889)) ([e6f1b7f](https://github.com/assurance-maladie-digital/design-system/commit/e6f1b7f32b55fcf51cd70b0bd413cb13383ffef9))
-  - **DialogBox:** Correction de l'alignement du titre ([#1890](https://github.com/assurance-maladie-digital/design-system/pull/1890))
+  - **DialogBox:** Correction de l'alignement du titre ([#1890](https://github.com/assurance-maladie-digital/design-system/pull/1890)) ([e329f25](https://github.com/assurance-maladie-digital/design-system/commit/e329f252e1314d31effc426d91ef9215ed8a589a))
+
+- ♿️ **Accessibilité**
+  - **DialogBox:** Ajout de l'attribut `aria-label` sur le bouton fermer ([#1891](https://github.com/assurance-maladie-digital/design-system/pull/1891))
 
 ### Documentation
 

--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -20,6 +20,7 @@
 
 				<VBtn
 					v-bind="options.closeBtn"
+					:aria-label="locales.closeBtn"
 					@click="close"
 				>
 					<VIcon v-bind="options.icon">
@@ -107,6 +108,8 @@
 		}
 	})
 	export default class DialogBox extends MixinsDeclaration {
+		locales = locales;
+
 		closeIcon = mdiClose;
 
 		get dialog(): boolean {

--- a/packages/vue-dot/src/elements/DialogBox/locales.ts
+++ b/packages/vue-dot/src/elements/DialogBox/locales.ts
@@ -1,4 +1,5 @@
 export const locales = {
+	closeBtn: 'Fermer la boîte de dialogue',
 	cancelBtn: 'Annuler',
 	confirmBtn: 'Valider'
 };

--- a/packages/vue-dot/src/elements/DialogBox/tests/__snapshots__/DialogBox.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DialogBox/tests/__snapshots__/DialogBox.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`DialogBox renders correctly 1`] = `
     <vcardtitle-stub tag="div" class="d-flex align-start flex-nowrap pa-0 mb-6">
       <!---->
       <vspacer-stub tag="div"></vspacer-stub>
-      <vbtn-stub height="32px" width="32px" tag="button" activeclass="" icon="true" type="button" class="mt-n2 mr-n2 ml-4">
+      <vbtn-stub height="32px" width="32px" tag="button" activeclass="" icon="true" type="button" aria-label="Fermer la boîte de dialogue" class="mt-n2 mr-n2 ml-4">
         <vicon-stub>
           M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z
         </vicon-stub>


### PR DESCRIPTION
## Description

Ajout de l'attribut `aria-label` sur le bouton fermer dans le composant `DialogBox`.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
