### PR TITLE
vue-dot: fix tooltips opacity

### DIFF
--- a/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
+++ b/packages/vue-dot/src/elements/CopyBtn/CopyBtn.vue
@@ -93,6 +93,6 @@
 		padding: 6px 16px;
 		box-shadow: none;
 		margin-top: 2px;
-		background: rgba(97, 97, 97, .9);
+		background: rgba(114,114,114,1);
 	}
 </style>

--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -112,6 +112,11 @@
 			}
 		}
 	}
+
+	// Fix tooltips opacity
+	.v-tooltip__content, .v-icon.vd-tooltip-icon {
+		opacity: 1 !important;
+	}
 }
 
 // Fix font size (default for these elements is 16px)


### PR DESCRIPTION
## Description

Tooltip background : retour sur la transparence #2753](https://github.com/assurance-maladie-digital/design-system/issues/2753)

Le tooltip ouvert possède un texte sur un fond de couleur sombre mais pas opaque, ce qui laisse entrevoir ce qu'il y a derrière l'objet. Cela peut être perturbant (même si accessible au niveau des contrastes) à la lecture.

## Type de changement

- Maintenance

## Checklist

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Mon code suit le style de code du projet
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
