### PR TITLE
Fix #2504 : Component > FooterBar : liens externes

### DIFF
--- a/packages/docs/src/content/composants/structure/footer-bar.md
+++ b/packages/docs/src/content/composants/structure/footer-bar.md
@@ -46,7 +46,7 @@ Vous pouvez personnaliser la liste des réseaux sociaux en utilisant la prop `so
 
 #### Liens externes
 
-Vous pouvez changer les liens par défaut par des liens externes en utilisant les props `sitemap-external-link`, `cgu-external-link`, `legal-notice-external-link` et  `a11y-statement-external-link`.
+Vous pouvez changer les liens par défaut par des liens externes en utilisant les props `sitemap-external-link`, `cgu-external-link`, `cookies-external-link`, `legal-notice-external-link` et  `a11y-statement-external-link`.
 
 <doc-example file="footer-bar/externalsLinks"></doc-example>
 

--- a/packages/docs/src/content/composants/structure/footer-bar.md
+++ b/packages/docs/src/content/composants/structure/footer-bar.md
@@ -44,6 +44,12 @@ Vous pouvez personnaliser la liste des réseaux sociaux en utilisant la prop `so
 
 <doc-example file="footer-bar/socialMediaLinks"></doc-example>
 
+#### Liens externes
+
+Vous pouvez changer les liens par défaut par des liens externes en utilisant les props `sitemap-external-link`, `cgu-external-link`, `legal-notice-external-link` et  `a11y-statement-external-link`.
+
+<doc-example file="footer-bar/externalsLinks"></doc-example>
+
 #### Composants Vuetify
 
 Vous pouvez personnaliser les composants Vuetify contenus dans le pattern `FooterBar` en utilisant la prop `vuetify-options`.

