### PR TITLE
🐛 vue-dot: Fix Nuxt import in LogoBrandSection

### DIFF
--- a/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
+++ b/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
@@ -96,7 +96,11 @@
 	import { secondaryLogoMapping } from './secondaryLogoMapping';
 	import { dividerDimensionsMapping } from './dividerDimensionsMapping';
 
-	import { NuxtApp } from '@nuxt/types/app';
+	/** Define a local interface since Nuxt isn't a dependency */
+	interface MaybeNuxtInstance extends Vue {
+		/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+		$nuxt: any;
+	}
 
 	const Props = Vue.extend({
 		props: {
@@ -194,7 +198,7 @@
 		}
 
 		get isNuxt(): boolean {
-			return (this as unknown as NuxtApp).$nuxt !== undefined;
+			return (this as unknown as MaybeNuxtInstance).$nuxt !== undefined;
 		}
 
 		get logoContainerComponent(): string {


### PR DESCRIPTION
## Description

Nuxt n'est pas une dépendance de Vue Dot, l'import générait donc une erreur dans les projets et le code est plus lisible de cette manière.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
