### PR TITLE
🐛 vue-dot: Hide close button on persistent mode in DialogBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 - 🐛 **Corrections de bugs**
   - **DatePicker:** Correction du parsing de la date ([#2095](https://github.com/assurance-maladie-digital/design-system/pull/2095)) ([28d713c](https://github.com/assurance-maladie-digital/design-system/commit/28d713c139f80c2998ec5d605244837870146786))
-  - **FilterModule:** Correction de l'ordre du contenu ([#2184](https://github.com/assurance-maladie-digital/design-system/pull/2184))
+  - **FilterModule:** Correction de l'ordre du contenu ([#2184](https://github.com/assurance-maladie-digital/design-system/pull/2184)) ([111c771](https://github.com/assurance-maladie-digital/design-system/commit/111c7715070922a25dcff86384a73c3537293b75))
+  - **DialogBox:** Correction de l'affichage du bouton *Fermer* en mode persistant ([#2185](https://github.com/assurance-maladie-digital/design-system/pull/2185))
 
 - ♿️ **Accessibilité**
   - **FilterModule:** Ajout de la propriété `attach` sur le menu ([#2073](https://github.com/assurance-maladie-digital/design-system/pull/2073)) ([658f95d](https://github.com/assurance-maladie-digital/design-system/commit/658f95d98db3e43df16b16667a093796448a0876))

--- a/packages/docs/src/data/api/dialog-box.ts
+++ b/packages/docs/src/data/api/dialog-box.ts
@@ -40,6 +40,12 @@ export const api: Api = {
 				description: 'Masque les boutons d’actions.'
 			},
 			{
+				name: 'persistent',
+				type: 'boolean',
+				default: false,
+				description: 'Désactive la fermeture de la boîte de dialogue lors de l’appui sur la touche *Échap* ou du clic en-dehors de l’élément.'
+			},
+			{
 				name: 'vuetify-options',
 				type: 'Options',
 				default: 'undefined',

--- a/packages/docs/src/data/examples/dialog-box/usage.vue
+++ b/packages/docs/src/data/examples/dialog-box/usage.vue
@@ -44,7 +44,8 @@
 
 		options = {
 			booleans: [
-				'hideActions'
+				'hideActions',
+				'persistent'
 			],
 			textFields: [
 				'title',

--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -3,6 +3,7 @@
 		v-model="dialog"
 		v-bind="$attrs"
 		:width="width"
+		:persistent="persistent"
 		class="vd-dialog-box"
 	>
 		<VCard v-bind="options.card">
@@ -19,6 +20,7 @@
 				<VSpacer v-bind="options.spacer" />
 
 				<VBtn
+					v-if="!persistent"
 					v-bind="options.closeBtn"
 					:aria-label="locales.closeBtn"
 					@click="close"
@@ -92,6 +94,10 @@
 				default: locales.confirmBtn
 			},
 			hideActions: {
+				type: Boolean,
+				default: false
+			},
+			persistent: {
 				type: Boolean,
 				default: false
 			}


### PR DESCRIPTION
## Description

Correction de l'affichage du bouton *Fermer* en mode persistant dans le composant `DialogBox`.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<div>
		<VBtn
			color="primary"
			@click="dialog = true"
		>
			Afficher le composant
		</VBtn>

		<DialogBox
			v-model="dialog"
			title="Enregistrement"
			persistent
			@cancel="dialog = false"
			@confirm="dialog = false"
		>
			<p>Souhaitez-vous procéder à l’enregistrement ?</p>
		</DialogBox>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		dialog = false;
	}
</script>
```

</details>

## Type de changement

- Correction de bug
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
