### PR TITLE
🐛 vue-dot: Fix RouterLink usage for Nuxt in LogoBrandSection

### DIFF
--- a/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
+++ b/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
@@ -96,6 +96,8 @@
 	import { secondaryLogoMapping } from './secondaryLogoMapping';
 	import { dividerDimensionsMapping } from './dividerDimensionsMapping';
 
+	import { NuxtApp } from '@nuxt/types/app';
+
 	const Props = Vue.extend({
 		props: {
 			theme: {
@@ -191,12 +193,20 @@
 			return this.theme === ThemeEnum.AMELI_PRO || this.theme === ThemeEnum.AMELI;
 		}
 
+		get isNuxt(): boolean {
+			return (this as unknown as NuxtApp).$nuxt !== undefined;
+		}
+
 		get logoContainerComponent(): string {
 			if (this.homeHref) {
 				return 'a';
 			}
 
-			return this.homeLink ? 'RouterLink' : 'div';
+			if (!this.homeLink) {
+				return 'div';
+			}
+
+			return this.isNuxt ? 'NuxtLink' : 'RouterLink';
 		}
 
 		get secondaryLogoCtnComponent(): string {


### PR DESCRIPTION
## Description

Utilisation de `NuxtLink` à la place de `RouterLink` lorsque Nuxt est détecté. Cela corrige les liens dans la documentation qui n'étaient pas valides car ils n'avaient pas la prop `href`.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