--- a/packages/docs/src/data/api/footer-bar.ts
+++ b/packages/docs/src/data/api/footer-bar.ts
@@ -29,16 +29,22 @@ export const api: Api = {
 				description: 'La valeur de la prop `to` du lien vers les *Conditions générales d’utilisation*.'
 			},
 			{
+				name: 'cgu-external-link',
+				type: 'string',
+				default: null,
+				description: 'L’URL du lien vers les *Conditions générales d’utilisation* si celui-ci est externe à l’application.'
+			},
+			{
 				name: 'cookies-route',
 				type: 'RawLocation',
 				default: `{ name: 'cookies' }`,
 				description: 'La valeur de la prop `to` du lien vers la *Gestion des cookies*.'
 			},
 			{
-				name: 'cgu-external-link',
+				name: 'cookies-external-link',
 				type: 'string',
 				default: null,
-				description: 'L’URL du lien vers les *Conditions générales d’utilisation* si celui-ci est externe à l’application.'
+				description: 'L’URL du lien vers la *Gestion des cookies* si celui-ci est externe à l’application.'
 			},
 			{
 				name: 'legal-notice-route',

--- a/packages/docs/src/data/api/footer-bar.ts
+++ b/packages/docs/src/data/api/footer-bar.ts
@@ -17,6 +17,12 @@ export const api: Api = {
 				description: 'La valeur de la prop `to` du lien vers le *Plan du site*.'
 			},
 			{
+				name: 'sitemap-external-link',
+				type: 'string',
+				default: null,
+				description: 'L’URL du lien vers le *Plan du site* si celui-ci est externe à l’application.'
+			},
+			{
 				name: 'cgu-route',
 				type: 'RawLocation',
 				default: `{ name: 'cgu' }`,
@@ -29,16 +35,34 @@ export const api: Api = {
 				description: 'La valeur de la prop `to` du lien vers la *Gestion des cookies*.'
 			},
 			{
+				name: 'cgu-external-link',
+				type: 'string',
+				default: null,
+				description: 'L’URL du lien vers les *Conditions générales d’utilisation* si celui-ci est externe à l’application.'
+			},
+			{
 				name: 'legal-notice-route',
 				type: 'RawLocation',
 				default: `{ name: 'legalNotice' }`,
 				description: 'La valeur de la prop `to` du lien vers les *Mentions légales*.'
 			},
 			{
+				name: 'legal-notice-external-link',
+				type: 'string',
+				default: null,
+				description: 'L’URL du lien vers les *Mentions légales* si celui-ci est externe à l’application.'
+			},
+			{
 				name: 'a11y-statement-route',
 				type: 'RawLocation',
 				default: `{ name: 'a11yStatement' }`,
 				description: 'La valeur de la prop `to` du lien vers la *Déclaration d’accessibilité*.'
+			},
+			{
+				name: 'a11y-statement-external-link',
+				type: 'string',
+				default: null,
+				description: 'L’URL du lien vers la *Déclaration d’accessibilité* si celui-ci est externe à l’application.'
 			},
 			{
 				name: 'hide-sitemap-link',

--- a/packages/docs/src/data/examples/footer-bar/externalsLinks.vue
+++ b/packages/docs/src/data/examples/footer-bar/externalsLinks.vue
@@ -1,7 +1,10 @@
 <template>
 	<FooterBar
 		v-bind="docProps"
-		hide-social-media-links
+		sitemap-external-link="https://www.ameli.fr/assure/plan-du-site"
+		cgu-external-link="https://www.ameli.fr/assure/mentions-legales-cgu"
+		legal-notice-external-link="https://www.ameli.fr/assure/mentions-legales-cgu"
+		a11y-statement-external-link="https://www.ameli.fr/rhone/assure/accessibilite"
 	>
 		<p class="text--secondary my-3">
 			Contenu supplémentaire.
@@ -14,7 +17,7 @@
 	import Component from 'vue-class-component';
 
 	@Component
-	export default class FooterBarHideSocialMediaLinks extends Vue {
+	export default class FooterBarExternalsLinks extends Vue {
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',

--- a/packages/docs/src/data/examples/footer-bar/externalsLinks.vue
+++ b/packages/docs/src/data/examples/footer-bar/externalsLinks.vue
@@ -1,0 +1,25 @@
+<template>
+	<FooterBar
+		v-bind="docProps"
+		hide-social-media-links
+	>
+		<p class="text--secondary my-3">
+			Contenu supplémentaire.
+		</p>
+	</FooterBar>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class FooterBarHideSocialMediaLinks extends Vue {
+		docProps = {
+			sitemapRoute: '/',
+			cguRoute: '/',
+			legalNoticeRoute: '/',
+			a11yStatementRoute: '/'
+		};
+	}
+</script>

--- a/packages/docs/src/data/examples/footer-bar/externalsLinks.vue
+++ b/packages/docs/src/data/examples/footer-bar/externalsLinks.vue
@@ -3,6 +3,7 @@
 		v-bind="docProps"
 		sitemap-external-link="https://www.ameli.fr/assure/plan-du-site"
 		cgu-external-link="https://www.ameli.fr/assure/mentions-legales-cgu"
+		cookies-external-link="https://www.ameli.fr/assure/mentions-legales-cgu"
 		legal-notice-external-link="https://www.ameli.fr/assure/mentions-legales-cgu"
 		a11y-statement-external-link="https://www.ameli.fr/rhone/assure/accessibilite"
 	>
@@ -21,6 +22,7 @@
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',
+			cookiesRoute: '/',
 			legalNoticeRoute: '/',
 			a11yStatementRoute: '/'
 		};

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -61,40 +61,64 @@
 		>
 			<slot name="prepend" />
 
+			<a
+				v-if="!hideSitemapLink && sitemapExternalLink"
+				v-bind="options.routerLink"
+				:href="sitemapExternalLink"
+				target="_blank"
+			>
+				{{ locales.sitemapLabel }}
+			</a>
 			<RouterLink
-				v-if="!hideSitemapLink"
+				v-if="!hideSitemapLink && !sitemapExternalLink"
 				v-bind="options.routerLink"
 				:to="sitemapRoute"
 			>
 				{{ locales.sitemapLabel }}
 			</RouterLink>
 
+			<a
+				v-if="!hideCguLink && cguExternalLink"
+				v-bind="options.routerLink"
+				:href="cguExternalLink"
+				target="_blank"
+			>
+				{{ locales.cguLabel }}
+			</a>
 			<RouterLink
-				v-if="!hideCguLink"
+				v-if="!hideCguLink && !cguExternalLink"
 				v-bind="options.routerLink"
 				:to="cguRoute"
 			>
 				{{ locales.cguLabel }}
 			</RouterLink>
 
-			<RouterLink
-				v-if="!hideCookiesLink"
+			<a
+				v-if="!hideLegalNoticeLink && legalNoticeExternalLink"
 				v-bind="options.routerLink"
-				:to="cookiesRoute"
+				:href="legalNoticeExternalLink"
+				target="_blank"
 			>
-				{{ locales.cookiesLabel }}
-			</RouterLink>
-
+				{{ locales.legalNoticeLabel }}
+			</a>
 			<RouterLink
-				v-if="!hideLegalNoticeLink"
+				v-if="!hideLegalNoticeLink && !legalNoticeExternalLink"
 				v-bind="options.routerLink"
 				:to="legalNoticeRoute"
 			>
 				{{ locales.legalNoticeLabel }}
 			</RouterLink>
 
+			<a
+				v-if="!hideA11yLink && a11yComplianceLabel && a11yStatementExternalLink"
+				v-bind="options.routerLink"
+				:href="a11yStatementExternalLink"
+				target="_blank"
+			>
+				{{ a11yComplianceLabel }}
+			</a>
 			<RouterLink
-				v-if="!hideA11yLink && a11yComplianceLabel"
+				v-if="!hideA11yLink && a11yComplianceLabel && !a11yStatementExternalLink"
 				v-bind="options.routerLink"
 				:to="a11yStatementRoute"
 			>
@@ -146,21 +170,33 @@
 				type: [Array, Object, String] as PropType<RawLocation>,
 				default: () => ({ name: 'sitemap' })
 			},
+			sitemapExternalLink: {
+				type: String as PropType<string>,
+				default: null
+			},
 			cguRoute: {
 				type: [Array, Object, String] as PropType<RawLocation>,
 				default: () => ({ name: 'cgu' })
 			},
-			cookiesRoute: {
-				type: [Array, Object, String] as PropType<RawLocation>,
-				default: () => ({ name: 'cookies' })
+			cguExternalLink: {
+				type: String as PropType<string>,
+				default: null
 			},
 			legalNoticeRoute: {
 				type: [Array, Object, String] as PropType<RawLocation>,
 				default: () => ({ name: 'legalNotice' })
 			},
+			legalNoticeExternalLink: {
+				type: String as PropType<string>,
+				default: null
+			},
 			a11yStatementRoute: {
 				type: [Array, Object, String] as PropType<RawLocation>,
 				default: () => ({ name: 'a11yStatement' })
+			},
+			a11yStatementExternalLink: {
+				type: String as PropType<string>,
+				default: null
 			},
 			hideSitemapLink: {
 				type: Boolean,

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -85,7 +85,7 @@
 				:route="legalNoticeRoute"
 				:options="options.routerLink"
 			>
-				{{ locales.cguLabel }}
+				{{ locales.legalNoticeLabel }}
 			</FooterLink>
 
 			<FooterLink

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -80,6 +80,15 @@
 			</FooterLink>
 
 			<FooterLink
+				v-if="!hideCookiesLink"
+				:external-link="cookiesExternalLink"
+				:route="cookiesRoute"
+				:options="options.routerLink"
+			>
+				{{ locales.cookiesLabel }}
+			</FooterLink>
+
+			<FooterLink
 				v-if="!hideLegalNoticeLink"
 				:external-link="legalNoticeExternalLink"
 				:route="legalNoticeRoute"
@@ -152,6 +161,14 @@
 				default: () => ({ name: 'cgu' })
 			},
 			cguExternalLink: {
+				type: String as PropType<string>,
+				default: null
+			},
+			cookiesRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'cookies' })
+			},
+			cookiesExternalLink: {
 				type: String as PropType<string>,
 				default: null
 			},

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -63,8 +63,8 @@
 
 			<FooterLink
 				v-if="!hideSitemapLink"
-				:sitemap-external-link="sitemapExternalLink"
-				:sitemap-route="sitemapRoute"
+				:external-link="sitemapExternalLink"
+				:route="sitemapRoute"
 				:options="options.routerLink"
 			>
 				{{ locales.sitemapLabel }}
@@ -72,8 +72,8 @@
 
 			<FooterLink
 				v-if="!hideCguLink"
-				:cgu-external-link="cguExternalLink"
-				:cgu-route="cguRoute"
+				:external-link="cguExternalLink"
+				:route="cguRoute"
 				:options="options.routerLink"
 			>
 				{{ locales.cguLabel }}
@@ -81,8 +81,8 @@
 
 			<FooterLink
 				v-if="!hideLegalNoticeLink"
-				:cgu-external-link="legalNoticeExternalLink"
-				:cgu-route="legalNoticeRoute"
+				:external-link="legalNoticeExternalLink"
+				:route="legalNoticeRoute"
 				:options="options.routerLink"
 			>
 				{{ locales.cguLabel }}
@@ -90,8 +90,8 @@
 
 			<FooterLink
 				v-if="!hideA11yLink"
-				:cgu-external-link="a11yStatementExternalLink"
-				:cgu-route="a11yStatementRoute"
+				:external-link="a11yStatementExternalLink"
+				:route="a11yStatementRoute"
 				:options="options.routerLink"
 			>
 				{{ a11yComplianceLabel }}

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -61,69 +61,41 @@
 		>
 			<slot name="prepend" />
 
-			<a
-				v-if="!hideSitemapLink && sitemapExternalLink"
-				v-bind="options.routerLink"
-				:href="sitemapExternalLink"
-				target="_blank"
+			<FooterLink
+				v-if="!hideSitemapLink"
+				:sitemap-external-link="sitemapExternalLink"
+				:sitemap-route="sitemapRoute"
+				:options="options.routerLink"
 			>
 				{{ locales.sitemapLabel }}
-			</a>
-			<RouterLink
-				v-if="!hideSitemapLink && !sitemapExternalLink"
-				v-bind="options.routerLink"
-				:to="sitemapRoute"
-			>
-				{{ locales.sitemapLabel }}
-			</RouterLink>
+			</FooterLink>
 
-			<a
-				v-if="!hideCguLink && cguExternalLink"
-				v-bind="options.routerLink"
-				:href="cguExternalLink"
-				target="_blank"
+			<FooterLink
+				v-if="!hideCguLink"
+				:cgu-external-link="cguExternalLink"
+				:cgu-route="cguRoute"
+				:options="options.routerLink"
 			>
 				{{ locales.cguLabel }}
-			</a>
-			<RouterLink
-				v-if="!hideCguLink && !cguExternalLink"
-				v-bind="options.routerLink"
-				:to="cguRoute"
+			</FooterLink>
+
+			<FooterLink
+				v-if="!hideLegalNoticeLink"
+				:cgu-external-link="legalNoticeExternalLink"
+				:cgu-route="legalNoticeRoute"
+				:options="options.routerLink"
 			>
 				{{ locales.cguLabel }}
-			</RouterLink>
+			</FooterLink>
 
-			<a
-				v-if="!hideLegalNoticeLink && legalNoticeExternalLink"
-				v-bind="options.routerLink"
-				:href="legalNoticeExternalLink"
-				target="_blank"
-			>
-				{{ locales.legalNoticeLabel }}
-			</a>
-			<RouterLink
-				v-if="!hideLegalNoticeLink && !legalNoticeExternalLink"
-				v-bind="options.routerLink"
-				:to="legalNoticeRoute"
-			>
-				{{ locales.legalNoticeLabel }}
-			</RouterLink>
-
-			<a
-				v-if="!hideA11yLink && a11yComplianceLabel && a11yStatementExternalLink"
-				v-bind="options.routerLink"
-				:href="a11yStatementExternalLink"
-				target="_blank"
+			<FooterLink
+				v-if="!hideA11yLink"
+				:cgu-external-link="a11yStatementExternalLink"
+				:cgu-route="a11yStatementRoute"
+				:options="options.routerLink"
 			>
 				{{ a11yComplianceLabel }}
-			</a>
-			<RouterLink
-				v-if="!hideA11yLink && a11yComplianceLabel && !a11yStatementExternalLink"
-				v-bind="options.routerLink"
-				:to="a11yStatementRoute"
-			>
-				{{ a11yComplianceLabel }}
-			</RouterLink>
+			</FooterLink>
 
 			<p
 				v-if="version"
@@ -147,6 +119,7 @@
 
 	import SocialMediaLinks from './SocialMediaLinks';
 	import { SocialMediaLink } from './SocialMediaLinks/types';
+	import FooterLink from './FooterLink';
 
 	import { config } from './config';
 	import { locales } from './locales';
@@ -242,6 +215,8 @@
 	@Component({
 		inheritAttrs: false,
 		components: {
+			FooterBar,
+			FooterLink,
 			SocialMediaLinks
 		}
 	})

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/FooterLink.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/FooterLink.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="d-flex">
 		<a
-			v-if="sitemapExternalLink || cguExternalLink || a11yStatementExternalLink || legalNoticeExternalLink"
+			v-if="externalLink"
 			v-bind="options"
-			:href="sitemapExternalLink || cguExternalLink || a11yStatementExternalLink || legalNoticeExternalLink"
+			:href="externalLink"
 			target="_blank"
 		>
 			<slot />
@@ -11,7 +11,7 @@
 		<RouterLink
 			v-else
 			v-bind="options"
-			:to="sitemapRoute || cguRoute || a11yStatementRoute || legalNoticeRoute"
+			:to="route"
 		>
 			<slot />
 		</RouterLink>
@@ -30,35 +30,11 @@
 				type: Object as PropType<Record<string, unknown>>,
 				default: () => ({})
 			},
