### PR TITLE
vue-dot: add suffix option on NirField

### DIFF
--- a/packages/docs/src/data/api/nir-field.ts
+++ b/packages/docs/src/data/api/nir-field.ts
@@ -23,6 +23,12 @@ export const api: Api = {
 				description: 'Rends le ou les champ(s) obligatoire(s) en utilisant la règle de validation [`required`](/composants-techniques/regles-de-validation/required).'
 			},
 			{
+				name: 'suffix',
+				type: 'boolean',
+				default: false,
+				description: 'Ajoute un astérisque à côté du ou des champ(s) pour indiquer qu’il(s) est(sont) obligatoire(s).'
+			},
+			{
 				name: 'tooltip',
 				type: 'string',
 				default: null,

--- a/packages/docs/src/data/examples/nir-field/usage.vue
+++ b/packages/docs/src/data/examples/nir-field/usage.vue
@@ -25,7 +25,8 @@
 
 		options = {
 			booleans: [
-				'required'
+				'required',
+				'suffix'
 			],
 			textFields: [
 				'tooltip'

--- a/packages/vue-dot/src/patterns/NirField/NirField.vue
+++ b/packages/vue-dot/src/patterns/NirField/NirField.vue
@@ -7,6 +7,7 @@
 			:value="computedNumberValue"
 			:label="locales.numberLabel"
 			:hint="locales.numberHint"
+			:suffix="suffix ? '*' : ''"
 			:rules="numberRules"
 			:success="numberFilled"
 			class="vd-number-field flex-grow-0 mx-1 mx-sm-2"
@@ -32,6 +33,7 @@
 			:value="keyValue"
 			:label="locales.keyLabel"
 			:hint="locales.keyHint"
+			:suffix="suffix ? '*' : ''"
 			:rules="keyRules"
 			:success="keyFilled"
 			class="vd-key-field flex-grow-0 mx-1 mx-sm-2"
@@ -112,6 +114,10 @@
 				}
 			},
 			required: {
+				type: Boolean,
+				default: false
+			},
+			suffix: {
 				type: Boolean,
 				default: false
 			},


### PR DESCRIPTION
## Description

Ajouter une option pour montrer que les champs sont obligatoires (*).

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<NirField
			required
			suffix
			v-model="nir"
		/>
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		nir: string | null = null;
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
