### PR TITLE
🐛 vue-dot: Fix link outline in LogoBrandSection

### DIFF
--- a/packages/docs/src/data/examples/logo-brand-section/usage.vue
+++ b/packages/docs/src/data/examples/logo-brand-section/usage.vue
@@ -28,7 +28,7 @@
 		options = {
 			booleans: [
 				'mobileVersion',
-				'reduce-logo'
+				'reduceLogo'
 			],
 			selects: {
 				theme: [

--- a/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
+++ b/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
@@ -52,7 +52,7 @@
 
 			<div
 				v-else-if="service.title || service.subTitle"
-				class="d-flex justify-center flex-column primary--text"
+				class="vd-header-title-container d-flex justify-center flex-column primary--text"
 			>
 				<h1
 					v-if="service.title"
@@ -282,7 +282,9 @@
 
 <style lang="scss" scoped>
 	.vd-header-brand-section {
-		overflow: hidden;
+		.vd-header-title-container {
+			overflow: hidden;
+		}
 
 		.vd-header-title {
 			line-height: 1.45 !important;


### PR DESCRIPTION
## Description

La bordure `outline` lors du focus n'est pas visible à cause du `overflow: hidden`

## Playground

<details>

```vue
<template>
	<LogoBrandSection theme="default" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
