### PR TITLE
✨ vue-dot: Add dark prop to BackBtn

### DIFF
--- a/packages/docs/src/content/composants/boutons/back-btn.md
+++ b/packages/docs/src/content/composants/boutons/back-btn.md
@@ -31,6 +31,12 @@ Les propriétés non définies dans la section API seront reportées directement
 
 <doc-tab-item label="Personnalisation">
 
+### Dark mode
+
+Vous pouvez utiliser la propriété `dark` pour afficher le bouton dans le thème sombre.
+
+<doc-example file="back-btn/dark"></doc-example>
+
 ### Slots
 
 Vous pouvez utiliser le slot par défaut pour remplacer le texte du bouton et le slot `icon` pour remplacer l'icône par défaut.

--- a/packages/docs/src/content/composants/boutons/back-btn.md
+++ b/packages/docs/src/content/composants/boutons/back-btn.md
@@ -15,6 +15,12 @@ Par défaut, le composant `BackBtn` n'effectue aucune action, vous devez implém
 
 </doc-alert>
 
+### Mode sombre
+
+Vous pouvez afficher le composant en mode sombre en utilisant la prop `dark`.
+
+<doc-example file="back-btn/dark"></doc-example>
+
 </doc-tab-item>
 
 <doc-tab-item label="API">
@@ -30,12 +36,6 @@ Les propriétés non définies dans la section API seront reportées directement
 </doc-tab-item>
 
 <doc-tab-item label="Personnalisation">
-
-### Dark mode
-
-Vous pouvez utiliser la propriété `dark` pour afficher le bouton dans le thème sombre.
-
-<doc-example file="back-btn/dark"></doc-example>
 
 ### Slots
 

--- a/packages/docs/src/data/api/back-btn.ts
+++ b/packages/docs/src/data/api/back-btn.ts
@@ -12,7 +12,7 @@ export const api: Api = {
 			{
 				name: 'dark',
 				type: 'boolean',
-				description: 'Applique un thème sombre au bouton.',
+				description: 'Active le mode sombre.',
 				default: false
 			}
 		],

--- a/packages/docs/src/data/api/back-btn.ts
+++ b/packages/docs/src/data/api/back-btn.ts
@@ -10,6 +10,18 @@ export const api: Api = {
 				default: false
 			},
 			{
+				name: 'dark',
+				type: 'boolean',
+				description: 'Applique un thème sombre au bouton.',
+				default: false
+			},
+			{
+				name: 'outlined',
+				type: 'boolean',
+				description: 'Applique un style de bouton avec contour.',
+				default: false
+			},
+			{
 				name: 'no-padding',
 				type: 'boolean',
 				description: 'Supprime le padding horizontal du bouton.',

--- a/packages/docs/src/data/api/back-btn.ts
+++ b/packages/docs/src/data/api/back-btn.ts
@@ -8,6 +8,18 @@ export const api: Api = {
 				type: 'boolean',
 				description: 'Masque l’icône du bouton.',
 				default: false
+			},
+			{
+				name: 'no-padding',
+				type: 'boolean',
+				description: 'Supprime le padding horizontal du bouton.',
+				default: false
+			},
+			{
+				name: 'elevation',
+				type: 'number',
+				description: 'Élévation du bouton.',
+				default: 0
 			}
 		],
 		slots: [

--- a/packages/docs/src/data/api/back-btn.ts
+++ b/packages/docs/src/data/api/back-btn.ts
@@ -14,24 +14,6 @@ export const api: Api = {
 				type: 'boolean',
 				description: 'Applique un thème sombre au bouton.',
 				default: false
-			},
-			{
-				name: 'outlined',
-				type: 'boolean',
-				description: 'Applique un style de bouton avec contour.',
-				default: false
-			},
-			{
-				name: 'no-padding',
-				type: 'boolean',
-				description: 'Supprime le padding horizontal du bouton.',
-				default: false
-			},
-			{
-				name: 'elevation',
-				type: 'number',
-				description: 'Élévation du bouton.',
-				default: 0
 			}
 		],
 		slots: [

--- a/packages/docs/src/data/examples/back-btn/dark.vue
+++ b/packages/docs/src/data/examples/back-btn/dark.vue
@@ -1,0 +1,18 @@
+<template>
+	<VSheet
+		color="primary"
+		class="pa-4 d-flex flex-wrap align-center justify-center"
+	>
+		<BackBtn
+			dark
+		/>
+	</VSheet>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+	import Component from 'vue-class-component';
+
+	@Component
+	export default class BackBtnDark extends Vue {}
+</script>

--- a/packages/docs/src/data/examples/back-btn/dark.vue
+++ b/packages/docs/src/data/examples/back-btn/dark.vue
@@ -1,11 +1,9 @@
 <template>
 	<VSheet
 		color="primary"
-		class="pa-4 d-flex flex-wrap align-center justify-center"
+		class="pa-4"
 	>
-		<BackBtn
-			dark
-		/>
+		<BackBtn dark />
 	</VSheet>
 </template>
 

--- a/packages/docs/src/data/examples/back-btn/usage.vue
+++ b/packages/docs/src/data/examples/back-btn/usage.vue
@@ -17,17 +17,8 @@
 	export default class BackBtnUsage extends Vue {
 		options = {
 			booleans: [
-				'hideBackIcon',
-				'noPadding',
-				'dark',
-				'outlined'
-			],
-			sliders: {
-				elevation: {
-					min: 0,
-					max: 10
-				}
-			},
+				'hideBackIcon'
+			]
 		};
 	}
 </script>

