### PR TITLE
🐛 vue-dot: Fix vertical spacing in FooterBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Non publié
 
+### Vue Dot
+
+- 🐛 **Corrections de bugs**
+  - **FooterBar:** Correction de l'espacement vertical ([#2398](https://github.com/assurance-maladie-digital/design-system/pull/2398))
+
 ### Vue Dash
 
 - 🐛 **Corrections de bugs**
@@ -19,7 +24,7 @@
   - **typescript-eslint:** Mise à jour du monorepo vers la `v5.43.0` ([#2383](https://github.com/assurance-maladie-digital/design-system/pull/2383)) ([b3c3d58](https://github.com/assurance-maladie-digital/design-system/commit/b3c3d58ecb78b80111f8c8cf01b568b3e4d9769f))
   - **netlify-cli:** Mise à jour vers la `v12.2.0` ([#2387](https://github.com/assurance-maladie-digital/design-system/pull/2387)) ([7314786](https://github.com/assurance-maladie-digital/design-system/commit/73147864ad224288f3f53abbd8673b29713e2c0e))
   - **sass-loader:** Mise à jour vers la `v10.4.1` ([#2388](https://github.com/assurance-maladie-digital/design-system/pull/2388)) ([c0f9de6](https://github.com/assurance-maladie-digital/design-system/commit/c0f9de6963e2df4e73a6b2f4f494c0f07b11f051))
-  - **typescript:** Mise à jour vers la `v4.9.3` ([#2389](https://github.com/assurance-maladie-digital/design-system/pull/2389))
+  - **typescript:** Mise à jour vers la `v4.9.3` ([#2389](https://github.com/assurance-maladie-digital/design-system/pull/2389)) ([ae1b3e4](https://github.com/assurance-maladie-digital/design-system/commit/ae1b3e423964aede8a900ef0daad4d758dd1e9af))
 
 ## v2.7.1
 

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -57,7 +57,7 @@
 
 		<div
 			:class="{ 'py-2 py-sm-0': !extendedMode }"
-			class="vd-footer-bar-links text-sm-center d-flex flex-column flex-sm-row flex-wrap align-start justify-center max-width-none mx-n3 my-n4"
+			class="vd-footer-bar-links text-sm-center d-flex flex-column flex-sm-row flex-wrap align-start justify-center max-width-none mx-n3 my-n3"
 		>
 			<slot name="prepend" />
 

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`FooterBar renders correctly 1`] = `
   <!---->
   <!---->
   <!---->
-  <div class="vd-footer-bar-links text-sm-center d-flex flex-column flex-sm-row flex-wrap align-start justify-center max-width-none mx-n3 my-n4 py-2 py-sm-0">
+  <div class="vd-footer-bar-links text-sm-center d-flex flex-column flex-sm-row flex-wrap align-start justify-center max-width-none mx-n3 my-n3 py-2 py-sm-0">
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
       Plan du site
     </routerlink-stub>


### PR DESCRIPTION
## Description

Correction de l'espacement vertical dans le composant `FooterBar`.

## Playground


<details>

```vue
<template>
	<div class="d-flex flex-column justify-end h-100">
		<FooterBar />
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>

```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
