### PR TITLE
Feat/#2483 Footer: lien cookie

### DIFF
--- a/packages/docs/src/data/api/footer-bar.ts
+++ b/packages/docs/src/data/api/footer-bar.ts
@@ -23,6 +23,12 @@ export const api: Api = {
 				description: 'La valeur de la prop `to` du lien vers les *Conditions générales d’utilisation*.'
 			},
 			{
+				name: 'cookies-route',
+				type: 'RawLocation',
+				default: `{ name: 'cookies' }`,
+				description: 'La valeur de la prop `to` du lien vers la *Gestion des cookies*.'
+			},
+			{
 				name: 'legal-notice-route',
 				type: 'RawLocation',
 				default: `{ name: 'legalNotice' }`,
@@ -45,6 +51,12 @@ export const api: Api = {
 				type: 'boolean',
 				default: false,
 				description: 'Masque le lien vers les *Conditions générales d’utilisation*.'
+			},
+			{
+				name: 'hide-cookies-link',
+				type: 'boolean',
+				default: false,
+				description: 'Masque le lien vers la *Gestion des cookies*.'
 			},
 			{
 				name: 'hide-legal-notice-link',

--- a/packages/docs/src/data/examples/footer-bar/default-slot.vue
+++ b/packages/docs/src/data/examples/footer-bar/default-slot.vue
@@ -15,6 +15,7 @@
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',
+			cookiesRoute: '/',
 			legalNoticeRoute: '/',
 			a11yStatementRoute: '/'
 		};

--- a/packages/docs/src/data/examples/footer-bar/hide-social-media-links.vue
+++ b/packages/docs/src/data/examples/footer-bar/hide-social-media-links.vue
@@ -18,6 +18,7 @@
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',
+			cookiesRoute: '/',
 			legalNoticeRoute: '/',
 			a11yStatementRoute: '/'
 		};

--- a/packages/docs/src/data/examples/footer-bar/options.vue
+++ b/packages/docs/src/data/examples/footer-bar/options.vue
@@ -20,6 +20,7 @@
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',
+			cookiesRoute: '/',
 			legalNoticeRoute: '/',
 			a11yStatementRoute: '/'
 		};

--- a/packages/docs/src/data/examples/footer-bar/slots.vue
+++ b/packages/docs/src/data/examples/footer-bar/slots.vue
@@ -48,6 +48,7 @@
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',
+			cookiesRoute: '/',
 			legalNoticeRoute: '/',
 			a11yStatementRoute: '/'
 		};

--- a/packages/docs/src/data/examples/footer-bar/socialMediaLinks.vue
+++ b/packages/docs/src/data/examples/footer-bar/socialMediaLinks.vue
@@ -20,6 +20,7 @@
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',
+			cookiesRoute: '/',
 			legalNoticeRoute: '/',
 			a11yStatementRoute: '/'
 		};

--- a/packages/docs/src/data/examples/footer-bar/usage.vue
+++ b/packages/docs/src/data/examples/footer-bar/usage.vue
@@ -21,6 +21,7 @@
 			a11yCompliance: A11yComplianceEnum.NON_COMPLIANT,
 			sitemapRoute: '/',
 			cguRoute: '/',
+			cookiesRoute: '/',
 			legalNoticeRoute: '/',
 			a11yStatementRoute: '/'
 		};
@@ -29,6 +30,7 @@
 			'sitemapRoute',
 			'a11yCompliance',
 			'cguRoute',
+			'cookiesRoute',
 			'legalNoticeRoute',
 			'a11yStatementRoute'
 		];
@@ -44,6 +46,7 @@
 			booleans: [
 				'hideSitemapLink',
 				'hideCguLink',
+				'hideCookiesLink',
 				'hideLegalNoticeLink',
 				'hideA11yLink'
 			],

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -78,6 +78,14 @@
 			</RouterLink>
 
 			<RouterLink
+				v-if="!hideCookiesLink"
+				v-bind="options.routerLink"
+				:to="cookiesRoute"
+			>
+				{{ locales.cookiesLabel }}
+			</RouterLink>
+
+			<RouterLink
 				v-if="!hideLegalNoticeLink"
 				v-bind="options.routerLink"
 				:to="legalNoticeRoute"
@@ -142,6 +150,10 @@
 				type: [Array, Object, String] as PropType<RawLocation>,
 				default: () => ({ name: 'cgu' })
 			},
+			cookiesRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'cookies' })
+			},
 			legalNoticeRoute: {
 				type: [Array, Object, String] as PropType<RawLocation>,
 				default: () => ({ name: 'legalNotice' })
@@ -155,6 +167,10 @@
 				default: false
 			},
 			hideCguLink: {
+				type: Boolean,
+				default: false
+			},
+			hideCookiesLink: {
 				type: Boolean,
 				default: false
 			},

--- a/packages/vue-dot/src/patterns/FooterBar/locales.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/locales.ts
@@ -4,6 +4,7 @@ export const locales = {
 	goTopBtnLabel: 'Retour en haut de la page',
 	sitemapLabel: 'Plan du site',
 	cguLabel: 'Conditions générales d’utilisation',
+	cookiesLabel: 'Gestion des cookies',
 	legalNoticeLabel: 'Mentions légales',
 	versionLabel: 'Version',
 	followUs: 'Suivez-nous',

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -13,6 +13,9 @@ exports[`FooterBar renders correctly 1`] = `
       Conditions générales d’utilisation
     </routerlink-stub>
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
+      Gestion des cookies
+    </routerlink-stub>
+    <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
       Mentions légales
     </routerlink-stub>
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">


### PR DESCRIPTION
## Description

Ajouter un lien interne vers la page des cookies dans les 2 versions (simple et large) du footer

## Playground

<details>

```vue
<template>
	<PageContainer>
		<FooterBar />
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
