### PR TITLE
Feat/#2528 Accessibilité > Couleurs

### DIFF
--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -131,3 +131,33 @@
 		min-width: 38px;
 	}
 }
+
+// Fix colors transparency
+.theme--light {
+	.v-sheet, .v-input, .v-text-field, .v-textarea, .v-label {
+		color: #040404;
+	}
+	.v-input {
+		input, textarea {
+			color: #040404;
+		}
+	}
+	.v-data-table {
+		th, tr {
+			border-bottom: thin solid #1A1A1A;
+		}
+	}
+}
+.theme--dark {
+	.v-sheet, .v-input, .v-text-field, .v-textarea, .v-label {
+		color: #ffffff;
+	}
+	.v-input {
+		input, textarea {
+			color: #ffffff;
+		}
+	}
+}
+.theme--dark.v-toolbar {
+	color: #ffffff;
+}

--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -141,6 +141,9 @@
 		input, textarea {
 			color: #040404;
 		}
+		.v-text-field--outlined:not(.v-input--is-focused):not(.v-input--has-state) > .v-input__control > .v-input__slot fieldset {
+			color: #a8a8a8;
+		}
 	}
 	.v-data-table {
 		th, tr {

--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -141,14 +141,14 @@
 		input, textarea {
 			color: #040404;
 		}
-		.v-text-field--outlined:not(.v-input--is-focused):not(.v-input--has-state) > .v-input__control > .v-input__slot fieldset {
-			color: #a8a8a8;
-		}
 	}
 	.v-data-table {
 		th, tr {
 			border-bottom: thin solid #1A1A1A;
 		}
+	}
+	.v-text-field--outlined:not(.v-input--is-focused):not(.v-input--has-state) > .v-input__control > .v-input__slot fieldset {
+		color: #a8a8a8;
 	}
 }
 .theme--dark {

--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -158,6 +158,18 @@
 		}
 	}
 }
+.theme--light.v-application .text--primary {
+	color: #040404 !important;
+}
+.theme--light.v-application .text--secondary {
+	color: #757575 !important;
+}
+.theme--dark.v-application .text--primary {
+	color: #ffffff !important;
+}
+.theme--dark.v-application .text--secondary {
+	color: #bbbbbb !important;
+}
 .theme--dark.v-toolbar {
 	color: #ffffff;
 }


### PR DESCRIPTION
## Description

Ne plus utiliser l'opacité pour les éléments graphiques signifiants et choisir des contrastes conformes au RGAA en vigueur

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
