### PR TITLE
✨ vue-dot: Add home-href prop to HeaderBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - **HeaderBar:** Ajout du thème *Compte entreprise* ([#1898](https://github.com/assurance-maladie-digital/design-system/pull/1898)) ([c05b914](https://github.com/assurance-maladie-digital/design-system/commit/c05b9141519de7c0dbf2a03163db2d07b20521e3))
   - **CookieBanner:** Ajout d'un nouveau composant ([#1922](https://github.com/assurance-maladie-digital/design-system/pull/1922)) ([4d8d1d0](https://github.com/assurance-maladie-digital/design-system/commit/4d8d1d06a600ba63f4e8bb12b9745359dd6ed66b))
   - **CookiesPage:** Ajout d'un nouveau composant ([#1924](https://github.com/assurance-maladie-digital/design-system/pull/1924)) ([ae650be](https://github.com/assurance-maladie-digital/design-system/commit/ae650be71cac2a0fa39945798a28dedc63ca98d5))
+  - **HeaderBar:** Ajout de la prop `home-href` ([#1966](https://github.com/assurance-maladie-digital/design-system/pull/1966))
 
 - 🐛 **Corrections de bugs**
   - **ExternalLinks:** Correction de l'affichage du menu ([#1889](https://github.com/assurance-maladie-digital/design-system/pull/1889)) ([e6f1b7f](https://github.com/assurance-maladie-digital/design-system/commit/e6f1b7f32b55fcf51cd70b0bd413cb13383ffef9))

--- a/packages/docs/src/data/api/header-bar.ts
+++ b/packages/docs/src/data/api/header-bar.ts
@@ -57,6 +57,13 @@ const homeLinkProp = {
 	description: 'Le lien vers la page d’accueil.<br>La valeur `false` permet de désactiver le lien.'
 };
 
+const homeHrefProp = {
+	name: 'home-href',
+	type: 'String',
+	default: 'undefined',
+	description: 'Un lien externe à l’application vers la page d’accueil.'
+};
+
 const drawerProp = {
 	name: 'drawer',
 	type: 'boolean',
@@ -81,6 +88,7 @@ export const api: Api = {
 			},
 			innerWidthProp,
 			homeLinkProp,
+			homeHrefProp,
 			{
 				name: 'show-nav-bar-menu-btn',
 				type: 'boolean',
@@ -129,7 +137,8 @@ export const api: Api = {
 			titleProp,
 			subTitleProp,
 			mobileVersionProp,
-			homeLinkProp
+			homeLinkProp,
+			homeHrefProp
 		],
 		slots: [
 			{

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderBar.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderBar.vue
@@ -24,6 +24,7 @@
 						:service-sub-title="serviceSubTitle"
 						:mobile-version="isMobileVersion"
 						:home-link="homeLink"
+						:home-href="homeHref"
 					>
 						<slot name="secondary-logo" />
 					</HeaderBrandSection>
@@ -119,6 +120,10 @@
 			},
 			homeLink: {
 				type: [String, Boolean, Object] as PropType<Next>,
+				default: undefined
+			},
+			homeHref: {
+				type: String,
 				default: undefined
 			},
 			showNavBarMenuBtn: {

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderBrandSection/HeaderBrandSection.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderBrandSection/HeaderBrandSection.vue
@@ -8,6 +8,7 @@
 			:aria-current-value="null"
 			:aria-label="locales.homeLinkLabel"
 			:to="homeLink"
+			:href="homeHref"
 			class="vd-header-home-link"
 		>
 			<Logo
@@ -105,6 +106,10 @@
 			homeLink: {
 				type: [String, Boolean, Object] as PropType<Next>,
 				default: '/'
+			},
+			homeHref: {
+				type: String,
+				default: undefined
 			}
 		}
 	});
@@ -164,6 +169,10 @@
 		}
 
 		get logoContainerComponent(): string {
+			if (this.homeHref) {
+				return 'a';
+			}
+
 			return this.homeLink ? 'RouterLink' : 'div';
 		}
 


### PR DESCRIPTION
## Description

Ajout de la prop `home-href` dans le composant `HeaderBar`.

Cette prop permet d'utiliser un lien externe à l'application pour le lien vers la page d'accueil, ce qui est utile pour des projets qui s'intègrent dans des portails.

## Type de changement

- Nouvelle fonctionnalité
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
