### PR TITLE
Fix #2502 : Component > NotificationBar : fix warning styles

### DIFF
--- a/packages/docs/src/vuetify.options.ts
+++ b/packages/docs/src/vuetify.options.ts
@@ -8,7 +8,8 @@ export default {
 			light: colorTheme
 		},
 		options: {
-			variations: false
+			variations: false,
+			customProperties: true
 		}
 	},
 	icons: {

--- a/packages/vue-dot/dev/vuetify.ts
+++ b/packages/vue-dot/dev/vuetify.ts
@@ -11,6 +11,9 @@ export const vuetify = new Vuetify({
 	theme: {
 		themes: {
 			light: colorTheme
+		},
+		options: {
+			customProperties: true
 		}
 	},
 	icons: {

--- a/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
+++ b/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
@@ -137,7 +137,17 @@
 	.vd-notification-bar :deep(.v-snack__wrapper) {
 		min-width: 0;
 	}
-
+	.vd-notification-bar :deep(.warning) {
+		background-color: var(--v-yellow-base) !important;
+		border-color: var(--v-yellow-base) !important;
+		color: var(--v-black) !important;
+		.v-icon__svg {
+			fill: var(--v-black) !important;
+		}
+		.v-btn {
+			color: var(--v-black) !important;
+		}
+	}
 	.vd-notification-icon {
 		min-width: 24px;
 	}

--- a/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
+++ b/packages/vue-dot/src/patterns/NotificationBar/NotificationBar.vue
@@ -133,19 +133,21 @@
 </script>
 
 <style lang="scss" scoped>
+	@import '@cnamts/design-tokens/dist/tokens';
+
 	// Use min-width to avoid shrinking with flexbox
 	.vd-notification-bar :deep(.v-snack__wrapper) {
 		min-width: 0;
 	}
 	.vd-notification-bar :deep(.warning) {
-		background-color: var(--v-yellow-base) !important;
-		border-color: var(--v-yellow-base) !important;
-		color: var(--v-black) !important;
+		background-color: $vd-yellow-base !important;
+		border-color: $vd-yellow-base !important;
+		color: $vd-grey-darken-80 !important;
 		.v-icon__svg {
-			fill: var(--v-black) !important;
+			fill: $vd-grey-darken-80 !important;
 		}
 		.v-btn {
-			color: var(--v-black) !important;
+			color: $vd-grey-darken-80 !important;
 		}
 	}
 	.vd-notification-icon {


### PR DESCRIPTION
## Description

Adapter le composant NotificationBar aux maquettes

![Capture d’écran 2023-01-30 à 15 51 56](https://user-images.githubusercontent.com/1822420/215512154-03233636-d21e-4a9b-8650-39a31a5edd26.png)

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
