### PR TITLE
🐛 docs: Fix HeaderBar sticky mobile usage example

### DIFF
--- a/packages/docs/src/data/examples/header-bar/usage.vue
+++ b/packages/docs/src/data/examples/header-bar/usage.vue
@@ -16,6 +16,7 @@
 				'sticky-header-example': $attrs.sticky,
 				'hide-secondary-title-overflow': $attrs.theme === ThemeEnum.COMPTE_ENTREPRISE
 			}"
+			:vuetify-options="vuetifyOptions"
 			v-on="$listeners"
 		/>
 
@@ -33,6 +34,7 @@
 
 	import { NavigationItem } from '@cnamts/vue-dot/src/patterns/HeaderBar/types';
 	import { ThemeEnum } from '@cnamts/vue-dot/src/constants/enums/ThemeEnum';
+	import { Options } from '@cnamts/vue-dot/src/mixins/customizable';
 
 	const EXAMPLE_TARGET = 'header-bar-usage';
 
@@ -82,6 +84,14 @@
 				'serviceSubTitle'
 			]
 		};
+
+		get vuetifyOptions(): Options {
+			return {
+				navigationDrawer: {
+					hideOverlay: Boolean(this.$attrs.sticky && this.$attrs.mobileVersion)
+				}
+			};
+		};
 	}
 </script>
 
@@ -92,6 +102,10 @@
 
 		:deep(.vd-header-bar) {
 			position: static !important;
+		}
+
+		:deep(.v-navigation-drawer--fixed) {
+			position: absolute;
 		}
 
 		&.hide-secondary-title-overflow :deep(.vd-header-brand-section) {


### PR DESCRIPTION
## Description

Correction de l'exemple d'utilisation du composant `HeaderBar` avec les props `sticky` et `mobile-version`.

## Type de changement

- Correction de bug
- Documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
