### PR TITLE
✨ vue-dot: Add vuetify-options to SubHeader

### DIFF
--- a/packages/docs/src/content/composants/structure/sub-header.md
+++ b/packages/docs/src/content/composants/structure/sub-header.md
@@ -61,6 +61,12 @@ Vous pouvez utiliser les props `items-number-loading` et `heading-loading` sur c
 
 <doc-tab-item label="Personnalisation">
 
+#### Composants Vuetify
+
+Vous pouvez personnaliser les composants Vuetify contenus dans le pattern `SubHeader` en utilisant la prop `vuetify-options`.
+
+<doc-example file="sub-header/options"></doc-example>
+
 ### Slots
 
 Vous pouvez utiliser les slots pour remplacer les contenus par défaut ou pour en ajouter.

--- a/packages/docs/src/data/api/sub-header.ts
+++ b/packages/docs/src/data/api/sub-header.ts
@@ -56,6 +56,7 @@ export const api: Api = {
 			},
 			...widthable,
 			...customizable(`{
+	sheet: 'VSheet',
 	backBtn: 'VBtn'
 }`)
 		],

--- a/packages/docs/src/data/examples/sub-header/options.vue
+++ b/packages/docs/src/data/examples/sub-header/options.vue
@@ -1,8 +1,8 @@
 <template>
 	<SubHeader
+		:vuetify-options="vuetifyOptions"
 		title-text="Paul Dupont"
 		sub-title-text="1 69 08 75 125 456 75"
-		:vuetify-options="vuetifyOptions"
 	/>
 </template>
 
