### PR TITLE
vue-dot: CopyBtn - add promise function and change tests

### DIFF
--- a/packages/vue-dot/src/functions/copyToClipboard/index.ts
+++ b/packages/vue-dot/src/functions/copyToClipboard/index.ts
@@ -20,7 +20,21 @@ export function copyToClipboard(textToCopy: string): void {
 	}
 
 	el.select();
-	document.execCommand('copy'); // TODO: Use Clipboard API when supported
+
+	const navigatorClipboard = new Promise<void>((resolve, reject) => {
+		if (navigator.clipboard) {
+			navigator.clipboard.writeText(textToCopy)
+				.then(resolve)
+				.catch(reject);
+		} else {
+			if (document.execCommand('copy')) {
+				resolve();
+			} else {
+				reject(new Error('La copie dans le presse-papier a échoué.'));
+			}
+		}
+	});
+
 	document.body.removeChild(el);
 
 	// If a selection existed before copying


### PR DESCRIPTION
## Description

Dans la fonction copyToClipboard, on utilise la méthode document.execCommand('copy'); qui est dépréciée. Il faut utiliser l'API Clipboard lorsqu'elle est disponible et utiliser la méthode actuelle comme fallback et supprimer le // TODO: Use Clipboard API when supported.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<CopyBtn
			label="Copier le numéro de dossier"
			text-to-copy="1456570791"
		/>
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>i
```

</details>

## Type de changement

- Refactoring

## Checklist

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Mon code suit le style de code du projet
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
