### PR TITLE
Feat/ErrorPage : add warning message for v2.9.0

### DIFF
--- a/packages/docs/src/content/templates/error-page.md
+++ b/packages/docs/src/content/templates/error-page.md
@@ -3,6 +3,13 @@ title: ErrorPage
 description: Le template `ErrorPage` est utilisé pour afficher une page d’erreur.
 ---
 
+<doc-alert type="warning">
+
+Ce composant est déprécié en faveur des composants [`MaintenancePage`](/composants/templates/maintenance-page)
+ et [`NotFoundPage`](/composants/templates/notfound-page) depuis la [version 2.9.0](https://github.com/assurance-maladie-digital/design-system/releases/tag/2.9.0).
+
+</doc-alert>
+
 <doc-tabs>
 
 <doc-tab-item label="Utilisation">

--- a/packages/docs/src/content/templates/error-page.md
+++ b/packages/docs/src/content/templates/error-page.md
@@ -5,8 +5,8 @@ description: Le template `ErrorPage` est utilisé pour afficher une page d’err
 
 <doc-alert type="warning">
 
-Ce composant est déprécié en faveur des composants [`MaintenancePage`](/composants/templates/maintenance-page)
- et [`NotFoundPage`](/composants/templates/notfound-page) depuis la [version 2.9.0](https://github.com/assurance-maladie-digital/design-system/releases/tag/2.9.0).
+Ce composant est déprécié en faveur des composants [`MaintenancePage`](/templates/maintenance-page)
+ et [`NotFoundPage`](/templates/notfound-page) depuis la [version 2.9.0](https://github.com/assurance-maladie-digital/design-system/releases/tag/2.9.0).
 
 </doc-alert>
 


### PR DESCRIPTION
**A merge avec la v2.0.9**

## Description

Ajout d'un warning pour le composant ErrorPage :

![Capture d’écran 2023-01-17 à 09 27 15](https://user-images.githubusercontent.com/1822420/212847219-3814e819-f1b4-4c14-aed2-d7364261f348.png)

## Type de changement

- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
