### PR TITLE
🐛 docs: Fix root element class name in DocA11yCriteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - 🐛 **Corrections de bugs**
   - **introduction:** Correction du contenu de la section *Équipe* ([#2197](https://github.com/assurance-maladie-digital/design-system/pull/2197)) ([2e5fda8](https://github.com/assurance-maladie-digital/design-system/commit/2e5fda8311f334f92f0e16ee35097f2eba4b6cce))
-  - **NotificationBar:** Correction de l'exemple `options` ([#2198](https://github.com/assurance-maladie-digital/design-system/pull/2198))
+  - **NotificationBar:** Correction de l'exemple `options` ([#2198](https://github.com/assurance-maladie-digital/design-system/pull/2198)) ([90b7dc0](https://github.com/assurance-maladie-digital/design-system/commit/90b7dc0c2e46358f631a9a3f1b7ff7e2c545d47b))
+  - **DocA11yCriteria:** Correction du nom de la classe de l'élément principal ([#2200](https://github.com/assurance-maladie-digital/design-system/pull/2200))
 
 - 📝 **Documentation**
   - **global:** Ajout de la page *Design Tokens* ([#2117](https://github.com/assurance-maladie-digital/design-system/pull/2117)) ([51e8952](https://github.com/assurance-maladie-digital/design-system/commit/51e8952f4958d3799e4fc10b417fa63d21fd6188))

--- a/packages/docs/src/components/global/DocA11yCriteria.vue
+++ b/packages/docs/src/components/global/DocA11yCriteria.vue
@@ -1,7 +1,7 @@
 <template>
 	<VExpansionPanels
 		accordion
-		class="doc-roadmap w-100"
+		class="doc-a11y-criteria w-100"
 	>
 		<VExpansionPanel
 			v-for="(item, index) in items"


### PR DESCRIPTION
## Description

Correction du nom de la classe de l'élément principal du composant `DocA11yCriteria`.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
