### PR TITLE
vue-dot: notification position

### DIFF
--- a/packages/docs/src/data/examples/notification-bar/options.vue
+++ b/packages/docs/src/data/examples/notification-bar/options.vue
@@ -29,7 +29,8 @@
 	export default class NotificationBarOptions extends Vue {
 		vuetifyOptions = {
 			snackBar: {
-				rounded: 'pill'
+				rounded: 'pill',
+				top: true
 			},
 			icon: {
 				class: 'mr-3'

--- a/packages/vue-dot/src/patterns/NotificationBar/config.ts
+++ b/packages/vue-dot/src/patterns/NotificationBar/config.ts
@@ -1,7 +1,6 @@
 export const config = {
 	snackBar: {
-		timeout: -1,
-		top: true
+		timeout: -1
 	},
 	icon: {
 		class: 'mr-2'

--- a/packages/vue-dot/src/patterns/NotificationBar/tests/__snapshots__/NotificationBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/NotificationBar/tests/__snapshots__/NotificationBar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotificationBar renders correctly 1`] = `
-<vsnackbar-stub tag="div" value="true" top="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status" class="vd-notification-bar grey-darken-80--text">
+<vsnackbar-stub tag="div" value="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status" class="vd-notification-bar grey-darken-80--text">
   <div class="d-flex align-center">
     <vicon-stub color="grey-darken-80" class="vd-notification-icon mr-2">
       M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z
@@ -13,7 +13,7 @@ exports[`NotificationBar renders correctly 1`] = `
 `;
 
 exports[`NotificationBar renders correctly with a custom icon 1`] = `
-<vsnackbar-stub tag="div" value="true" top="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status" class="vd-notification-bar grey-darken-80--text">
+<vsnackbar-stub tag="div" value="true" contentclass="" timeout="-1" transition="v-snack-transition" role="status" class="vd-notification-bar grey-darken-80--text">
   <div class="d-flex align-center">
     <vicon-stub color="grey-darken-80" class="vd-notification-icon mr-2">
       test-icon


### PR DESCRIPTION
## Description

Définition de la position bottom par défaut des notifications (mobile first) 

## Playground

<details>

```vue
<template>
	<div>
		<NotificationBar
			v-show="showNotificationBar"
			close-btn-text="Masquer"
			:vuetify-options="vuetifyOptions"
		/>

		<VBtn
			color="primary"
			@click="notifyUser"
		>
			Envoyer une notification
		</VBtn>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { mapActions, mapState } from 'vuex';

	const EXAMPLE_REF = 'label-example';

	@Component({
		computed: mapState('notification', ['notification']),
		methods: mapActions('notification', ['addNotification'])
	})
	export default class NotificationBarLabel extends Vue {
		vuetifyOptions = {
			snackBar: {
				rounded: 'pill',
				top: true
			},
			icon: {
				class: 'mr-3'
			},
			btn: {
				rounded: true
			}
		};
		get showNotificationBar(): boolean {
			return this.notification?.ref === EXAMPLE_REF;
		}
		notifyUser(): void {
			this.addNotification({
				ref: EXAMPLE_REF,
				type: 'info',
				message: 'Exemple de notification.'
			});
		}
	}
	</script>
```

</details>

## Type de changement

- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