@@ -13,7 +13,7 @@
 	@Component
 	export default class SubHeaderOptions extends Vue {
 		vuetifyOptions = {
-			background: {
+			sheet: {
 				color: 'primary'
 			},
 			backBtn: {

--- a/packages/docs/src/data/examples/sub-header/options.vue
+++ b/packages/docs/src/data/examples/sub-header/options.vue
@@ -1,0 +1,26 @@
+<template>
+	<SubHeader
+		title-text="Paul Dupont"
+		sub-title-text="1 69 08 75 125 456 75"
+		:vuetify-options="vuetifyOptions"
+	/>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class SubHeaderOptions extends Vue {
+		vuetifyOptions = {
+			background: {
+				color: 'primary'
+			},
+			backBtn: {
+				color: 'transparent',
+				small: true,
+				depressed: true
+			}
+		};
+	}
+</script>

--- a/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
@@ -1,102 +1,101 @@
 <template>
-	<div class="vd-sub-header">
-		<VSheet
-			v-bind="options.background"
-			class="white--text py-6 px-8"
-		>
-			<slot name="back-btn">
-				<VFadeTransition
-					v-if="!hideBackBtn"
-					mode="out-in"
+	<VSheet
+		v-bind="options.sheet"
+		class="vd-sub-header white--text py-6 px-8"
+		:style="widthStyles"
+	>
+		<slot name="back-btn">
+			<VFadeTransition
+				v-if="!hideBackBtn"
+				mode="out-in"
+			>
+				<VSkeletonLoader
+					v-if="loading"
+					height="28"
+					type="button"
+					width="100"
+					class="mb-1"
+					dark
+				/>
+
+				<VBtn
+					v-else
+					v-bind="options.backBtn"
+					class="vd-sub-header-back-btn mb-1"
+					@click="$emit('back')"
 				>
-					<VSkeletonLoader
-						v-if="loading"
-						height="28"
-						type="button"
-						width="100"
-						class="mb-1"
-						dark
-					/>
-
-					<VBtn
-						v-else
-						v-bind="options.backBtn"
-						class="vd-sub-header-back-btn mb-1"
-						@click="$emit('back')"
-					>
-						<slot name="back-btn-icon">
-							<VIcon class="mr-2">
-								{{ backArrowIcon }}
-							</VIcon>
-						</slot>
-
-						{{ backBtnText }}
-					</VBtn>
-				</VFadeTransition>
-			</slot>
-
-			<div class="vd-sub-header-content d-flex justify-space-between">
-				<div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
-					<slot name="title">
-						<VFadeTransition mode="out-in">
-							<HeaderLoading
-								v-if="loading"
-								width="300"
-								height="2rem"
-								dark
-							/>
-
-							<h2
-								v-else-if="titleText"
-								class="text-h5 font-weight-bold"
-							>
-								{{ titleText }}
-							</h2>
-						</VFadeTransition>
+					<slot name="back-btn-icon">
+						<VIcon class="mr-2">
+							{{ backArrowIcon }}
+						</VIcon>
 					</slot>
 
-					<slot name="sub-title">
-						<VFadeTransition
-							v-if="subTitleText"
-							mode="out-in"
-						>
-							<HeaderLoading
-								v-if="loading"
-								class="mt-1"
-								width="250"
-								height="2rem"
-								dark
-							/>
+					{{ backBtnText }}
+				</VBtn>
+			</VFadeTransition>
+		</slot>
 
-							<p
-								v-else
-								class="text-h6 font-weight-bold mt-1 mb-0"
-								:style="{ color: fadeWhite }"
-							>
-								{{ subTitleText }}
-							</p>
-						</VFadeTransition>
-					</slot>
-
-					<slot name="additional-informations" />
-				</div>
-
-				<slot name="right-content">
-					<VThemeProvider dark>
-						<DataListGroup
-							v-if="dataListGroupItems"
-							:items="dataListGroupItems"
-							:loading="loading"
-							:render-html-value="renderHtmlValue"
-							item-width="auto"
-							class="flex-nowrap flex-shrink-0"
-							@click:list-item="emitItemAction"
+		<div class="vd-sub-header-content d-flex justify-space-between">
+			<div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
+				<slot name="title">
+					<VFadeTransition mode="out-in">
+						<HeaderLoading
+							v-if="loading"
+							width="300"
+							height="2rem"
+							dark
 						/>
-					</VThemeProvider>
+
+						<h2
+							v-else-if="titleText"
+							class="text-h5 font-weight-bold"
+						>
+							{{ titleText }}
+						</h2>
+					</VFadeTransition>
 				</slot>
+
+				<slot name="sub-title">
+					<VFadeTransition
+						v-if="subTitleText"
+						mode="out-in"
+					>
+						<HeaderLoading
+							v-if="loading"
+							class="mt-1"
+							width="250"
+							height="2rem"
+							dark
+						/>
+
+						<p
+							v-else
+							class="text-h6 font-weight-bold mt-1 mb-0"
+							:style="{ color: fadeWhite }"
+						>
+							{{ subTitleText }}
+						</p>
+					</VFadeTransition>
+				</slot>
+
+				<slot name="additional-informations" />
 			</div>
-		</VSheet>
-	</div>
+
+			<slot name="right-content">
+				<VThemeProvider dark>
+					<DataListGroup
+						v-if="dataListGroupItems"
+						:items="dataListGroupItems"
+						:loading="loading"
+						:render-html-value="renderHtmlValue"
+						item-width="auto"
+						class="flex-nowrap flex-shrink-0"
+						@click:list-item="emitItemAction"
+					/>
+				</VThemeProvider>
+			</slot>
+		</div>
+	</VSheet>
 </template>
 
 <script lang="ts">

--- a/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
@@ -1,8 +1,8 @@
 <template>
 	<VSheet
 		v-bind="options.sheet"
-		class="vd-sub-header white--text py-6 px-8"
 		:style="widthStyles"
+		class="vd-sub-header white--text py-6 px-8"
 	>
 		<slot name="back-btn">
 			<VFadeTransition

--- a/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
+++ b/packages/vue-dot/src/patterns/SubHeader/SubHeader.vue
@@ -1,99 +1,101 @@
 <template>
-	<div
-		:style="widthStyles"
-		class="vd-sub-header secondary white--text py-6 px-8"
-	>
-		<slot name="back-btn">
-			<VFadeTransition
-				v-if="!hideBackBtn"
-				mode="out-in"
-			>
-				<VSkeletonLoader
-					v-if="loading"
-					height="28"
-					type="button"
-					width="100"
-					class="mb-1"
-					dark
-				/>
-
-				<VBtn
-					v-else
-					v-bind="options.backBtn"
-					class="vd-sub-header-back-btn mb-1"
-					@click="$emit('back')"
+	<div class="vd-sub-header">
+		<VSheet
+			v-bind="options.background"
+			class="white--text py-6 px-8"
+		>
+			<slot name="back-btn">
+				<VFadeTransition
+					v-if="!hideBackBtn"
+					mode="out-in"
 				>
-					<slot name="back-btn-icon">
-						<VIcon class="mr-2">
-							{{ backArrowIcon }}
-						</VIcon>
+					<VSkeletonLoader
+						v-if="loading"
+						height="28"
+						type="button"
+						width="100"
+						class="mb-1"
+						dark
+					/>
+
+					<VBtn
+						v-else
+						v-bind="options.backBtn"
+						class="vd-sub-header-back-btn mb-1"
+						@click="$emit('back')"
+					>
+						<slot name="back-btn-icon">
+							<VIcon class="mr-2">
+								{{ backArrowIcon }}
+							</VIcon>
+						</slot>
+
+						{{ backBtnText }}
+					</VBtn>
+				</VFadeTransition>
+			</slot>
+
+			<div class="vd-sub-header-content d-flex justify-space-between">
+				<div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
+					<slot name="title">
+						<VFadeTransition mode="out-in">
+							<HeaderLoading
+								v-if="loading"
+								width="300"
+								height="2rem"
+								dark
+							/>
+
+							<h2
+								v-else-if="titleText"
+								class="text-h5 font-weight-bold"
+							>
+								{{ titleText }}
+							</h2>
+						</VFadeTransition>
 					</slot>
 
-					{{ backBtnText }}
-				</VBtn>
-			</VFadeTransition>
-		</slot>
-
-		<div class="vd-sub-header-content d-flex justify-space-between">
-			<div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
-				<slot name="title">
-					<VFadeTransition mode="out-in">
-						<HeaderLoading
-							v-if="loading"
-							width="300"
-							height="2rem"
-							dark
-						/>
-
-						<h2
-							v-else-if="titleText"
-							class="text-h5 font-weight-bold"
+					<slot name="sub-title">
+						<VFadeTransition
+							v-if="subTitleText"
+							mode="out-in"
 						>
-							{{ titleText }}
-						</h2>
-					</VFadeTransition>
-				</slot>
+							<HeaderLoading
+								v-if="loading"
+								class="mt-1"
+								width="250"
+								height="2rem"
+								dark
+							/>
 
-				<slot name="sub-title">
-					<VFadeTransition
-						v-if="subTitleText"
-						mode="out-in"
-					>
-						<HeaderLoading
-							v-if="loading"
-							class="mt-1"
-							width="250"
-							height="2rem"
-							dark
+							<p
+								v-else
+								class="text-h6 font-weight-bold mt-1 mb-0"
+								:style="{ color: fadeWhite }"
+							>
+								{{ subTitleText }}
+							</p>
+						</VFadeTransition>
+					</slot>
+
+					<slot name="additional-informations" />
+				</div>
+
+				<slot name="right-content">
+					<VThemeProvider dark>
+						<DataListGroup
+							v-if="dataListGroupItems"
+							:items="dataListGroupItems"
+							:loading="loading"
+							:render-html-value="renderHtmlValue"
+							item-width="auto"
+							class="flex-nowrap flex-shrink-0"
+							@click:list-item="emitItemAction"
 						/>
-
-						<p
-							v-else
-							class="text-h6 font-weight-bold mt-1 mb-0"
-							:style="{ color: fadeWhite }"
-						>
-							{{ subTitleText }}
-						</p>
-					</VFadeTransition>
+					</VThemeProvider>
 				</slot>
-
-				<slot name="additional-informations" />
 			</div>
-
-			<slot name="right-content">
-				<VThemeProvider dark>
-					<DataListGroup
-						v-if="dataListGroupItems"
-						:items="dataListGroupItems"
-						:loading="loading"
-						:render-html-value="renderHtmlValue"
-						item-width="auto"
-						class="flex-nowrap flex-shrink-0"
-						@click:list-item="emitItemAction"
-					/>
-				</VThemeProvider>
-			</slot>
-		</div>
+		</VSheet>
 	</div>
 </template>
 

--- a/packages/vue-dot/src/patterns/SubHeader/config.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/config.ts
@@ -1,5 +1,5 @@
 export const config = {
-	background: {
+	sheet: {
 		color: 'secondary'
 	},
 	backBtn: {

--- a/packages/vue-dot/src/patterns/SubHeader/config.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/config.ts
@@ -1,4 +1,7 @@
 export const config = {
+	background: {
+		color: 'secondary'
+	},
 	backBtn: {
 		color: 'transparent',
 		small: true,

--- a/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
@@ -1,53 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SubHeader renders correctly 1`] = `
-<div class="vd-sub-header">
-  <vsheet-stub color="secondary" tag="div" class="white--text py-6 px-8">
-    <vfadetransition-stub mode="out-in" origin="top center 0">
-      <vbtn-stub color="transparent" tag="button" activeclass="" small="true" depressed="true" type="button" class="vd-sub-header-back-btn mb-1 text-none font-weight-regular white--text px-1">
-        <vicon-stub class="mr-2">
-          M21,11H6.83L10.41,7.41L9,6L3,12L9,18L10.41,16.58L6.83,13H21V11Z
-        </vicon-stub>
+<vsheet-stub color="secondary" tag="div" class="vd-sub-header white--text py-6 px-8" style="width: 100%;">
+  <vfadetransition-stub mode="out-in" origin="top center 0">
+    <vbtn-stub color="transparent" tag="button" activeclass="" small="true" depressed="true" type="button" class="vd-sub-header-back-btn mb-1 text-none font-weight-regular white--text px-1">
+      <vicon-stub class="mr-2">
+        M21,11H6.83L10.41,7.41L9,6L3,12L9,18L10.41,16.58L6.83,13H21V11Z
+      </vicon-stub>
 
-        Retour
-      </vbtn-stub>
-    </vfadetransition-stub>
-    <div class="vd-sub-header-content d-flex justify-space-between">
-      <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
-        <vfadetransition-stub mode="out-in" origin="top center 0">
-          <h2 class="text-h5 font-weight-bold">
-            Test
-          </h2>
-        </vfadetransition-stub>
-        <!---->
-      </div>
-      <vthemeprovider-stub dark="true">
-        <!---->
-      </vthemeprovider-stub>
+      Retour
+    </vbtn-stub>
+  </vfadetransition-stub>
+  <div class="vd-sub-header-content d-flex justify-space-between">
+    <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
+      <vfadetransition-stub mode="out-in" origin="top center 0">
+        <h2 class="text-h5 font-weight-bold">
+          Test
+        </h2>
+      </vfadetransition-stub>
+      <!---->
     </div>
-  </vsheet-stub>
-</div>
+    <vthemeprovider-stub dark="true">
+      <!---->
+    </vthemeprovider-stub>
+  </div>
+</vsheet-stub>
 `;
 
 exports[`SubHeader renders loading state correctly 1`] = `
-<div class="vd-sub-header">
-  <div class="white--text py-6 px-8 v-sheet theme--light secondary">
-    <transition-stub name="fade-transition" mode="out-in">
-      <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 28px; width: 100px;">
-        <div class="v-skeleton-loader__button v-skeleton-loader__bone"></div>
-      </div>
-    </transition-stub>
-    <div class="vd-sub-header-content d-flex justify-space-between">
-      <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
-        <transition-stub name="fade-transition" mode="out-in">
-          <div aria-busy="true" aria-live="polite" role="alert" aria-hidden="true" class="v-skeleton-loader vd-header-loading v-skeleton-loader--is-loading theme--dark" style="height: 2rem; width: 300px;">
-            <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
-          </div>
-        </transition-stub>
-        <!---->
-      </div>
-      <div class="vd-data-list-group d-flex flex-wrap max-width-none ma-n4 flex-nowrap flex-shrink-0"><datalist loading="true" list-title="Catégorie 1" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist><datalist loading="true" list-title="Catégorie 2" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist></div>
+<div class="vd-sub-header white--text py-6 px-8 v-sheet theme--light secondary" style="width: 100%;">
+  <transition-stub name="fade-transition" mode="out-in">
+    <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 28px; width: 100px;">
+      <div class="v-skeleton-loader__button v-skeleton-loader__bone"></div>
     </div>
+  </transition-stub>
+  <div class="vd-sub-header-content d-flex justify-space-between">
+    <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
+      <transition-stub name="fade-transition" mode="out-in">
+        <div aria-busy="true" aria-live="polite" role="alert" aria-hidden="true" class="v-skeleton-loader vd-header-loading v-skeleton-loader--is-loading theme--dark" style="height: 2rem; width: 300px;">
+          <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+    <div class="vd-data-list-group d-flex flex-wrap max-width-none ma-n4 flex-nowrap flex-shrink-0"><datalist loading="true" list-title="Catégorie 1" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist><datalist loading="true" list-title="Catégorie 2" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist></div>
   </div>
 </div>
 `;

--- a/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/__snapshots__/SubHeader.spec.ts.snap
@@ -1,49 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SubHeader renders correctly 1`] = `
-<div class="vd-sub-header secondary white--text py-6 px-8" style="width: 100%;">
-  <vfadetransition-stub mode="out-in" origin="top center 0">
-    <vbtn-stub color="transparent" tag="button" activeclass="" small="true" depressed="true" type="button" class="vd-sub-header-back-btn mb-1 text-none font-weight-regular white--text px-1">
-      <vicon-stub class="mr-2">
-        M21,11H6.83L10.41,7.41L9,6L3,12L9,18L10.41,16.58L6.83,13H21V11Z
-      </vicon-stub>
+<div class="vd-sub-header">
+  <vsheet-stub color="secondary" tag="div" class="white--text py-6 px-8">
+    <vfadetransition-stub mode="out-in" origin="top center 0">
+      <vbtn-stub color="transparent" tag="button" activeclass="" small="true" depressed="true" type="button" class="vd-sub-header-back-btn mb-1 text-none font-weight-regular white--text px-1">
+        <vicon-stub class="mr-2">
+          M21,11H6.83L10.41,7.41L9,6L3,12L9,18L10.41,16.58L6.83,13H21V11Z
+        </vicon-stub>
 
-      Retour
-    </vbtn-stub>
-  </vfadetransition-stub>
-  <div class="vd-sub-header-content d-flex justify-space-between">
-    <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
-      <vfadetransition-stub mode="out-in" origin="top center 0">
-        <h2 class="text-h5 font-weight-bold">
-          Test
-        </h2>
-      </vfadetransition-stub>
-      <!---->
+        Retour
+      </vbtn-stub>
+    </vfadetransition-stub>
+    <div class="vd-sub-header-content d-flex justify-space-between">
+      <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
+        <vfadetransition-stub mode="out-in" origin="top center 0">
+          <h2 class="text-h5 font-weight-bold">
+            Test
+          </h2>
+        </vfadetransition-stub>
+        <!---->
+      </div>
+      <vthemeprovider-stub dark="true">
+        <!---->
+      </vthemeprovider-stub>
     </div>
-    <vthemeprovider-stub dark="true">
-      <!---->
-    </vthemeprovider-stub>
-  </div>
+  </vsheet-stub>
 </div>
 `;
 
 exports[`SubHeader renders loading state correctly 1`] = `
-<div class="vd-sub-header secondary white--text py-6 px-8" style="width: 100%;">
-  <transition-stub name="fade-transition" mode="out-in">
-    <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 28px; width: 100px;">
-      <div class="v-skeleton-loader__button v-skeleton-loader__bone"></div>
+<div class="vd-sub-header">
+  <div class="white--text py-6 px-8 v-sheet theme--light secondary">
+    <transition-stub name="fade-transition" mode="out-in">
+      <div aria-busy="true" aria-live="polite" role="alert" class="v-skeleton-loader mb-1 v-skeleton-loader--is-loading theme--dark" style="height: 28px; width: 100px;">
+        <div class="v-skeleton-loader__button v-skeleton-loader__bone"></div>
+      </div>
+    </transition-stub>
+    <div class="vd-sub-header-content d-flex justify-space-between">
+      <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
+        <transition-stub name="fade-transition" mode="out-in">
+          <div aria-busy="true" aria-live="polite" role="alert" aria-hidden="true" class="v-skeleton-loader vd-header-loading v-skeleton-loader--is-loading theme--dark" style="height: 2rem; width: 300px;">
+            <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
+          </div>
+        </transition-stub>
+        <!---->
+      </div>
+      <div class="vd-data-list-group d-flex flex-wrap max-width-none ma-n4 flex-nowrap flex-shrink-0"><datalist loading="true" list-title="Catégorie 1" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist><datalist loading="true" list-title="Catégorie 2" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist></div>
     </div>
-  </transition-stub>
-  <div class="vd-sub-header-content d-flex justify-space-between">
-    <div class="vd-sub-header-informations d-flex flex-column flex-shrink-0 mr-10">
-      <transition-stub name="fade-transition" mode="out-in">
-        <div aria-busy="true" aria-live="polite" role="alert" aria-hidden="true" class="v-skeleton-loader vd-header-loading v-skeleton-loader--is-loading theme--dark" style="height: 2rem; width: 300px;">
-          <div class="v-skeleton-loader__heading v-skeleton-loader__bone"></div>
-        </div>
-      </transition-stub>
-      <!---->
-    </div>
-    <div class="vd-data-list-group d-flex flex-wrap max-width-none ma-n4 flex-nowrap flex-shrink-0"><datalist loading="true" list-title="Catégorie 1" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist><datalist loading="true" list-title="Catégorie 2" items="[object Object],[object Object]" items-number-loading="2" heading-loading="true" width="auto" class="ma-4"></datalist></div>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Description

Ajouter une option pour changer la couleur de fond du composant.

## Playground

<details>

```vue
<template>
	<SubHeader
		title-text="Paul Dupont"
		sub-title-text="1 69 08 75 125 456 75"
		:vuetify-options="vuetifyOptions"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class SubHeaderOptions extends Vue {
		vuetifyOptions = {
			background: {
				color: 'primary'
			}
		};
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