-			sitemapRoute: {
+			route: {
 				type: [Array, Object, String] as PropType<RawLocation>,
-				default: () => ({ name: 'sitemap' })
+				default: () => ({ name: '' })
 			},
-			sitemapExternalLink: {
-				type: String as PropType<string>,
-				default: null
-			},
-			cguRoute: {
-				type: [Array, Object, String] as PropType<RawLocation>,
-				default: () => ({ name: 'cgu' })
-			},
-			cguExternalLink: {
-				type: String as PropType<string>,
-				default: null
-			},
-			legalNoticeRoute: {
-				type: [Array, Object, String] as PropType<RawLocation>,
-				default: () => ({ name: 'legalNotice' })
-			},
-			legalNoticeExternalLink: {
-				type: String as PropType<string>,
-				default: null
-			},
-			a11yStatementRoute: {
-				type: [Array, Object, String] as PropType<RawLocation>,
-				default: () => ({ name: 'a11yStatement' })
-			},
-			a11yStatementExternalLink: {
+			externalLink: {
 				type: String as PropType<string>,
 				default: null
 			}

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/FooterLink.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/FooterLink.vue
@@ -1,0 +1,72 @@
+<template>
+	<div class="d-flex">
+		<a
+			v-if="sitemapExternalLink || cguExternalLink || a11yStatementExternalLink || legalNoticeExternalLink"
+			v-bind="options"
+			:href="sitemapExternalLink || cguExternalLink || a11yStatementExternalLink || legalNoticeExternalLink"
+			target="_blank"
+		>
+			<slot />
+		</a>
+		<RouterLink
+			v-else
+			v-bind="options"
+			:to="sitemapRoute || cguRoute || a11yStatementRoute || legalNoticeRoute"
+		>
+			<slot />
+		</RouterLink>
+	</div>
+</template>
+
+<script lang="ts">
+	import Vue, { PropType } from 'vue';
+	import Component, { mixins } from 'vue-class-component';
+
+	import { RawLocation } from 'vue-router';
+
+	const Props = Vue.extend({
+		props: {
+			options: {
+				type: Object as PropType<Record<string, unknown>>,
+				default: () => ({})
+			},
+			sitemapRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'sitemap' })
+			},
+			sitemapExternalLink: {
+				type: String as PropType<string>,
+				default: null
+			},
+			cguRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'cgu' })
+			},
+			cguExternalLink: {
+				type: String as PropType<string>,
+				default: null
+			},
+			legalNoticeRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'legalNotice' })
+			},
+			legalNoticeExternalLink: {
+				type: String as PropType<string>,
+				default: null
+			},
+			a11yStatementRoute: {
+				type: [Array, Object, String] as PropType<RawLocation>,
+				default: () => ({ name: 'a11yStatement' })
+			},
+			a11yStatementExternalLink: {
+				type: String as PropType<string>,
+				default: null
+			}
+		}
+	});
+
+	const MixinsDeclaration = mixins(Props);
+
+	@Component
+	export default class FooterLink extends MixinsDeclaration {}
+</script>

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/index.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/index.ts
@@ -1,0 +1,3 @@
+import FooterLink from './FooterLink.vue';
+
+export default FooterLink;

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/FooterLink.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/FooterLink.spec.ts
@@ -1,0 +1,18 @@
+import Vue from 'vue';
+
+import { Wrapper } from '@vue/test-utils';
+
+import { mountComponent } from '@/tests';
+import { html } from '@/tests/utils/html';
+
+import FooterLink from '../';
+
+let wrapper: Wrapper<Vue>;
+
+describe('FooterLink', () => {
+	it('renders correctly', () => {
+		wrapper = mountComponent(FooterLink);
+
+		expect(html(wrapper)).toMatchSnapshot();
+	});
+});

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/FooterLink.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/FooterLink.spec.ts
@@ -6,12 +6,15 @@ import { mountComponent } from '@/tests';
 import { html } from '@/tests/utils/html';
 
 import FooterLink from '../';
