### PR TITLE
🐛 vue-dot: Fix VTextField border color

### DIFF
--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -49,8 +49,8 @@
 	}
 }
 
-// Fix color contrast of disabled elements
 .theme--light {
+	// Fix color contrast of disabled elements
 	&.v-label--is-disabled,
 	&.v-input--is-disabled .v-label,
 	&.v-icon.v-icon--disabled,
@@ -87,6 +87,13 @@
 			> .v-icon {
 				color: #767676 !important;
 			}
+		}
+	}
+
+	// Fix fieldset border color
+	.v-text-field--outlined:not(.v-input--is-focused):not(.v-input--has-state) {
+		> .v-input__control > .v-input__slot fieldset {
+			color: rgba(0, 0, 0, .42) !important;
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes #2528 

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<VTextField outlined />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [x] J'ai mis à jour le fichier Changelog