--- a/packages/docs/src/data/examples/back-btn/usage.vue
+++ b/packages/docs/src/data/examples/back-btn/usage.vue
@@ -17,8 +17,16 @@
 	export default class BackBtnUsage extends Vue {
 		options = {
 			booleans: [
-				'hideBackIcon'
-			]
+				'hideBackIcon',
+				'noPadding',
+				'dark'
+			],
+			sliders: {
+				elevation: {
+					min: 0,
+					max: 10
+				}
+			},
 		};
 	}
 </script>

--- a/packages/docs/src/data/examples/back-btn/usage.vue
+++ b/packages/docs/src/data/examples/back-btn/usage.vue
@@ -19,7 +19,8 @@
 			booleans: [
 				'hideBackIcon',
 				'noPadding',
-				'dark'
+				'dark',
+				'outlined'
 			],
 			sliders: {
 				elevation: {

--- a/packages/docs/src/data/examples/back-btn/usage.vue
+++ b/packages/docs/src/data/examples/back-btn/usage.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="d-flex flex-wrap align-center justify-center">
+	<div
+		:class="{ 'primary': $attrs.dark }"
+		class="d-flex flex-wrap align-center justify-center w-100"
+	>
 		<BackBtn
 			v-bind="$attrs"
 			v-on="$listeners"
@@ -17,7 +20,8 @@
 	export default class BackBtnUsage extends Vue {
 		options = {
 			booleans: [
-				'hideBackIcon'
+				'hideBackIcon',
+				'dark'
 			]
 		};
 	}

--- a/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
+++ b/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
@@ -2,8 +2,13 @@
 	<VBtn
 		v-bind="$attrs"
 		:text="!dark"
+		:dark="dark"
 		:color="dark ? 'white' : 'primary'"
 		:outlined="dark"
+		:class="{
+			'px-0': !dark,
+			'pr-1': !dark && !hideBackIcon
+		}"
 		class="vd-back-btn"
 		v-on="$listeners"
 	>
@@ -11,7 +16,8 @@
 			<VIcon
 				v-if="!hideBackIcon"
 				:color="dark ? 'white' : 'primary'"
-				class="ml-n1 mr-1"
+				:class="{ 'ml-n1': dark }"
+				class="mr-1"
 			>
 				{{ backIcon }}
 			</VIcon>
@@ -49,14 +55,15 @@
 	@Component
 	export default class BackBtn extends MixinsDeclaration {
 		locales = locales;
+
 		backIcon = mdiArrowLeft;
 	}
 </script>
 
 <style lang="scss" scoped>
 	.v-btn {
-		// Disable hover state
-		&::before {
+		// Disable hover state on light theme
+		&.theme--light::before {
 			content: none;
 		}
 

--- a/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
+++ b/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
@@ -1,9 +1,10 @@
 <template>
 	<VBtn
 		v-bind="$attrs"
-		:text="!dark"
+		:text="!dark && !outlined"
+		:outlined="outlined"
 		:elevation="elevation"
-		color="primary"
+		:color="dark && outlined ? 'white' : 'primary'"
 		class="vd-back-btn"
 		:class="noPadding ? 'px-0' : 'px-4'"
 		v-on="$listeners"
@@ -45,6 +46,10 @@
 			elevation: {
 				type: [Number, String],
 				default: 0
+			},
+			outlined: {
+				type: Boolean,
+				default: false
 			},
 			dark: {
 				type: Boolean,

--- a/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
+++ b/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
@@ -1,12 +1,10 @@
 <template>
 	<VBtn
 		v-bind="$attrs"
-		:text="!dark && !outlined"
-		:outlined="outlined"
-		:elevation="elevation"
-		:color="dark && outlined ? 'white' : 'primary'"
+		:text="!dark"
+		:color="dark ? 'white' : 'primary'"
+		:outlined="dark"
 		class="vd-back-btn"
-		:class="noPadding ? 'px-0' : 'px-4'"
 		v-on="$listeners"
 	>
 		<slot name="icon">
@@ -39,18 +37,6 @@
 				type: Boolean,
 				default: false
 			},
-			noPadding: {
-				type: Boolean,
-				default: false
-			},
-			elevation: {
-				type: [Number, String],
-				default: 0
-			},
-			outlined: {
-				type: Boolean,
-				default: false
-			},
 			dark: {
 				type: Boolean,
 				default: false
@@ -63,7 +49,6 @@
 	@Component
 	export default class BackBtn extends MixinsDeclaration {
 		locales = locales;
-
 		backIcon = mdiArrowLeft;
 	}
 </script>

--- a/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
+++ b/packages/vue-dot/src/elements/BackBtn/BackBtn.vue
@@ -1,17 +1,18 @@
 <template>
 	<VBtn
 		v-bind="$attrs"
-		:class="{ 'pr-1': !hideBackIcon }"
-		text
+		:text="!dark"
+		:elevation="elevation"
 		color="primary"
-		class="vd-back-btn px-0"
+		class="vd-back-btn"
+		:class="noPadding ? 'px-0' : 'px-4'"
 		v-on="$listeners"
 	>
 		<slot name="icon">
 			<VIcon
 				v-if="!hideBackIcon"
-				color="primary"
-				class="mr-1"
+				:color="dark ? 'white' : 'primary'"
+				class="ml-n1 mr-1"
 			>
 				{{ backIcon }}
 			</VIcon>
@@ -34,6 +35,18 @@
 	const Props = Vue.extend({
 		props: {
 			hideBackIcon: {
+				type: Boolean,
+				default: false
+			},
+			noPadding: {
+				type: Boolean,
+				default: false
+			},
+			elevation: {
+				type: [Number, String],
+				default: 0
+			},
+			dark: {
 				type: Boolean,
 				default: false
 			}

--- a/packages/vue-dot/src/elements/BackBtn/tests/__snapshots__/BackBtn.spec.ts.snap
+++ b/packages/vue-dot/src/elements/BackBtn/tests/__snapshots__/BackBtn.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BackBtn renders correctly 1`] = `
-<vbtn-stub color="primary" tag="button" activeclass="" text="true" type="button" class="vd-back-btn">
-  <vicon-stub color="primary" class="ml-n1 mr-1">
+<vbtn-stub color="primary" tag="button" activeclass="" text="true" type="button" class="vd-back-btn px-0 pr-1">
+  <vicon-stub color="primary" class="mr-1">
     M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z
   </vicon-stub>
   Retour

--- a/packages/vue-dot/src/elements/BackBtn/tests/__snapshots__/BackBtn.spec.ts.snap
+++ b/packages/vue-dot/src/elements/BackBtn/tests/__snapshots__/BackBtn.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BackBtn renders correctly 1`] = `
-<vbtn-stub color="primary" elevation="0" tag="button" activeclass="" text="true" type="button" class="vd-back-btn px-4">
+<vbtn-stub color="primary" tag="button" activeclass="" text="true" type="button" class="vd-back-btn">
   <vicon-stub color="primary" class="ml-n1 mr-1">
     M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z
   </vicon-stub>

--- a/packages/vue-dot/src/elements/BackBtn/tests/__snapshots__/BackBtn.spec.ts.snap
+++ b/packages/vue-dot/src/elements/BackBtn/tests/__snapshots__/BackBtn.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BackBtn renders correctly 1`] = `
-<vbtn-stub color="primary" tag="button" activeclass="" text="true" type="button" class="vd-back-btn px-0 pr-1">
-  <vicon-stub color="primary" class="mr-1">
+<vbtn-stub color="primary" elevation="0" tag="button" activeclass="" text="true" type="button" class="vd-back-btn px-4">
+  <vicon-stub color="primary" class="ml-n1 mr-1">
     M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z
   </vicon-stub>
   Retour


### PR DESCRIPTION
## Description

Ajouter la prop dark au composant BackBtn#2775](https://github.com/assurance-maladie-digital/design-system/issues/2775)
Improve display

## Playground

<details>

```vue
<template>
	<PageContainer>
		<VSheet
			color="primary"
			class="pa-4"
		>
			<BackBtn
				dark
			/>
		</VSheet>
		<VSheet class="pa-4">
			<BackBtn />
		</VSheet>
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
