### PR TITLE
♻️ vue-dot: Auto select file type on inline upload in UploadWorkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - ♻️ **Refactoring**
   - **HeaderBar:** Modification de la valeur de la propriété `z-index` ([#1902](https://github.com/assurance-maladie-digital/design-system/pull/1902)) ([bc652ac](https://github.com/assurance-maladie-digital/design-system/commit/bc652aca7653046465994f5c8290a71090f7fdb2))
+  - **UploadWorkflow:** Sélection automatique du type de fichier lors de l'upload par ligne ([#1919](https://github.com/assurance-maladie-digital/design-system/pull/1919))
 
 - ♿️ **Accessibilité**
   - **DialogBox:** Ajout de l'attribut `aria-label` sur le bouton fermer ([#1892](https://github.com/assurance-maladie-digital/design-system/pull/1892)) ([7d2aa84](https://github.com/assurance-maladie-digital/design-system/commit/7d2aa8457a758979efa50767f2c629dd5b8892a5))
@@ -67,7 +68,7 @@
   - **@babel/core:** Mise à jour vers la `v7.17.9` ([#1893](https://github.com/assurance-maladie-digital/design-system/pull/1893)) ([68931d2](https://github.com/assurance-maladie-digital/design-system/commit/68931d29acc5a57a2b3136cc657b1f25b42facab))
   - **eslint-plugin-jsdoc:** Mise à jour vers la `v39` ([#1901](https://github.com/assurance-maladie-digital/design-system/pull/1901)) ([f69cc95](https://github.com/assurance-maladie-digital/design-system/commit/f69cc95152fc8d494fefa4cecbaeb9bca3401ff7))
   - **@rushstack/eslint-patch:** Mise à jour vers la `v1.1.2` ([#1916](https://github.com/assurance-maladie-digital/design-system/pull/1916)) ([b903cb4](https://github.com/assurance-maladie-digital/design-system/commit/b903cb42232cd7d36cc69bddc5079ffa4919218e))
-  - **eslint-plugin-jsdoc:** Mise à jour vers la `v39.1.0` ([#1918](https://github.com/assurance-maladie-digital/design-system/pull/1918))
+  - **eslint-plugin-jsdoc:** Mise à jour vers la `v39.1.0` ([#1918](https://github.com/assurance-maladie-digital/design-system/pull/1918)) ([20bce7a](https://github.com/assurance-maladie-digital/design-system/commit/20bce7aff5ae1e7b707fcb6ef8a130e1f00eb9c3))
 
 ## v2.3.0
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
@@ -14,8 +14,8 @@
 			v-bind="options.fileList"
 			:files="fileList"
 			@delete-file="resetFile"
-			@retry="showFileUpload"
-			@upload="showFileUpload"
+			@retry="uploadInline"
+			@upload="uploadInline"
 			@view-file="emitViewFileEvent"
 		/>
 
@@ -23,8 +23,8 @@
 			ref="fileUpload"
 			v-bind="options.fileUpload"
 			v-model="uploadedFile"
-			@change="fileSelected"
 			@error="uploadError"
+			@change="fileSelected"
 		/>
 
 		<DialogBox
@@ -89,6 +89,9 @@
 	export default class UploadWorkflow extends MixinsDeclaration {
 		locales = locales;
 
+		// UploadWorkflowCore mixin
+		inlineSelect!: boolean;
+
 		selectRules = [
 			required
 		];
@@ -101,8 +104,9 @@
 			return locales.title(this.value.length > 1);
 		}
 
-		showFileUpload(id: string): void {
+		uploadInline(id: string): void {
 			this.selectedItem = id;
+			this.inlineSelect = true;
 			this.$refs.fileUpload.retry();
 		}
 	}

--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
@@ -20,6 +20,7 @@ interface TestComponent extends Vue {
 	fileList: FileListItem[];
 	error: boolean;
 	dialog: boolean;
+	inlineSelect: boolean;
 	selectedItem: string;
 	singleMode(): boolean;
 	fileSelected(): void;
@@ -182,7 +183,7 @@ describe('EventsFileFired', () => {
 
 		wrapper.vm.fileSelected();
 
-		expect(wrapper.vm.dialog).toBe(false);
+		expect(wrapper.vm.dialog).toBeFalsy();
 		expect(wrapper.vm.selectedItem).toEqual(fileListItem.id);
 	});
 
@@ -192,7 +193,18 @@ describe('EventsFileFired', () => {
 
 		wrapper.vm.fileSelected();
 
-		expect(wrapper.vm.dialog).toBe(true);
+		expect(wrapper.vm.dialog).toBeTruthy();
+	});
+
+	it('skips the dialog in inline upload mode', () => {
+		const value = [fileListItem, fileListItem];
+		const wrapper = createWrapper(value) as Wrapper<TestComponent>;
+
+		wrapper.setData({ inlineSelect: true });
+		wrapper.vm.fileSelected();
+
+		expect(wrapper.vm.selectedItem).toBe('');
+		expect(wrapper.vm.inlineSelect).toBeFalsy();
 	});
 
 	// uploadError
@@ -205,7 +217,7 @@ describe('EventsFileFired', () => {
 
 		await wrapper.vm.$nextTick();
 
-		expect(wrapper.vm.uploadedFile).toBe(null);
+		expect(wrapper.vm.uploadedFile).toBeNull();
 		expect(wrapper.emitted('error')).toBeTruthy();
 	});
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
@@ -38,6 +38,7 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 
 	dialog = false;
 	error = false;
+	inlineSelect = false;
 
 	uploadedFile: File | null = null;
 
@@ -108,6 +109,13 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 		if (this.singleMode) {
 			this.selectedItem = this.selectItems[0].value;
 			this.setFileInList();
+			return;
+		}
+
+		if (this.inlineSelect) {
+			this.setFileInList();
+			this.inlineSelect = false;
+			this.selectedItem = '';
 			return;
 		}
 


### PR DESCRIPTION
## Description

Sélection automatique du type de fichier lors de l'upload par ligne dans le composant `UploadWorkflow`.

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
