### PR TITLE
🐛 vue-dot: Fix AccessibilityBanner remaining visible on focus out

### DIFF
--- a/packages/vue-dot/src/patterns/AccessibilityBanner/AccessibilityBanner.vue
+++ b/packages/vue-dot/src/patterns/AccessibilityBanner/AccessibilityBanner.vue
@@ -11,7 +11,7 @@
 				:width="btnWidth"
 				:to="accessibilityRoute"
 				@click="accept"
-				@focusout="accept"
+				@focusout="onFocusOut"
 			>
 				{{ locales.label }}
 			</VBtn>
@@ -68,6 +68,11 @@
 					return;
 				}
 			});
+		}
+
+		onFocusOut(): void {
+			this.active = false;
+			document.removeEventListener('keydown', this.checkTabKey);
 		}
 	}
 </script>

--- a/packages/vue-dot/src/patterns/AccessibilityBanner/AccessibilityBanner.vue
+++ b/packages/vue-dot/src/patterns/AccessibilityBanner/AccessibilityBanner.vue
@@ -11,7 +11,7 @@
 				:width="btnWidth"
 				:to="accessibilityRoute"
 				@click="accept"
-				@focusout="onFocusOut"
+				@focusout="accept"
 			>
 				{{ locales.label }}
 			</VBtn>
@@ -68,10 +68,6 @@
 					return;
 				}
 			});
-		}
-
-		onFocusOut(): void {
-			this.accept();
 		}
 	}
 </script>

--- a/packages/vue-dot/src/patterns/AccessibilityBanner/AccessibilityBanner.vue
+++ b/packages/vue-dot/src/patterns/AccessibilityBanner/AccessibilityBanner.vue
@@ -11,6 +11,7 @@
 				:width="btnWidth"
 				:to="accessibilityRoute"
 				@click="accept"
+				@focusout="onFocusOut"
 			>
 				{{ locales.label }}
 			</VBtn>
@@ -67,6 +68,10 @@
 					return;
 				}
 			});
+		}
+
+		onFocusOut(): void {
+			this.accept();
 		}
 	}
 </script>


### PR DESCRIPTION
## Description

Pouvoir faire disparaitre l'AccessibilityBanner à la perte de focus

## Playground

<details>

```vue
<template>
	<div class="d-flex flex-wrap align-center justify-center">
		<AccessibilityBanner
			v-if="active"
			accessibility-route="#section/utilisation"
			@accept="active = false; removeTabKey()"
		/>

		<VBtn
			v-if="!active"
			color="primary"
			@click="active = true; info = true; checkTabKey()"
		>
			Réinitialiser
		</VBtn>
		<div v-if="info">
			Cliquez sur la touche Tab
		</div>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';
	import AccessibilityBanner from '@cnamts/vue-dot/src/patterns/AccessibilityBanner';

	@Component({
		inheritAttrs: false,
		components: {
			AccessibilityBanner
		}
	})
	export default class AccessibilityBannerUsage extends Vue {
		active = true;
		info = true;

		mounted() {
			this.checkTabKey();
		}

		checkTabKey(): void {
			document.addEventListener('keydown', (e) => {
				if (e.key === 'Tab') {
					this.info = false;
				} else {
					return;
				}
			});
		}
		removeTabKey(): void {
			document.removeEventListener('keydown', this.checkTabKey);
		}
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
