### PR TITLE
♻️ vue-dot: Deprecate html util function

### DIFF
--- a/packages/docs/src/content/composants-techniques/tests-unitaires/create-router.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/create-router.md
@@ -45,7 +45,7 @@ describe('Component', () => {
 			router
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/create-router.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/create-router.md
@@ -14,7 +14,6 @@ import Component from '../';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createRouter,

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/create-store.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/create-store.md
@@ -57,7 +57,7 @@ describe('Component', () => {
 			store
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/create-store.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/create-store.md
@@ -18,7 +18,6 @@ import Component from '../';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createStore,

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/create-vuetify-instance.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/create-vuetify-instance.md
@@ -40,7 +40,7 @@ describe('Component', () => {
 			vuetify
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/create-vuetify-instance.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/create-vuetify-instance.md
@@ -15,7 +15,6 @@ import Component from '../';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/install-global-plugins.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/install-global-plugins.md
@@ -14,7 +14,6 @@ import Component from '../';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	installGlobalPlugins

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/install-global-plugins.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/install-global-plugins.md
@@ -32,7 +32,7 @@ describe('Component', () => {
 			localVue
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/install-router.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/install-router.md
@@ -14,7 +14,6 @@ import Component from '../';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	installRouter,

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/install-router.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/install-router.md
@@ -34,7 +34,7 @@ describe('Component', () => {
 			localVue
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/mock-translations.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/mock-translations.md
@@ -44,7 +44,7 @@ describe('Component', () => {
 			mocks
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/mock-translations.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/mock-translations.md
@@ -12,7 +12,6 @@ import Vue from 'vue';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	installGlobalPlugins,

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/mock-v-form-ref.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/mock-v-form-ref.md
@@ -38,7 +38,7 @@ describe('Component', () => {
 			mocks
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/docs/src/content/composants-techniques/tests-unitaires/mock-v-form-ref.md
+++ b/packages/docs/src/content/composants-techniques/tests-unitaires/mock-v-form-ref.md
@@ -12,7 +12,6 @@ import Vue from 'vue';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	installGlobalPlugins,

--- a/packages/docs/src/content/guides/tests-unitaires.md
+++ b/packages/docs/src/content/guides/tests-unitaires.md
@@ -42,7 +42,6 @@ import Vuetify from 'vuetify';
 // Import des différentes fonctions utilitaires de Vue Dot
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,
@@ -82,7 +81,7 @@ describe('AppFooter', () => {
 
 <doc-alert type="warning">
 
-La function `html()` qui permet de ne pas inclure le code source des fonctions dans les snapshots est une fonction dépréciée. Elle sera supprimée dans la prochaine version majeure de Vue Dot.
+La function `html()`, qui permettait de contourner un bug et de ne pas inclure le code source des fonctions dans les snapshots, est dépréciée car le bug a été corrigé. Elle sera supprimée dans la prochaine version majeure.
 
 </doc-alert>
 
@@ -103,7 +102,6 @@ import VueRouter from 'vue-router';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createRouter
@@ -163,7 +161,6 @@ import { MutationTree, Store } from 'vuex';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createStore,

--- a/packages/docs/src/content/guides/tests-unitaires.md
+++ b/packages/docs/src/content/guides/tests-unitaires.md
@@ -75,10 +75,16 @@ describe('AppFooter', () => {
 
 		// On vérifie que le composant n'a pas changé soudainement
 		// Voir https://jestjs.io/fr/docs/snapshot-testing
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```
+
+<doc-alert type="warning">
+
+La function `html()` qui permet de ne pas inclure le code source des fonctions dans les snapshots est une fonction dépréciée. Elle sera supprimée dans la prochaine version majeure de Vue Dot.
+
+</doc-alert>
 
 <doc-alert type="info">
 
@@ -141,7 +147,7 @@ describe('Home', () => {
 			router // Utilisation du routeur
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```
@@ -207,7 +213,7 @@ describe('Home', () => {
 			mocks
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 		// Vérification du bon appel de la mutation
 		expect(mutations.updateUserInformation).toHaveBeenCalled();
 	});
@@ -250,7 +256,7 @@ describe('AppForm', () => {
 			mocks
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```
@@ -296,7 +302,7 @@ describe('Home', () => {
 			mocks
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });
 ```

--- a/packages/form-builder/src/components/FormBuilder/tests/FormBuilder.spec.ts
+++ b/packages/form-builder/src/components/FormBuilder/tests/FormBuilder.spec.ts
@@ -18,6 +18,6 @@ describe('FormBuilder', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/form-builder/src/components/FormBuilder/tests/FormBuilder.spec.ts
+++ b/packages/form-builder/src/components/FormBuilder/tests/FormBuilder.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@cnamts/vue-dot/tests';
-import { html } from '@cnamts/vue-dot/tests/utils/html';
 
 import FormBuilder from '../';
 

--- a/packages/form-builder/src/components/FormField/fields/tests/ChoiceField.spec.ts
+++ b/packages/form-builder/src/components/FormField/fields/tests/ChoiceField.spec.ts
@@ -45,7 +45,7 @@ describe('ChoiceField', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders the other field', () => {
@@ -67,7 +67,7 @@ describe('ChoiceField', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders the other field when the corresponding choice is selected', () => {
@@ -90,7 +90,7 @@ describe('ChoiceField', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders with single error message', () => {
@@ -110,7 +110,7 @@ describe('ChoiceField', () => {
 			true
 		);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders with multiple error messages', () => {
@@ -133,6 +133,6 @@ describe('ChoiceField', () => {
 			true
 		);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/form-builder/src/components/FormField/fields/tests/ChoiceField.spec.ts
+++ b/packages/form-builder/src/components/FormField/fields/tests/ChoiceField.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@cnamts/vue-dot/tests';
-import { html } from '@cnamts/vue-dot/tests/utils/html';
 import { Field } from './../../types';
 
 import ChoiceField from '../ChoiceField.vue';

--- a/packages/form-builder/src/components/FormField/tests/FormField.spec.ts
+++ b/packages/form-builder/src/components/FormField/tests/FormField.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@cnamts/vue-dot/tests';
-import { html } from '@cnamts/vue-dot/tests/utils/html';
 
 import FormField from '../FormField.vue';
 

--- a/packages/form-builder/src/components/FormField/tests/FormField.spec.ts
+++ b/packages/form-builder/src/components/FormField/tests/FormField.spec.ts
@@ -25,6 +25,6 @@ describe('FormField', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/form-builder/src/components/FormFieldList/tests/FormFieldList.spec.ts
+++ b/packages/form-builder/src/components/FormFieldList/tests/FormFieldList.spec.ts
@@ -18,6 +18,6 @@ describe('FormFieldList', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/form-builder/src/components/FormFieldList/tests/FormFieldList.spec.ts
+++ b/packages/form-builder/src/components/FormFieldList/tests/FormFieldList.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@cnamts/vue-dot/tests';
-import { html } from '@cnamts/vue-dot/tests/utils/html';
 
 import FormFieldList from '../';
 

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/LinksList/tests/LinksList.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/LinksList/tests/LinksList.spec.ts
@@ -43,6 +43,6 @@ describe('LinksList', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/LinksList/tests/LinksList.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/LinksList/tests/LinksList.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppFooter/tests/AppFooter.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppFooter/tests/AppFooter.spec.ts
@@ -30,6 +30,6 @@ describe('AppFooter', () => {
 			vuetify
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppFooter/tests/AppFooter.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppFooter/tests/AppFooter.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppHeader/tests/AppHeader.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppHeader/tests/AppHeader.spec.ts
@@ -37,7 +37,7 @@ describe('AppHeader', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly when maintenance is enabled', () => {
@@ -49,6 +49,6 @@ describe('AppHeader', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppHeader/tests/AppHeader.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/components/layout/AppHeader/tests/AppHeader.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/About.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/About.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/About.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/About.spec.ts
@@ -49,6 +49,6 @@ describe('About', () => {
 			})<% } %>
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Home.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Home.spec.ts
@@ -32,6 +32,6 @@ describe('Home', () => {
 			vuetify
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Home.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Home.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Maintenance.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Maintenance.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Maintenance.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/Maintenance.spec.ts
@@ -30,6 +30,6 @@ describe('Maintenance', () => {
 			vuetify
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/NotFound.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/NotFound.spec.ts
@@ -30,6 +30,6 @@ describe('NotFound', () => {
 			vuetify
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/NotFound.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/src/views/tests/NotFound.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/App.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/App.spec.ts
@@ -35,7 +35,7 @@ describe('App', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly when maintenance is enabled', () => {
@@ -47,6 +47,6 @@ describe('App', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/App.spec.ts
+++ b/packages/vue-cli-plugin-vue-dash/generator/template/tests/unit/App.spec.ts
@@ -3,7 +3,6 @@ import Vuetify from 'vuetify';
 
 import {
 	Wrapper,
-	html,
 	shallowMount,
 	createLocalVue,
 	createVuetifyInstance,

--- a/packages/vue-dot/src/elements/BackBtn/tests/BackBtn.spec.ts
+++ b/packages/vue-dot/src/elements/BackBtn/tests/BackBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import BackBtn from '../';
 

--- a/packages/vue-dot/src/elements/BackBtn/tests/BackBtn.spec.ts
+++ b/packages/vue-dot/src/elements/BackBtn/tests/BackBtn.spec.ts
@@ -12,6 +12,6 @@ describe('BackBtn', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(BackBtn);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/BackToTopBtn/tests/BackToTopBtn.spec.ts
+++ b/packages/vue-dot/src/elements/BackToTopBtn/tests/BackToTopBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import BackToTopBtn from '../';
 

--- a/packages/vue-dot/src/elements/BackToTopBtn/tests/BackToTopBtn.spec.ts
+++ b/packages/vue-dot/src/elements/BackToTopBtn/tests/BackToTopBtn.spec.ts
@@ -12,6 +12,6 @@ describe('BackToTopBtn', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(BackToTopBtn);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/CopyBtn/tests/CopyBtn.spec.ts
+++ b/packages/vue-dot/src/elements/CopyBtn/tests/CopyBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import CopyBtn from '../';
 

--- a/packages/vue-dot/src/elements/CopyBtn/tests/CopyBtn.spec.ts
+++ b/packages/vue-dot/src/elements/CopyBtn/tests/CopyBtn.spec.ts
@@ -17,6 +17,6 @@ describe('CopyBtn', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/CustomIcon/tests/CustomIcon.spec.ts
+++ b/packages/vue-dot/src/elements/CustomIcon/tests/CustomIcon.spec.ts
@@ -29,7 +29,7 @@ describe('CustomIcon', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a custom size', () => {
@@ -41,6 +41,6 @@ describe('CustomIcon', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/CustomIcon/tests/CustomIcon.spec.ts
+++ b/packages/vue-dot/src/elements/CustomIcon/tests/CustomIcon.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import CustomIcon from '../';
 

--- a/packages/vue-dot/src/elements/DataList/DataListItem/tests/DataListItem.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/tests/DataListItem.spec.ts
@@ -16,7 +16,7 @@ describe('DataListItem', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a value', () => {
@@ -27,7 +27,7 @@ describe('DataListItem', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly a value with HTML as text', () => {
@@ -64,7 +64,7 @@ describe('DataListItem', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with an action', () => {
@@ -75,7 +75,7 @@ describe('DataListItem', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('emits click:action event when the action button is pressed', async() => {
@@ -110,6 +110,6 @@ describe('DataListItem', () => {
 		const elExists = wrapper.find('.vd-row').exists();
 		expect(elExists).toBe(true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/DataList/DataListItem/tests/DataListItem.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/DataListItem/tests/DataListItem.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DataListItem from '../';
 

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/tests/DataListLoading.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/tests/DataListLoading.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DataListLoading from '../';
 import HeaderLoading from '../../../HeaderLoading';

--- a/packages/vue-dot/src/elements/DataList/DataListLoading/tests/DataListLoading.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/DataListLoading/tests/DataListLoading.spec.ts
@@ -19,7 +19,7 @@ describe('DataListLoading', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a header', () => {
@@ -29,7 +29,7 @@ describe('DataListLoading', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with more items', () => {
@@ -39,7 +39,7 @@ describe('DataListLoading', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly in row mode', () => {
@@ -50,6 +50,6 @@ describe('DataListLoading', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
@@ -27,7 +27,7 @@ describe('DataList', () => {
 		const titleExists = wrapper.find('h4').exists();
 		expect(titleExists).toBe(false);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a title', () => {
@@ -41,7 +41,7 @@ describe('DataList', () => {
 		const elExists = wrapper.find('h4').exists();
 		expect(elExists).toBe(true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with an empty list', () => {
@@ -55,7 +55,7 @@ describe('DataList', () => {
 		const itemsExists = wrapper.find('.vd-data-list-item').exists();
 		expect(itemsExists).toBe(false);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with an icon', () => {
@@ -77,7 +77,7 @@ describe('DataList', () => {
 		const itemsExists = wrapper.find('.vd-data-list-item .v-icon').exists();
 		expect(itemsExists).toBe(true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a class', async() => {
@@ -96,7 +96,7 @@ describe('DataList', () => {
 		const itemsExists = wrapper.find('.vd-data-list-item.custom-class').exists();
 		expect(itemsExists).toBe(true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders loading state correctly', async() => {
@@ -113,7 +113,7 @@ describe('DataList', () => {
 		let itemsExists = wrapper.find('.vd-data-list-item').exists();
 		expect(itemsExists).toBe(false);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 
 		wrapper.setProps({ loading: false });
 
@@ -123,7 +123,7 @@ describe('DataList', () => {
 		itemsExists = wrapper.find('.vd-data-list-item').exists();
 		expect(itemsExists).toBe(true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with an action', async() => {
@@ -139,7 +139,7 @@ describe('DataList', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('emits action event', async() => {

--- a/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
+++ b/packages/vue-dot/src/elements/DataList/tests/DataList.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DataList from '../';
 import { getDataList } from './data/dataList';

--- a/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
+++ b/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
@@ -12,6 +12,6 @@ describe('DialogBox', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(DialogBox);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
+++ b/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DialogBox from '../DialogBox.vue';
 

--- a/packages/vue-dot/src/elements/DownloadBtn/tests/DownloadBtn.spec.ts
+++ b/packages/vue-dot/src/elements/DownloadBtn/tests/DownloadBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DownloadBtn from '../DownloadBtn.vue';
 

--- a/packages/vue-dot/src/elements/DownloadBtn/tests/DownloadBtn.spec.ts
+++ b/packages/vue-dot/src/elements/DownloadBtn/tests/DownloadBtn.spec.ts
@@ -25,7 +25,7 @@ describe('DownloadBtn', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('calls download function when pressed', async() => {

--- a/packages/vue-dot/src/elements/ExternalLinks/tests/ExternalLinks.spec.ts
+++ b/packages/vue-dot/src/elements/ExternalLinks/tests/ExternalLinks.spec.ts
@@ -16,6 +16,6 @@ describe('ExternalLinks', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/ExternalLinks/tests/ExternalLinks.spec.ts
+++ b/packages/vue-dot/src/elements/ExternalLinks/tests/ExternalLinks.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import ExternalLinks from '../ExternalLinks.vue';
 

--- a/packages/vue-dot/src/elements/FilePreview/tests/FilePreview.spec.ts
+++ b/packages/vue-dot/src/elements/FilePreview/tests/FilePreview.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FilePreview from '../';
 

--- a/packages/vue-dot/src/elements/FilePreview/tests/FilePreview.spec.ts
+++ b/packages/vue-dot/src/elements/FilePreview/tests/FilePreview.spec.ts
@@ -24,6 +24,6 @@ describe('FilePreview', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/FranceConnectBtn/tests/FranceConnectBtn.spec.ts
+++ b/packages/vue-dot/src/elements/FranceConnectBtn/tests/FranceConnectBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FranceConnectBtn from '../FranceConnectBtn.vue';
 

--- a/packages/vue-dot/src/elements/FranceConnectBtn/tests/FranceConnectBtn.spec.ts
+++ b/packages/vue-dot/src/elements/FranceConnectBtn/tests/FranceConnectBtn.spec.ts
@@ -16,6 +16,6 @@ describe('FranceConnectBtn', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/HeaderLoading/tests/HeaderLoading.spec.ts
+++ b/packages/vue-dot/src/elements/HeaderLoading/tests/HeaderLoading.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import HeaderLoading from '../';
 

--- a/packages/vue-dot/src/elements/HeaderLoading/tests/HeaderLoading.spec.ts
+++ b/packages/vue-dot/src/elements/HeaderLoading/tests/HeaderLoading.spec.ts
@@ -12,6 +12,6 @@ describe('HeaderLoading', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(HeaderLoading);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/Logo/tests/Logo.spec.ts
+++ b/packages/vue-dot/src/elements/Logo/tests/Logo.spec.ts
@@ -12,6 +12,6 @@ describe('Logo', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(Logo);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/Logo/tests/Logo.spec.ts
+++ b/packages/vue-dot/src/elements/Logo/tests/Logo.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import Logo from '../';
 

--- a/packages/vue-dot/src/elements/LogoBrandSection/tests/LogoBrandSection.spec.ts
+++ b/packages/vue-dot/src/elements/LogoBrandSection/tests/LogoBrandSection.spec.ts
@@ -22,6 +22,6 @@ describe('LogoBrandSection', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/LogoBrandSection/tests/LogoBrandSection.spec.ts
+++ b/packages/vue-dot/src/elements/LogoBrandSection/tests/LogoBrandSection.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import LogoBrandSection from '../';
 import { ThemeEnum } from '../../../constants/enums/ThemeEnum';

--- a/packages/vue-dot/src/elements/PageContainer/tests/PageContainer.spec.ts
+++ b/packages/vue-dot/src/elements/PageContainer/tests/PageContainer.spec.ts
@@ -12,6 +12,6 @@ describe('PageContainer', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(PageContainer);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/PageContainer/tests/PageContainer.spec.ts
+++ b/packages/vue-dot/src/elements/PageContainer/tests/PageContainer.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import PageContainer from '../';
 

--- a/packages/vue-dot/src/elements/SkipLink/tests/SkipLink.spec.ts
+++ b/packages/vue-dot/src/elements/SkipLink/tests/SkipLink.spec.ts
@@ -12,6 +12,6 @@ describe('SkipLink', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(SkipLink);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/elements/SkipLink/tests/SkipLink.spec.ts
+++ b/packages/vue-dot/src/elements/SkipLink/tests/SkipLink.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import SkipLink from '../';
 

--- a/packages/vue-dot/src/elements/UserMenuBtn/tests/UserMenuBtn.spec.ts
+++ b/packages/vue-dot/src/elements/UserMenuBtn/tests/UserMenuBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import UserMenuBtn from '../';
 

--- a/packages/vue-dot/src/elements/UserMenuBtn/tests/UserMenuBtn.spec.ts
+++ b/packages/vue-dot/src/elements/UserMenuBtn/tests/UserMenuBtn.spec.ts
@@ -16,6 +16,6 @@ describe('UserMenuBtn', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/ContextualMenu/tests/ContextualMenu.spec.ts
+++ b/packages/vue-dot/src/patterns/ContextualMenu/tests/ContextualMenu.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import ContextualMenu from '../';
 

--- a/packages/vue-dot/src/patterns/ContextualMenu/tests/ContextualMenu.spec.ts
+++ b/packages/vue-dot/src/patterns/ContextualMenu/tests/ContextualMenu.spec.ts
@@ -30,6 +30,6 @@ describe('ContextualMenu', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/CookieBanner/tests/CookieBanner.spec.ts
+++ b/packages/vue-dot/src/patterns/CookieBanner/tests/CookieBanner.spec.ts
@@ -13,6 +13,6 @@ describe('CookieBanner', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(CookieBanner);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/CookieBanner/tests/CookieBanner.spec.ts
+++ b/packages/vue-dot/src/patterns/CookieBanner/tests/CookieBanner.spec.ts
@@ -3,7 +3,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import CookieBanner from '../';
 

--- a/packages/vue-dot/src/patterns/DataListGroup/tests/DataListGroup.spec.ts
+++ b/packages/vue-dot/src/patterns/DataListGroup/tests/DataListGroup.spec.ts
@@ -21,7 +21,7 @@ describe('DataListGroup', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders loading state correctly', async() => {
@@ -32,6 +32,6 @@ describe('DataListGroup', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/DataListGroup/tests/DataListGroup.spec.ts
+++ b/packages/vue-dot/src/patterns/DataListGroup/tests/DataListGroup.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DataListGroup from '../';
 import HeaderLoading from '../../../elements/HeaderLoading';

--- a/packages/vue-dot/src/patterns/DatePicker/tests/DatePicker.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/DatePicker.spec.ts
@@ -34,6 +34,6 @@ describe('DatePicker', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/DatePicker/tests/DatePicker.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/DatePicker.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DatePicker from '../';
 

--- a/packages/vue-dot/src/patterns/FileUpload/tests/FileUpload.spec.ts
+++ b/packages/vue-dot/src/patterns/FileUpload/tests/FileUpload.spec.ts
@@ -12,7 +12,7 @@ describe('FileUpload', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(FileUpload);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with only one extension allowed', () => {
@@ -22,6 +22,6 @@ describe('FileUpload', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/FileUpload/tests/FileUpload.spec.ts
+++ b/packages/vue-dot/src/patterns/FileUpload/tests/FileUpload.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FileUpload from '../';
 

--- a/packages/vue-dot/src/patterns/FilterModule/FilterManager/tests/FilterManager.spec.ts
+++ b/packages/vue-dot/src/patterns/FilterModule/FilterManager/tests/FilterManager.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FilterManager from '../';
 

--- a/packages/vue-dot/src/patterns/FilterModule/FilterManager/tests/FilterManager.spec.ts
+++ b/packages/vue-dot/src/patterns/FilterModule/FilterManager/tests/FilterManager.spec.ts
@@ -40,7 +40,7 @@ describe('FilterManager', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a single filter', () => {
@@ -50,6 +50,6 @@ describe('FilterManager', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/FilterModule/FilterSelector/tests/FilterSelector.spec.ts
+++ b/packages/vue-dot/src/patterns/FilterModule/FilterSelector/tests/FilterSelector.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FilterSelector from '../';
 

--- a/packages/vue-dot/src/patterns/FilterModule/FilterSelector/tests/FilterSelector.spec.ts
+++ b/packages/vue-dot/src/patterns/FilterModule/FilterSelector/tests/FilterSelector.spec.ts
@@ -16,6 +16,6 @@ describe('FilterSelector', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/FilterModule/tests/FilterModule.spec.ts
+++ b/packages/vue-dot/src/patterns/FilterModule/tests/FilterModule.spec.ts
@@ -21,6 +21,6 @@ describe('FilterModule', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/FilterModule/tests/FilterModule.spec.ts
+++ b/packages/vue-dot/src/patterns/FilterModule/tests/FilterModule.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import DialogBox from '../../../elements/DialogBox';
 

--- a/packages/vue-dot/src/patterns/FooterBar/CollapsibleList/tests/CollapsibleList.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/CollapsibleList/tests/CollapsibleList.spec.ts
@@ -3,7 +3,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import CollapsibleList from '../';
 

--- a/packages/vue-dot/src/patterns/FooterBar/CollapsibleList/tests/CollapsibleList.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/CollapsibleList/tests/CollapsibleList.spec.ts
@@ -27,6 +27,6 @@ describe('CollapsibleList', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/FooterBar/SocialMediaLinks/tests/SocialMediaLinks.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/SocialMediaLinks/tests/SocialMediaLinks.spec.ts
@@ -3,7 +3,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import SocialMediaLinks from '../';
 

--- a/packages/vue-dot/src/patterns/FooterBar/SocialMediaLinks/tests/SocialMediaLinks.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/SocialMediaLinks/tests/SocialMediaLinks.spec.ts
@@ -13,6 +13,6 @@ describe('SocialMediaLinks', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(SocialMediaLinks);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
@@ -15,6 +15,6 @@ describe('FooterBar', () => {
 			stubs: ['RouterLink']
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterBar/tests/FooterBar.spec.ts
@@ -3,7 +3,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FooterBar from '../';
 

--- a/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/tests/FooterBtn.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/tests/FooterBtn.spec.ts
@@ -4,7 +4,6 @@ import { Wrapper } from '@vue/test-utils';
 import consola from 'consola';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FooterBtn from '../';
 

--- a/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/tests/FooterBtn.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterWrapper/FooterBtn/tests/FooterBtn.spec.ts
@@ -20,7 +20,7 @@ describe('FooterBtn', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(FooterBtn);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 		expect(spy).toHaveBeenCalledWith('FooterBtn is deprecated since v2.2.0, use FooterBar instead.');
 	});
 });

--- a/packages/vue-dot/src/patterns/FooterWrapper/tests/FooterWrapper.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterWrapper/tests/FooterWrapper.spec.ts
@@ -20,7 +20,7 @@ describe('FooterWrapper', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(FooterWrapper);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 		expect(spy).toHaveBeenCalledWith('FooterWrapper is deprecated since v2.2.0, use FooterBar instead.');
 	});
 });

--- a/packages/vue-dot/src/patterns/FooterWrapper/tests/FooterWrapper.spec.ts
+++ b/packages/vue-dot/src/patterns/FooterWrapper/tests/FooterWrapper.spec.ts
@@ -4,7 +4,6 @@ import { Wrapper } from '@vue/test-utils';
 import consola from 'consola';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FooterWrapper from '../';
 

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderMenuBtn/tests/HeaderMenuBtn.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderMenuBtn/tests/HeaderMenuBtn.spec.ts
@@ -12,6 +12,6 @@ describe('HeaderMenuBtn', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(HeaderMenuBtn);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderMenuBtn/tests/HeaderMenuBtn.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderMenuBtn/tests/HeaderMenuBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import HeaderMenuBtn from '../';
 

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/HeaderNavigationBar.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/HeaderNavigationBar.spec.ts
@@ -17,6 +17,6 @@ describe('HeaderNavigationBar', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/HeaderNavigationBar.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/HeaderNavigationBar.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import HeaderNavigationBar from '../';
 import { ThemeEnum } from '../../ThemeEnum';

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
@@ -18,6 +18,6 @@ describe('HeaderNavigationDrawer', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/HeaderNavigationDrawer.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import HeaderNavigationDrawer from '../';
 import { ThemeEnum } from '../../ThemeEnum';

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationDrawer/tests/__snapshots__/HeaderNavigationDrawer.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderNavigationDrawer renders correctly 1`] = `""`;
+exports[`HeaderNavigationDrawer renders correctly 1`] = ``;

--- a/packages/vue-dot/src/patterns/HeaderBar/tests/HeaderBar.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/tests/HeaderBar.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import HeaderBar from '../';
 

--- a/packages/vue-dot/src/patterns/HeaderBar/tests/HeaderBar.spec.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/tests/HeaderBar.spec.ts
@@ -12,6 +12,6 @@ describe('HeaderBar', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(HeaderBar);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/LangBtn/tests/LangBtn.spec.ts
+++ b/packages/vue-dot/src/patterns/LangBtn/tests/LangBtn.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import LangBtn from '../';
 

--- a/packages/vue-dot/src/patterns/LangBtn/tests/LangBtn.spec.ts
+++ b/packages/vue-dot/src/patterns/LangBtn/tests/LangBtn.spec.ts
@@ -16,6 +16,6 @@ describe('LangBtn', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/NirField/tests/NirField.spec.ts
+++ b/packages/vue-dot/src/patterns/NirField/tests/NirField.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import NirField from '../';
 

--- a/packages/vue-dot/src/patterns/NirField/tests/NirField.spec.ts
+++ b/packages/vue-dot/src/patterns/NirField/tests/NirField.spec.ts
@@ -12,7 +12,7 @@ describe('NirField', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(NirField, undefined, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with 13 characters', () => {
@@ -22,7 +22,7 @@ describe('NirField', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a tooltip', () => {
@@ -32,6 +32,6 @@ describe('NirField', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/NotificationBar/tests/NotificationBar.spec.ts
+++ b/packages/vue-dot/src/patterns/NotificationBar/tests/NotificationBar.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { localVue, mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import Vuex from 'vuex';
 localVue.use(Vuex);

--- a/packages/vue-dot/src/patterns/NotificationBar/tests/NotificationBar.spec.ts
+++ b/packages/vue-dot/src/patterns/NotificationBar/tests/NotificationBar.spec.ts
@@ -47,7 +47,7 @@ describe('NotificationBar', () => {
 			store
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a custom icon', () => {
@@ -61,6 +61,6 @@ describe('NotificationBar', () => {
 			store
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/PaginatedTable/tests/PaginatedTable.spec.ts
+++ b/packages/vue-dot/src/patterns/PaginatedTable/tests/PaginatedTable.spec.ts
@@ -17,6 +17,6 @@ describe('PaginatedTable', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/PaginatedTable/tests/PaginatedTable.spec.ts
+++ b/packages/vue-dot/src/patterns/PaginatedTable/tests/PaginatedTable.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import PaginatedTable from '../';
 

--- a/packages/vue-dot/src/patterns/PhoneField/tests/PhoneField.spec.ts
+++ b/packages/vue-dot/src/patterns/PhoneField/tests/PhoneField.spec.ts
@@ -12,6 +12,6 @@ describe('PhoneField', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(PhoneField, undefined, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/PhoneField/tests/PhoneField.spec.ts
+++ b/packages/vue-dot/src/patterns/PhoneField/tests/PhoneField.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import PhoneField from '../';
 

--- a/packages/vue-dot/src/patterns/RatingPicker/EmotionPicker/tests/EmotionPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/EmotionPicker/tests/EmotionPicker.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import EmotionPicker from '../';
 

--- a/packages/vue-dot/src/patterns/RatingPicker/EmotionPicker/tests/EmotionPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/EmotionPicker/tests/EmotionPicker.spec.ts
@@ -21,6 +21,6 @@ describe('EmotionPicker', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/RatingPicker/NumberPicker/tests/NumberPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/NumberPicker/tests/NumberPicker.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import NumberPicker from '../';
 

--- a/packages/vue-dot/src/patterns/RatingPicker/NumberPicker/tests/NumberPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/NumberPicker/tests/NumberPicker.spec.ts
@@ -16,6 +16,6 @@ describe('NumberPicker', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/RatingPicker/StarsPicker/tests/StarsPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/StarsPicker/tests/StarsPicker.spec.ts
@@ -16,6 +16,6 @@ describe('StarsPicker', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/RatingPicker/StarsPicker/tests/StarsPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/StarsPicker/tests/StarsPicker.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import StarsPicker from '../';
 

--- a/packages/vue-dot/src/patterns/RatingPicker/tests/RatingPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/tests/RatingPicker.spec.ts
@@ -26,7 +26,7 @@ describe('RatingPicker', () => {
 	it('renders correctly', () => {
 		wrapper = createTestComponent();
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('sets readonly internal value on update', () => {

--- a/packages/vue-dot/src/patterns/RatingPicker/tests/RatingPicker.spec.ts
+++ b/packages/vue-dot/src/patterns/RatingPicker/tests/RatingPicker.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import RatingPicker from '../';
 

--- a/packages/vue-dot/src/patterns/SubHeader/tests/SubHeader.spec.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/SubHeader.spec.ts
@@ -21,7 +21,7 @@ describe('SubHeader', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders loading state correctly', async() => {
@@ -33,6 +33,6 @@ describe('SubHeader', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/SubHeader/tests/SubHeader.spec.ts
+++ b/packages/vue-dot/src/patterns/SubHeader/tests/SubHeader.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import SubHeader from '../';
 import HeaderLoading from '../../../elements/HeaderLoading';

--- a/packages/vue-dot/src/patterns/TableToolbar/tests/TableToolbar.spec.ts
+++ b/packages/vue-dot/src/patterns/TableToolbar/tests/TableToolbar.spec.ts
@@ -18,7 +18,7 @@ describe('TableToolbar', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly when loading', () => {
@@ -30,7 +30,7 @@ describe('TableToolbar', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with content slot', () => {
@@ -44,7 +44,7 @@ describe('TableToolbar', () => {
 			}
 		}, true);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with no items', () => {
@@ -55,6 +55,6 @@ describe('TableToolbar', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/TableToolbar/tests/TableToolbar.spec.ts
+++ b/packages/vue-dot/src/patterns/TableToolbar/tests/TableToolbar.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import TableToolbar from '../';
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/FileList/tests/FileList.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/FileList/tests/FileList.spec.ts
@@ -22,6 +22,6 @@ describe('FileList', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/UploadWorkflow/FileList/tests/FileList.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/FileList/tests/FileList.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FileList from '../';
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
@@ -34,7 +34,7 @@ describe('UploadWorkflow', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('renders correctly with a single file', () => {
@@ -48,6 +48,6 @@ describe('UploadWorkflow', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/tests/UploadWorkflow.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import FileUpload from '../../FileUpload';
 import DialogBox from '../../../elements/DialogBox';

--- a/packages/vue-dot/src/templates/CookiesPage/CookiesInformation/tests/CookiesInformation.spec.ts
+++ b/packages/vue-dot/src/templates/CookiesPage/CookiesInformation/tests/CookiesInformation.spec.ts
@@ -20,6 +20,6 @@ describe('CookiesInformation', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/templates/CookiesPage/CookiesInformation/tests/CookiesInformation.spec.ts
+++ b/packages/vue-dot/src/templates/CookiesPage/CookiesInformation/tests/CookiesInformation.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import CookiesInformation from '../';
 

--- a/packages/vue-dot/src/templates/CookiesPage/CookiesTable/tests/CookiesTable.spec.ts
+++ b/packages/vue-dot/src/templates/CookiesPage/CookiesTable/tests/CookiesTable.spec.ts
@@ -18,6 +18,6 @@ describe('CookiesTable', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/templates/CookiesPage/CookiesTable/tests/CookiesTable.spec.ts
+++ b/packages/vue-dot/src/templates/CookiesPage/CookiesTable/tests/CookiesTable.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import CookiesTable from '../';
 

--- a/packages/vue-dot/src/templates/CookiesPage/tests/CookiesPage.spec.ts
+++ b/packages/vue-dot/src/templates/CookiesPage/tests/CookiesPage.spec.ts
@@ -21,6 +21,6 @@ describe('CookiesPage', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/templates/CookiesPage/tests/CookiesPage.spec.ts
+++ b/packages/vue-dot/src/templates/CookiesPage/tests/CookiesPage.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import CookiesPage from '../';
 import PageContainer from '../../../elements/PageContainer';

--- a/packages/vue-dot/src/templates/CookiesPage/tests/__snapshots__/CookiesPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/CookiesPage/tests/__snapshots__/CookiesPage.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`CookiesPage renders correctly 1`] = `
         </vbtn-stub>
       </div>
       <cookiesinformation-stub type="essentials" tableitems="[object Object],[object Object]" class="mb-6"></cookiesinformation-stub>
-      <cookiesinformation-stub type="{[Function]}" tableitems="[object Object],[object Object]" class="mb-6"></cookiesinformation-stub>
+      <cookiesinformation-stub type="functional" tableitems="[object Object],[object Object]" class="mb-6"></cookiesinformation-stub>
       <cookiesinformation-stub type="analytics" tableitems="[object Object],[object Object]" class="mb-6"></cookiesinformation-stub>
       <div class="d-flex mt-16">
         <vspacer-stub tag="div"></vspacer-stub>

--- a/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import ErrorPage from '../';
 import PageContainer from '../../../elements/PageContainer';

--- a/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/ErrorPage.spec.ts
@@ -20,6 +20,6 @@ describe('ErrorPage', () => {
 			}
 		});
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/templates/MaintenancePage/tests/MaintenancePage.spec.ts
+++ b/packages/vue-dot/src/templates/MaintenancePage/tests/MaintenancePage.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import MaintenancePage from '../';
 import PageContainer from '../../../elements/PageContainer';

--- a/packages/vue-dot/src/templates/MaintenancePage/tests/MaintenancePage.spec.ts
+++ b/packages/vue-dot/src/templates/MaintenancePage/tests/MaintenancePage.spec.ts
@@ -15,6 +15,6 @@ describe('MaintenancePage', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(MaintenancePage);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/src/templates/NotFoundPage/tests/NotFoundPage.spec.ts
+++ b/packages/vue-dot/src/templates/NotFoundPage/tests/NotFoundPage.spec.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import { Wrapper } from '@vue/test-utils';
 
 import { mountComponent } from '@/tests';
-import { html } from '@/tests/utils/html';
 
 import NotFoundPage from '../';
 import PageContainer from '../../../elements/PageContainer';

--- a/packages/vue-dot/src/templates/NotFoundPage/tests/NotFoundPage.spec.ts
+++ b/packages/vue-dot/src/templates/NotFoundPage/tests/NotFoundPage.spec.ts
@@ -15,6 +15,6 @@ describe('NotFoundPage', () => {
 	it('renders correctly', () => {
 		wrapper = mountComponent(NotFoundPage);
 
-		expect(html(wrapper)).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/packages/vue-dot/tests/utils/html.ts
+++ b/packages/vue-dot/tests/utils/html.ts
@@ -18,7 +18,7 @@ interface HTMLFnOpts {
  *
  * `functionRemplacement` is used to ensure a deterministic snapshot
  * (workaround of https://github.com/vuejs/vue-test-utils/issues/975)
- * TODO: check if still required
+ * @deprecated Bug fixed, not useful anymore
  */
 export function html(wrapper: Wrapper<Vue>, options?: HTMLFnOpts): string {
 	const opts = {


### PR DESCRIPTION
## Description

delete deprecated html() function in tests [#2772](https://github.com/assurance-maladie-digital/design-system/issues/2772)

## Type de changement

- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
