### PR TITLE
✨ vue-dot: Allow number as key type in IndexedObject interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ✨ **Nouvelles fonctionnalités**
   - **PhoneField:** Ajout d'un nouveau composant ([#2204](https://github.com/assurance-maladie-digital/design-system/pull/2204)) ([cd9d4be](https://github.com/assurance-maladie-digital/design-system/commit/cd9d4be341cf021b1343963947793488cefa56dd))
+  - **IndexedObject:** Modification du type de la clé ([#2274](https://github.com/assurance-maladie-digital/design-system/pull/2274))
 
 ### Vue Dash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - ✨ **Nouvelles fonctionnalités**
   - **PhoneField:** Ajout d'un nouveau composant ([#2204](https://github.com/assurance-maladie-digital/design-system/pull/2204)) ([cd9d4be](https://github.com/assurance-maladie-digital/design-system/commit/cd9d4be341cf021b1343963947793488cefa56dd))
-  - **IndexedObject:** Modification du type de la clé ([#2274](https://github.com/assurance-maladie-digital/design-system/pull/2274))
+  - **types:** Modification du type de la clé de l'interface `IndexedObject` ([#2274](https://github.com/assurance-maladie-digital/design-system/pull/2274))
 
 ### Vue Dash
 

--- a/packages/design-tokens/src/colors.ts
+++ b/packages/design-tokens/src/colors.ts
@@ -1,5 +1,5 @@
 import { toKebabCase } from './utils';
-import { Palette, VuetifyTheme, Colors, IndexedObject } from './types';
+import { Palette, VuetifyTheme, Colors } from './types';
 
 export const palette: Palette = {
 	amBlue: {
@@ -170,6 +170,10 @@ export const lightTheme: VuetifyTheme = {
 	warning: palette.yellow.darken40,
 	risquePro: palette.brick.base
 };
+
+interface IndexedObject<T = string> {
+	[key: string | number]: T;
+}
 
 export const colorClasses: IndexedObject = {};
 

--- a/packages/design-tokens/src/types.d.ts
+++ b/packages/design-tokens/src/types.d.ts
@@ -1,7 +1,3 @@
-export interface IndexedObject<T = string> {
-	[key: string]: T;
-}
-
 export interface Theme {
 	primary: string;
 	secondary: string;

--- a/packages/vue-dot/src/types.d.ts
+++ b/packages/vue-dot/src/types.d.ts
@@ -10,7 +10,7 @@ import { NavigationGuardNext } from 'vue-router';
 export type Refs<T extends Record<string, unknown>> = Vue['$refs'] & T;
 
 export interface IndexedObject<T = string> {
-	[key: string]: T;
+	[key: string | number]: T;
 }
 
 export type Next = NavigationGuardNext<Vue>;


### PR DESCRIPTION
## Description

Set key type `string | number` in `IndexedObject` interface
Move and remove export from similar interface in package `design-tokens`

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [X] Ma Pull Request pointe vers la bonne branche
- [X] Mon code suit le style de code du projet
- [X] J'ai effectué une review de mon propre code
- [X] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [X] J'ai apporté les modifications correspondantes à la documentation
- [X] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
