### PR TITLE
✨ vue-dot: Add dark mode to FooterBar

### DIFF
--- a/packages/docs/src/content/composants/structure/footer-bar.md
+++ b/packages/docs/src/content/composants/structure/footer-bar.md
@@ -50,11 +50,18 @@ Vous pouvez changer les liens par défaut par des liens externes en utilisant le
 
 <doc-example file="footer-bar/externalsLinks"></doc-example>
 
+
 #### Composants Vuetify
 
 Vous pouvez personnaliser les composants Vuetify contenus dans le pattern `FooterBar` en utilisant la prop `vuetify-options`.
 
 <doc-example file="footer-bar/options"></doc-example>
+
+#### Dark mode
+
+Vous pouvez afficher un footer sombre en utilisant la prop `dark`.
+
+<doc-example file="footer-bar/dark"></doc-example>
 
 #### Slots
 

--- a/packages/docs/src/content/composants/structure/footer-bar.md
+++ b/packages/docs/src/content/composants/structure/footer-bar.md
@@ -23,6 +23,12 @@ Vous pouvez masquer les réseaux sociaux ou le logo de l’Assurance Maladie en 
 
 <doc-example file="footer-bar/hide-social-media-links"></doc-example>
 
+#### Mode sombre
+
+Vous pouvez afficher le footer en mode sombre en utilisant la prop `dark`.
+
+<doc-example file="footer-bar/dark"></doc-example>
+
 </doc-tab-item>
 
 <doc-tab-item label="API">
@@ -50,18 +56,11 @@ Vous pouvez changer les liens par défaut par des liens externes en utilisant le
 
 <doc-example file="footer-bar/externalsLinks"></doc-example>
 
-
 #### Composants Vuetify
 
 Vous pouvez personnaliser les composants Vuetify contenus dans le pattern `FooterBar` en utilisant la prop `vuetify-options`.
 
 <doc-example file="footer-bar/options"></doc-example>
-
-#### Dark mode
-
-Vous pouvez afficher un footer sombre en utilisant la prop `dark`.
-
-<doc-example file="footer-bar/dark"></doc-example>
 
 #### Slots
 

