### PR TITLE
components: fix tab navigation on dialogBox

### DIFF
--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -5,6 +5,7 @@
 		:width="width"
 		:persistent="persistent"
 		class="vd-dialog-box"
+		aria-modal="true"
 	>
 		<VCard v-bind="options.card">
 			<VCardTitle v-bind="options.cardTitle">
@@ -106,11 +107,18 @@
 
 	const MixinsDeclaration = mixins(Props, customizable(config));
 
-	@Component({
+	@Component<DialogBox>({
 		inheritAttrs: false,
 		model: {
 			prop: 'value',
 			event: 'change'
+		},
+		watch: {
+			dialog(value: boolean) {
+				if (value) {
+					this.setFocus();
+				}
+			}
 		}
 	})
 	export default class DialogBox extends MixinsDeclaration {
@@ -128,6 +136,30 @@
 
 		close(): void {
 			this.$emit('change', false);
+		}
+
+		setFocus(): void {
+			this.$nextTick(() => {
+				// to make NodeList works
+				// eslint-disable-next-line no-undef
+				const focusable = this.$el.querySelectorAll('button, input, select, textarea') as NodeListOf<HTMLElement>;
+
+				if (focusable.length) {
+					for (let i = 0; i < focusable.length; i++) {
+						// if we use Tab key, we can focus on targeted elements
+						focusable[i].addEventListener('keydown', (e: KeyboardEvent) => {
+							if (e.key === 'Tab') {
+								e.preventDefault();
+								if (i === focusable.length - 1) {
+									focusable[0].focus();
+								} else {
+									focusable[i + 1].focus();
+								}
+							}
+						});
+					}
+				}
+			});
 		}
 	}
 </script>


### PR DESCRIPTION
## Description

Fix tab navigation on DialogBox component

## Playground

<details>

```vue
<template>
	<div>
		<VBtn
			color="primary"
			@click="dialog = true"
		>
			Afficher le composant
		</VBtn>

		<DialogBox
			v-model="dialog"
			:width="dialogWidth"
			title="Enregistrement"
			@cancel="dialog = false"
			@confirm="dialog = false"
		>
			<p>Souhaitez-vous procéder à l’enregistrement ?</p>
		</DialogBox>
	</div>
</template>
<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { tokens } from '@cnamts/design-tokens';

	@Component
	export default class DialogBoxWidth extends Vue {
		dialog = false;

		dialogWidth = tokens.dialogWidth.dialogSmall;
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