+import FooterBar from '../../index';
 
 let wrapper: Wrapper<Vue>;
 
 describe('FooterLink', () => {
 	it('renders correctly', () => {
-		wrapper = mountComponent(FooterLink);
+		wrapper = mountComponent(FooterLink, {
+			stubs: ['RouterLink']
+		});
 
 		expect(html(wrapper)).toMatchSnapshot();
 	});

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/__snapshots__/FooterLink.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/__snapshots__/FooterLink.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`FooterLink renders correctly 1`] = `
 <div class="d-flex">
-  <routerlink to="[object Object]"></routerlink>
+  <router-link to="[object Object]"></router-link>
 </div>
 `;

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/__snapshots__/FooterLink.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/__snapshots__/FooterLink.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FooterLink renders correctly 1`] = `
+<div class="d-flex">
+  <routerlink to="[object Object]"></routerlink>
+</div>
+`;

--- a/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/__snapshots__/FooterLink.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterLink/tests/__snapshots__/FooterLink.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`FooterLink renders correctly 1`] = `
 <div class="d-flex">
-  <router-link to="[object Object]"></router-link>
+  <routerlink-stub to="[object Object]"></routerlink-stub>
 </div>
 `;

--- a/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
@@ -12,7 +12,7 @@ let wrapper: Wrapper<Vue>;
 describe('FooterBar', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(FooterBar, {
-			stubs: ['RouterLink']
+			stubs: ['FooterLink']
 		});
 
 		expect(html(wrapper)).toMatchSnapshot();

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -6,18 +6,22 @@ exports[`FooterBar renders correctly 1`] = `
   <!---->
   <!---->
   <div class="vd-footer-bar-links text-sm-center d-flex flex-column flex-sm-row flex-wrap align-start justify-center max-width-none mx-n3 my-n3 py-2 py-sm-0">
+    <!---->
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
       Plan du site
     </routerlink-stub>
+    <!---->
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
       Conditions générales d’utilisation
     </routerlink-stub>
+    <!---->
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
       Gestion des cookies
     </routerlink-stub>
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
       Mentions légales
     </routerlink-stub>
+    <!---->
     <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
       Accessibilité&nbsp;: non conforme
     </routerlink-stub>

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -6,25 +6,18 @@ exports[`FooterBar renders correctly 1`] = `
   <!---->
   <!---->
   <div class="vd-footer-bar-links text-sm-center d-flex flex-column flex-sm-row flex-wrap align-start justify-center max-width-none mx-n3 my-n3 py-2 py-sm-0">
-    <!---->
-    <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
+    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
       Plan du site
-    </routerlink-stub>
-    <!---->
-    <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
+    </footerlink-stub>
+    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
       Conditions générales d’utilisation
-    </routerlink-stub>
-    <!---->
-    <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
-      Gestion des cookies
-    </routerlink-stub>
-    <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
-      Mentions légales
-    </routerlink-stub>
-    <!---->
-    <routerlink-stub to="[object Object]" class="text--primary my-3 mx-4">
+    </footerlink-stub>
+    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
+      Conditions générales d’utilisation
+    </footerlink-stub>
+    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
       Accessibilité&nbsp;: non conforme
-    </routerlink-stub>
+    </footerlink-stub>
     <!---->
   </div>
 </vfooter-stub>

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -13,7 +13,10 @@ exports[`FooterBar renders correctly 1`] = `
       Conditions générales d’utilisation
     </footerlink-stub>
     <footerlink-stub options="[object Object]" route="[object Object]">
-      Conditions générales d’utilisation
+      Gestion des cookies
+    </footerlink-stub>
+    <footerlink-stub options="[object Object]" route="[object Object]">
+      Mentions légales
     </footerlink-stub>
     <footerlink-stub options="[object Object]" route="[object Object]">
       Accessibilité&nbsp;: non conforme

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -6,16 +6,16 @@ exports[`FooterBar renders correctly 1`] = `
   <!---->
   <!---->
   <div class="vd-footer-bar-links text-sm-center d-flex flex-column flex-sm-row flex-wrap align-start justify-center max-width-none mx-n3 my-n3 py-2 py-sm-0">
-    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
+    <footerlink-stub options="[object Object]" route="[object Object]">
       Plan du site
     </footerlink-stub>
-    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
+    <footerlink-stub options="[object Object]" route="[object Object]">
       Conditions générales d’utilisation
     </footerlink-stub>
-    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
+    <footerlink-stub options="[object Object]" route="[object Object]">
       Conditions générales d’utilisation
     </footerlink-stub>
-    <footerlink-stub options="[object Object]" sitemaproute="[object Object]" cguroute="[object Object]" legalnoticeroute="[object Object]" a11ystatementroute="[object Object]">
+    <footerlink-stub options="[object Object]" route="[object Object]">
       Accessibilité&nbsp;: non conforme
     </footerlink-stub>
     <!---->


### PR DESCRIPTION
## Description

Ajouter la possibilité de mettre des liens externes dans le footer

## Playground

<details>

```vue
<template>
	<PageContainer>
		<FooterBar
			sitemap-external-link="https://www.ameli.fr/assure/plan-du-site"
			cgu-external-link="https://www.ameli.fr/assure/mentions-legales-cgu"
			legal-notice-external-link="https://www.ameli.fr/assure/mentions-legales-cgu"
			a11y-statement-external-link="https://www.ameli.fr/rhone/assure/accessibilite"
		/>
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
