### PR TITLE
🐛 docs: Fix missing custom Vuetify variables

### DIFF
--- a/packages/docs/nuxt.config.js
+++ b/packages/docs/nuxt.config.js
@@ -95,7 +95,8 @@ export default {
 		defaultAssets: false,
 		treeShake: {
 			directives: ['Scroll']
-		}
+		},
+		customVariables: ['~/assets/styles/variables.scss']
 	},
 	googleFonts: {
 		families: {

--- a/packages/docs/src/assets/styles/variables.scss
+++ b/packages/docs/src/assets/styles/variables.scss
@@ -1,0 +1,1 @@
+@import '@cnamts/vue-dot/src/styles/variables';


### PR DESCRIPTION
## Description

Le fichier `variables.scss` de Vue Dot n'étais pas importé dans la documentation.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
