### PR TITLE
🐛 vue-dot: Fix VRow max-width

### DIFF
--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -12,7 +12,8 @@
 .v-simple-checkbox svg,
 .v-slide-group__content,
 .v-slider__tick-label,
-.v-slider__thumb-container * {
+.v-slider__thumb-container *,
+.row {
 	max-width: none;
 }
 


### PR DESCRIPTION
## Description

Il y a un margin négatif sur le composant `VRow`, on ne doit donc pas appliquer `max-width: 100%;` dessus.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
