### PR TITLE
✨ vue-dot: Add link to secondary logo in HeaderBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   - **HeaderBar:** Ajout du thème *Compte entreprise* ([#1898](https://github.com/assurance-maladie-digital/design-system/pull/1898)) ([c05b914](https://github.com/assurance-maladie-digital/design-system/commit/c05b9141519de7c0dbf2a03163db2d07b20521e3))
   - **CookieBanner:** Ajout d'un nouveau composant ([#1922](https://github.com/assurance-maladie-digital/design-system/pull/1922)) ([4d8d1d0](https://github.com/assurance-maladie-digital/design-system/commit/4d8d1d06a600ba63f4e8bb12b9745359dd6ed66b))
   - **CookiesPage:** Ajout d'un nouveau composant ([#1924](https://github.com/assurance-maladie-digital/design-system/pull/1924)) ([ae650be](https://github.com/assurance-maladie-digital/design-system/commit/ae650be71cac2a0fa39945798a28dedc63ca98d5))
-  - **HeaderBar:** Ajout de la prop `home-href` ([#1966](https://github.com/assurance-maladie-digital/design-system/pull/1966))
+  - **HeaderBar:** Ajout de la prop `home-href` ([#1966](https://github.com/assurance-maladie-digital/design-system/pull/1966)) ([d288de2](https://github.com/assurance-maladie-digital/design-system/commit/d288de2eb1fd5577fee0bc79b7245e2284155882))
+  - **HeaderBar:** Ajout d'un lien vers la page d'accueil sur le logo secondaire ([#1967](https://github.com/assurance-maladie-digital/design-system/pull/1967))
 
 - 🐛 **Corrections de bugs**
   - **ExternalLinks:** Correction de l'affichage du menu ([#1889](https://github.com/assurance-maladie-digital/design-system/pull/1889)) ([e6f1b7f](https://github.com/assurance-maladie-digital/design-system/commit/e6f1b7f32b55fcf51cd70b0bd413cb13383ffef9))

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderBrandSection/HeaderBrandSection.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderBrandSection/HeaderBrandSection.vue
@@ -33,11 +33,20 @@
 				<path d="M14.3 49.3c-.2 0-.4-.2-.4-.4V14.2c0-.2.2-.4.4-.4.3 0 .5.2.5.4v34.7c0 .2-.2.4-.5.4Z" />
 			</svg>
 
-			<img
+			<component
+				:is="secondaryLogoCtnComponent"
 				v-if="secondaryLogo"
-				:src="secondaryLogo.src"
-				:alt="secondaryLogo.alt"
+				:aria-current-value="null"
+				:aria-label="secondaryLogoLabel"
+				:to="homeLink"
+				:href="homeHref"
+				class="vd-header-home-link"
 			>
+				<img
+					:src="secondaryLogo.src"
+					:alt="secondaryLogo.alt"
+				>
+			</component>
 
 			<div
 				v-else-if="service.title || service.subTitle"
@@ -168,12 +177,32 @@
 			return Boolean(this.$slots.default || this.secondaryLogo);
 		}
 
+		get hasSecondaryLogoLink(): boolean {
+			return this.theme === ThemeEnum.AMELI_PRO || this.theme === ThemeEnum.AMELI;
+		}
+
 		get logoContainerComponent(): string {
 			if (this.homeHref) {
 				return 'a';
 			}
 
 			return this.homeLink ? 'RouterLink' : 'div';
+		}
+
+		get secondaryLogoCtnComponent(): string {
+			if (this.hasSecondaryLogoLink) {
+				return this.logoContainerComponent;
+			}
+
+			return 'div';
+		}
+
+		get secondaryLogoLabel(): string | null {
+			if (this.hasSecondaryLogoLink && this.secondaryLogo) {
+				return `${locales.homeLinkPrefix} ${this.secondaryLogo.alt}`;
+			}
+
+			return null;
 		}
 
 		get showDivider(): boolean {

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderBrandSection/locales.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderBrandSection/locales.ts
@@ -1,7 +1,8 @@
 export const locales = {
+	homeLinkPrefix: 'Accueil,',
 	homeLinkLabel: 'Accueil, l’Assurance Maladie',
 	logoCnam: 'Caisse nationale',
-	logoAmeli: 'Ameli.fr',
+	logoAmeli: 'ameli.fr',
 	logoAmeliPro: 'AmeliPro',
 	compteEntreprise: {
 		title: {


### PR DESCRIPTION
## Description

Ajout d'un lien vers la page d'accueil sur le logo secondaire dans le composant `HeaderBar`.

## Playground

<details>

```vue
<template>
	<HeaderBar
		service-title="Design System"
		theme="ameli-pro"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
