### PR TITLE
♿️ vue-dot: Add contentinfo role on FooterBar

### DIFF
--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -4,8 +4,9 @@
 			...options.footer,
 			...$attrs
 		}"
-		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode }"
+		role="contentinfo"
 		class="vd-footer-bar flex-column align-stretch pa-3 w-100"
+		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode }"
 	>
 		<div
 			v-if="extendedMode"

--- a/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
+++ b/packages/vue-dot/src/patterns/FooterBar/FooterBar.vue
@@ -4,9 +4,9 @@
 			...options.footer,
 			...$attrs
 		}"
+		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode }"
 		role="contentinfo"
 		class="vd-footer-bar flex-column align-stretch pa-3 w-100"
-		:class="{ 'py-4 py-sm-7 px-4 px-md-14': extendedMode }"
 	>
 		<div
 			v-if="extendedMode"

--- a/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/__snapshots__/FooterBar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FooterBar renders correctly 1`] = `
-<vfooter-stub color="#fff" elevation="3" height="auto" minheight="40px" tag="footer" class="vd-footer-bar flex-column align-stretch pa-3 w-100">
+<vfooter-stub color="#fff" elevation="3" height="auto" minheight="40px" tag="footer" role="contentinfo" class="vd-footer-bar flex-column align-stretch pa-3 w-100">
   <!---->
   <!---->
   <!---->


### PR DESCRIPTION
## Description

Ajouter le rôle "contentinfo" sur le composant FooterBar #2740

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<FooterBar />
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
