### PR TITLE
🐛 vue-dot: Fix tab active state in HeaderBar

### DIFF
--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/HeaderNavigationBar.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/HeaderNavigationBar.vue
@@ -19,6 +19,7 @@
 					v-else
 					v-bind="options.tabs"
 					:value="tab"
+					:optional="true"
 					@change="emitTabUpdateEvent"
 				>
 					<VTab

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/HeaderNavigationBar.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/HeaderNavigationBar.vue
@@ -19,7 +19,7 @@
 					v-else
 					v-bind="options.tabs"
 					:value="tab"
-					:optional="true"
+					optional
 					@change="emitTabUpdateEvent"
 				>
 					<VTab

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/__snapshots__/HeaderNavigationBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/__snapshots__/HeaderNavigationBar.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`HeaderNavigationBar renders correctly 1`] = `
 <vsheet-stub color="#0a347b" height="48px" dark="true" tag="div" dense="true" class="vd-navigation-bar d-flex align-center justify-center px-14">
   <vsheet-stub color="transparent" tag="div" class="d-flex">
-    <vtabs-stub activeclass="" backgroundcolor="transparent" nexticon="$next" previcon="$prev" slidersize="2"></vtabs-stub>
+    <vtabs-stub activeclass="" backgroundcolor="transparent" nexticon="$next" optional="true" previcon="$prev" slidersize="2"></vtabs-stub>
   </vsheet-stub>
 </vsheet-stub>
 `;

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/HeaderNavigationDrawer.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/HeaderNavigationDrawer.vue
@@ -22,7 +22,7 @@
 			<VTabs
 				v-bind="options.tabs"
 				:value="tab"
-				:optional="true"
+				optional
 				@change="emitTabUpdateEvent"
 			>
 				<VTab

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/HeaderNavigationDrawer.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/HeaderNavigationDrawer.vue
@@ -22,6 +22,7 @@
 			<VTabs
 				v-bind="options.tabs"
 				:value="tab"
+				:optional="true"
 				@change="emitTabUpdateEvent"
 			>
 				<VTab

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
@@ -13,7 +13,8 @@ describe('HeaderNavigationDrawer', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(HeaderNavigationDrawer, {
 			propsData: {
-				theme: ThemeEnum.DEFAULT
+				theme: ThemeEnum.DEFAULT,
+				mobileVersion: true
 			}
 		});
 

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
@@ -1,0 +1,22 @@
+import Vue from 'vue';
+import { Wrapper } from '@vue/test-utils';
+
+import { mountComponent } from '@/tests';
+import { html } from '@/tests/utils/html';
+
+import HeaderNavigationDrawer from '../';
+import { ThemeEnum } from '../../ThemeEnum';
+
+let wrapper: Wrapper<Vue>;
+
+describe('HeaderNavigationDrawer', () => {
+	it('renders correctly', () => {
+		wrapper = mountComponent(HeaderNavigationDrawer, {
+			propsData: {
+				theme: ThemeEnum.DEFAULT
+			}
+		});
+
+		expect(html(wrapper)).toMatchSnapshot();
+	});
+});

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeaderNavigationDrawer renders correctly 1`] = `""`;

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
@@ -1,3 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderNavigationDrawer renders correctly 1`] = `""`;
+exports[`HeaderNavigationDrawer renders correctly 1`] = `
+<vnavigationdrawer-stub app="true" color="#0a347b" mobilebreakpoint="1264" dark="true" height="100vh" minivariantwidth="56" src="" tag="nav" temporary="true" width="320px" class="pa-4">
+  <div class="d-flex align-center justify-end mb-8">
+    <vbtn-stub tag="button" activeclass="" icon="true" type="button" aria-label="Fermer le menu">
+      <vicon-stub>
+        M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z
+      </vicon-stub>
+    </vbtn-stub>
+  </div>
+  <vtabs-stub activeclass="" backgroundcolor="transparent" nexticon="$next" optional="true" previcon="$prev" slidersize="2" vertical="true" dense="true"></vtabs-stub>
+</vnavigationdrawer-stub>
+`;


### PR DESCRIPTION
## Description

Bug : Lorsque j'utilise le composant HeaderBar et que j'accède à une page différente de celles qui sont listées dans navigation-items, la barre en dessous du bouton reste présente (active).

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<HeaderBar :navigation-items="navigationItems">
		<UserMenuBtn full-name="Édith Cartier">
			<VListItem
				v-for="(item, index) in items"
				:key="index"
			>
				<VListItemTitle>
					<router-link to="test">
						{{ item }}
					</router-link>
				</VListItemTitle>
			</VListItem>
		</UserMenuBtn>
	</HeaderBar>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { NavigationItem } from '@cnamts/vue-dot/src/patterns/HeaderBar/types';

	@Component
	export default class HeaderBarNavigationBar extends Vue {
		items = [
			'Profil'
		];
		navigationItems: NavigationItem[] = [
			{
				label: 'Accueil',
				to: '/'
			},
			{
				label: 'Mes projets',
				to: '/projets'
			},
			{
				label: 'Mes outils',
				to: '/outils'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
