### PR TITLE
🐛 vue-dot: Fix theme prop default value in LogoBrandSection

### DIFF
--- a/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
+++ b/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
@@ -100,7 +100,7 @@
 		props: {
 			theme: {
 				type: String as PropType<ThemeEnum>,
-				required: true
+				default: ThemeEnum.DEFAULT
 			},
 			serviceTitle: {
 				type: String,


### PR DESCRIPTION
## Description

Actuellement la prop `theme` requiert une valeur alors que celle-ci est documentée comme ayant la valeur par défaut `default`.

## Playground

<details>

```vue
<template>
	<LogoBrandSection />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
