### PR TITLE
🐛 vue-dash: Fix lint hook not blocking warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Non publié
+
+### Vue Dash
+
+- 🐛 **Corrections de bugs**
+  - **template:** Correction du hook de qualité ne bloquant pas les warnings ([#2376](https://github.com/assurance-maladie-digital/design-system/pull/2376))
+
 ## v2.7.1
 
 **Version publiée le 07/11/2022.**

--- a/packages/vue-cli-plugin-vue-dash/generator/template/lint-staged.config.js
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	'*.{ts,vue}': [
-		'vue-cli-service lint'
+		'vue-cli-service lint --max-warnings=0'
 	]
 };


### PR DESCRIPTION
## Description

Correction du hook de qualité ne bloquant pas les warnings dans le Starter Kit.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
