### PR TITLE
⬆️ vue-dot: Replace content-disposition with content-disposition-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - ♿️ **Accessibilité**
   - **DialogBox:** Ajout de l'attribut `aria-label` sur le bouton fermer ([#1892](https://github.com/assurance-maladie-digital/design-system/pull/1892)) ([7d2aa84](https://github.com/assurance-maladie-digital/design-system/commit/7d2aa8457a758979efa50767f2c629dd5b8892a5))
 
+- ⬆️ **Dépendances**
+  - **DownloadBtn:** Remplacement de la dépendance `content-disposition` par `content-disposition-header` ([#1895](https://github.com/assurance-maladie-digital/design-system/pull/1895))
+
 ### Documentation
 
 - 📝 **Documentation**
@@ -16,7 +19,7 @@
   - **functions:** Documentation de la fonction `formatDate` ([#1883](https://github.com/assurance-maladie-digital/design-system/pull/1883)) ([4cff971](https://github.com/assurance-maladie-digital/design-system/commit/4cff9719de724662cfee642f606b46b2b52da449))
 
 - ♻️ **Refactoring**
-  - **DocTabItem:** Ajout de la prop `eager` ([#1894](https://github.com/assurance-maladie-digital/design-system/pull/1894))
+  - **DocTabItem:** Ajout de la prop `eager` ([#1894](https://github.com/assurance-maladie-digital/design-system/pull/1894)) ([cf4d05e](https://github.com/assurance-maladie-digital/design-system/commit/cf4d05efd6497b5d6eee328fef783aaf84b3a03b))
 
 ### Interne
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 		"@babel/core": "7.17.9",
 		"@mdi/js": "6.6.96",
 		"@rushstack/eslint-patch": "1.1.1",
-		"@types/content-disposition": "0.5.4",
 		"@types/fs-extra": "9.0.13",
 		"@types/jest": "26.0.24",
 		"@types/node": "14.18.12",

--- a/packages/vue-dot/package.json
+++ b/packages/vue-dot/package.json
@@ -39,7 +39,7 @@
 		"test": "vue-cli-service test:unit --runInBand"
 	},
 	"dependencies": {
-		"content-disposition": "^0.5.3",
+		"content-disposition-header": "^0.6.0",
 		"deepmerge": "^4.2.2"
 	},
 	"peerDependencies": {

--- a/packages/vue-dot/src/elements/DownloadBtn/DownloadBtn.vue
+++ b/packages/vue-dot/src/elements/DownloadBtn/DownloadBtn.vue
@@ -24,7 +24,7 @@
 	import { mapActions } from 'vuex';
 
 	import { AxiosResponse } from 'axios';
-	import contentDisposition from 'content-disposition';
+	import { parse } from 'content-disposition-header';
 
 	import { mdiDownload } from '@mdi/js';
 
@@ -88,7 +88,7 @@
 			let filename: string | null = null;
 
 			try {
-				filename = contentDisposition.parse(contentDispositionHeader).parameters.filename;
+				filename = parse(contentDispositionHeader).parameters.filename;
 			} catch {
 				filename = this.fallbackFilename || this.getTimestampFilename();
 			}

--- a/packages/vue-dot/tsconfig.json
+++ b/packages/vue-dot/tsconfig.json
@@ -4,8 +4,7 @@
 		"baseUrl": ".",
 		"types": [
 			"node",
-			"jest",
-			"content-disposition"
+			"jest"
 		],
 		"paths": {
 			"@/tests/*": [


### PR DESCRIPTION
## Description

Remplacement de la dépendance `content-disposition` par `content-disposition-header` car `content-disposition` qui est une refonte de `content-disposition` avec le support navigateur.

## Type de changement

- Maintenance

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
