### PR TITLE
🐛 vue-dot: Fix HeaderBar drawer rendered on mobile without items

### DIFF
--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/HeaderNavigationDrawer.vue
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/HeaderNavigationDrawer.vue
@@ -1,6 +1,6 @@
 <template>
 	<VNavigationDrawer
-		v-if="mobileVersion"
+		v-if="mobileVersion && items"
 		v-bind="options.navigationDrawer"
 		:value="drawer"
 		:color="backgroundColor"

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
@@ -1,14 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderNavigationDrawer renders correctly 1`] = `
-<vnavigationdrawer-stub app="true" color="#0a347b" mobilebreakpoint="1264" dark="true" height="100vh" minivariantwidth="56" src="" tag="nav" temporary="true" width="320px" class="pa-4">
-  <div class="d-flex align-center justify-end mb-8">
-    <vbtn-stub tag="button" activeclass="" icon="true" type="button" aria-label="Fermer le menu">
-      <vicon-stub>
-        M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z
-      </vicon-stub>
-    </vbtn-stub>
-  </div>
-  <vtabs-stub activeclass="" backgroundcolor="transparent" nexticon="$next" optional="true" previcon="$prev" slidersize="2" vertical="true" dense="true"></vtabs-stub>
-</vnavigationdrawer-stub>
-`;
+exports[`HeaderNavigationDrawer renders correctly 1`] = `""`;


### PR DESCRIPTION
## Description

Le composant HeaderNavigationDrawer est présent dans le DOM de la page en mobile lorsque le composant HeaderBar est utilisé sans éléments de navigation.

## Playground

<details>

```vue
<template>
	<HeaderBar :navigation-items="navigationItems" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { NavigationItem } from '@cnamts/vue-dot/src/patterns/HeaderBar/types';

	@Component
	export default class HeaderBarNavigationBar extends Vue {
		navigationItems: NavigationItem[] = [
			{
				label: 'Accueil'
			},
			{
				label: 'Mes projets'
			},
			{
				label: 'Mes outils'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