--- a/packages/docs/src/data/api/footer-bar.ts
+++ b/packages/docs/src/data/api/footer-bar.ts
@@ -141,7 +141,13 @@ export const api: Api = {
 	divider: 'VDivider',
 	routerLink: 'RouterLink'
 }`
-			}
+			},
+			{
+				name: 'dark',
+				type: 'boolean',
+				default: false,
+				description: 'Affiche le mode sombre.'
+			},
 		],
 		slots: [
 			{

--- a/packages/docs/src/data/api/footer-bar.ts
+++ b/packages/docs/src/data/api/footer-bar.ts
@@ -146,8 +146,8 @@ export const api: Api = {
 				name: 'dark',
 				type: 'boolean',
 				default: false,
-				description: 'Affiche le mode sombre.'
-			},
+				description: 'Active le mode sombre.'
+			}
 		],
 		slots: [
 			{

--- a/packages/docs/src/data/examples/footer-bar/dark.vue
+++ b/packages/docs/src/data/examples/footer-bar/dark.vue
@@ -1,0 +1,26 @@
+<template>
+	<FooterBar
+		v-bind="docProps"
+		hide-social-media-links
+	>
+		<p class="text--secondary my-3">
+			Contenu supplémentaire.
+		</p>
+	</FooterBar>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class FooterBarHideSocialMediaLinks extends Vue {
+		docProps = {
+			sitemapRoute: '/',
+			cguRoute: '/',
+			cookiesRoute: '/',
+			legalNoticeRoute: '/',
+			a11yStatementRoute: '/'
+		};
+	}
+</script>

--- a/packages/docs/src/data/examples/footer-bar/dark.vue
+++ b/packages/docs/src/data/examples/footer-bar/dark.vue
@@ -1,7 +1,7 @@
 <template>
 	<FooterBar
 		v-bind="docProps"
-		hide-social-media-links
+		dark
 	>
 		<p class="text--secondary my-3">
 			Contenu supplémentaire.
@@ -14,7 +14,7 @@
 	import Component from 'vue-class-component';
 
 	@Component
-	export default class FooterBarHideSocialMediaLinks extends Vue {
+	export default class FooterBarDark extends Vue {
 		docProps = {
 			sitemapRoute: '/',
 			cguRoute: '/',

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -266,6 +266,21 @@
 	@import '@cnamts/design-tokens/dist/tokens';
 
 	// Use deep selector to style user content as well
+	.vd-footer-bar.theme--dark :deep() {
+		background-color: $vd-grey-darken-20 !important;
+		.vd-footer-bar-links {
+			a {
+				color: rgb(255, 255, 255) !important;
+			}
+		}
+		p,
+		.primary--text {
+			color: rgba(255, 255, 255, .6) !important;
+		}
+		svg {
+			fill: rgba(255, 255, 255) !important;
+		}
+	}
 	.vd-footer-bar-links :deep() {
 		a {
 			transition: .15s;
@@ -278,26 +293,8 @@
 				border-color: currentColor;
 			}
 		}
-
 		p {
 			padding: 1px 0;
-		}
-	}
-	.vd-footer-bar.theme--dark :deep() {
-		background-color: $vd-grey-darken-20 !important;
-		.vd-footer-bar-links {
-			a {
-				color: rgb(255, 255, 255) !important;
-			}
-		}
-		p {
-			color: rgba(255, 255, 255, 0.6) !important;
-		}
-		.primary--text {
-			color: rgba(255, 255, 255, 0.6) !important;
-		}
-		svg {
-			fill: rgba(255, 255, 255) !important;
 		}
 	}
 </style>

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -4,7 +4,7 @@
 			...options.footer,
 			...$attrs
 		}"
-		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode }"
+		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode, 'dark-mode': $vuetify.theme.dark }"
 		class="vd-footer-bar flex-column align-stretch pa-3 w-100"
 	>
 		<div
@@ -281,6 +281,17 @@
 
 		p {
 			padding: 1px 0;
+		}
+	}
+	.vd-footer-bar.theme--dark :deep() {
+		background-color: $vd-grey-darken-60 !important;
+		.vd-footer-bar-links {
+			a {
+				color: rgb(255, 255, 255) !important;
+			}
+		}
+		p {
+			color: rgba(255, 255, 255, 0.6) !important;
 		}
 	}
 </style>

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -4,7 +4,7 @@
 			...options.footer,
 			...$attrs
 		}"
-		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode, 'dark-mode': $vuetify.theme.dark }"
+		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode }"
 		class="vd-footer-bar flex-column align-stretch pa-3 w-100"
 	>
 		<div
@@ -264,21 +264,22 @@
 
 <style lang="scss" scoped>
 	@import '@cnamts/design-tokens/dist/tokens';
+	$white: rgb(255, 255, 255);
 
 	// Use deep selector to style user content as well
 	.vd-footer-bar.theme--dark :deep() {
 		background-color: $vd-grey-darken-20 !important;
 		.vd-footer-bar-links {
 			a {
-				color: rgb(255, 255, 255) !important;
+				color: $white !important;
 			}
 		}
 		p,
 		.primary--text {
-			color: rgba(255, 255, 255, .6) !important;
+			color: rgba($white, .6) !important;
 		}
 		svg {
-			fill: rgba(255, 255, 255) !important;
+			fill: $white !important;
 		}
 	}
 	.vd-footer-bar-links :deep() {

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -264,24 +264,27 @@
 
 <style lang="scss" scoped>
 	@import '@cnamts/design-tokens/dist/tokens';
-	$white: rgb(255, 255, 255);
+
+	$white: #fff;
 
 	// Use deep selector to style user content as well
 	.vd-footer-bar.theme--dark :deep() {
 		background-color: $vd-grey-darken-20 !important;
-		.vd-footer-bar-links {
-			a {
-				color: $white !important;
-			}
+
+		.vd-footer-bar-links a {
+			color: $white !important;
 		}
+
 		p,
 		.primary--text {
 			color: rgba($white, .6) !important;
 		}
+
 		svg {
 			fill: $white !important;
 		}
 	}
+
 	.vd-footer-bar-links :deep() {
 		a {
 			transition: .15s;
@@ -294,6 +297,7 @@
 				border-color: currentColor;
 			}
 		}
+
 		p {
 			padding: 1px 0;
 		}

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -284,7 +284,7 @@
 		}
 	}
 	.vd-footer-bar.theme--dark :deep() {
-		background-color: $vd-grey-darken-60 !important;
+		background-color: $vd-grey-darken-20 !important;
 		.vd-footer-bar-links {
 			a {
 				color: rgb(255, 255, 255) !important;

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -293,5 +293,11 @@
 		p {
 			color: rgba(255, 255, 255, 0.6) !important;
 		}
+		.primary--text {
+			color: rgba(255, 255, 255, 0.6) !important;
+		}
+		svg {
+			fill: rgba(255, 255, 255) !important;
+		}
 	}
 </style>


### PR DESCRIPTION
## Description

Add dark grey mode on Footer

![Capture d’écran 2023-02-23 à 11 29 11](https://user-images.githubusercontent.com/1822420/220881984-26295f93-94b1-4fb1-99a9-6efa95244afb.png)

Fixes #2544

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<FooterBar dark />
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>

```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
