### PR TITLE
♻️ vue-dash: Use consola instead of @cnamts/cli-helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   - **global:** Correction des erreurs de lint ([#1915](https://github.com/assurance-maladie-digital/design-system/pull/1915)) ([42c4644](https://github.com/assurance-maladie-digital/design-system/commit/42c4644cde3cc9bd1925edb6a55e02dab58680a8))
 
 - 🔧 **Configuration**
-  - **scripts:** Refonte des scripts `build` et `post-install` ([#1935](https://github.com/assurance-maladie-digital/design-system/pull/1935))
+  - **scripts:** Refonte des scripts `build` et `post-install` ([#1935](https://github.com/assurance-maladie-digital/design-system/pull/1935)) ([3ead4d7](https://github.com/assurance-maladie-digital/design-system/commit/3ead4d7e1697a9445fbc2b59d362c599d2db4a52))
 
 - ⬆️ **Dépendances**
   - **DownloadBtn:** Remplacement de la dépendance `content-disposition` par `content-disposition-header` ([#1895](https://github.com/assurance-maladie-digital/design-system/pull/1895)) ([6008bb3](https://github.com/assurance-maladie-digital/design-system/commit/6008bb3b01c0d34c28b545162478da09d4ac625d))
@@ -44,6 +44,7 @@
 
 - ♻️ **Refactoring**
   - **template:** Modification de la position du bouton *Retour* ([#1912](https://github.com/assurance-maladie-digital/design-system/pull/1912)) ([cb0f08f](https://github.com/assurance-maladie-digital/design-system/commit/cb0f08fdb8bc427b7df372830fd0b18c0021b0ab))
+  - **global:** Utilisation de `consola` à la place de `@cnamts/cli-helpers` ([#1936](https://github.com/assurance-maladie-digital/design-system/pull/1936))
 
 - 🎨 **Qualité de code**
   - **global:** Amélioration de la qualité du code ([#1908](https://github.com/assurance-maladie-digital/design-system/pull/1908)) ([7a25f77](https://github.com/assurance-maladie-digital/design-system/commit/7a25f77243e5ea7a0a2a900d1c1ed08628b6d46b))

--- a/packages/vue-cli-plugin-vue-dash/fixEnvFile.js
+++ b/packages/vue-cli-plugin-vue-dash/fixEnvFile.js
@@ -1,11 +1,10 @@
 const fs = require('fs');
-
-const { log, warn, getPath } = require('@cnamts/cli-helpers');
-
-const { fileExists } = require('./utils');
+const consola = require('consola');
 
 const ENV_DIST_PATH = 'public/js/config.js.dist';
 const ENV_PATH = 'public/js/config.js';
+
+const { getPath } = require('./utils');
 
 /**
  * Copy env file if missing to save debugging time
@@ -16,15 +15,14 @@ function fixEnvFile() {
 	const envFilePathDist = getPath(ENV_DIST_PATH);
 	const envFilePath = getPath(ENV_PATH);
 
-	const shouldCopyFile = !fileExists(envFilePath) && fileExists(envFilePathDist);
+	const shouldCopyFile = !fs.existsSync(envFilePath) && fs.existsSync(envFilePathDist);
 
 	if (shouldCopyFile) {
-		warn('Fix missing config.js file');
+		consola.warn('Fix missing config.js file');
 
 		fs.copyFileSync(envFilePathDist, envFilePath);
 
-		log(`Copied ${ENV_DIST_PATH} to ${ENV_PATH}`);
-		log();
+		consola.info(`Copied ${ENV_DIST_PATH} to ${ENV_PATH}`);
 	}
 }
 

--- a/packages/vue-cli-plugin-vue-dash/generator/functions/fixPackageIndentation.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/functions/fixPackageIndentation.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 
-const { getPath } = require('@cnamts/cli-helpers');
+const { getPath } = require('../../utils');
 
 const TAB_CHARACTER = '	';
 const SPACE_REGEX = / {2}/gm;
@@ -13,13 +13,7 @@ const SPACE_REGEX = / {2}/gm;
  * @returns {void}
  */
 function fixPackageIndentation(invoking, projectName) {
-	let packagePath;
-
-	if (invoking) {
-		packagePath = getPath('package.json');
-	} else {
-		packagePath = getPath(projectName + '/package.json');
-	}
+	const packagePath = getPath(invoking ? 'package.json' : projectName + '/package.json');
 
 	const package = fs.readFileSync(packagePath).toString();
 

--- a/packages/vue-cli-plugin-vue-dash/package.json
+++ b/packages/vue-cli-plugin-vue-dash/package.json
@@ -23,7 +23,7 @@
 		"lint": "eslint . --fix"
 	},
 	"dependencies": {
-		"@cnamts/cli-helpers": "^2.1.0",
+		"consola": "^2.15.3",
 		"dayjs": "^1.8.34",
 		"fs-extra": "^10.0.0",
 		"superb": "^4.0.0"

--- a/packages/vue-cli-plugin-vue-dash/utils.js
+++ b/packages/vue-cli-plugin-vue-dash/utils.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const path = require('path');
 
 /**
  * Capitalize the first letter of a string
@@ -11,16 +11,16 @@ function capitalizeFirstLetter(string) {
 }
 
 /**
- * Checks if the file exists (sync)
+ * Get path relative to current working directory
  *
- * @param {string} path The path of the file
- * @returns {boolean} If the file exists
+ * @param {string} value The path to join
+ * @returns {string} The normalized path
  */
-function fileExists(path) {
-	return fs.existsSync(path);
+function getPath(value) {
+	return path.join(process.cwd(), value);
 }
 
 module.exports = {
 	capitalizeFirstLetter,
-	fileExists
+	getPath
 };


### PR DESCRIPTION
## Description

Utilisation de `consola` à la place de `@cnamts/cli-helpers`  dans Vue Dash.

## Type de changement

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
