### PR TITLE
🐛 vue-dot: Fix item overflow in ContextualMenu

### DIFF
--- a/packages/vue-dot/src/patterns/ContextualMenu/ContextualMenu.vue
+++ b/packages/vue-dot/src/patterns/ContextualMenu/ContextualMenu.vue
@@ -15,7 +15,7 @@
 					'ps-12': level === 5,
 					'ps-14': level === 6
 				}"
-				class="d-flex align-center text-decoration-none text-body-1 pl-4"
+				class="d-flex align-center text-decoration-none text-body-1 px-4 py-2"
 				@click.prevent.stop="setHash(hash)"
 				v-text="text"
 			/>
@@ -84,7 +84,6 @@
 	}
 
 	a {
-		height: 40px;
 		position: relative;
 		transition: none;
 

--- a/packages/vue-dot/src/patterns/ContextualMenu/tests/__snapshots__/ContextualMenu.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/ContextualMenu/tests/__snapshots__/ContextualMenu.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextualMenu renders correctly 1`] = `
 <ul class="vd-contextual-menu">
-  <li><a href="#example-1" class="d-flex align-center text-decoration-none text-body-1 pl-4 text--secondary">Titre 1</a></li>
-  <li><a href="#example-2" class="d-flex align-center text-decoration-none text-body-1 pl-4 text--secondary">Titre 2</a></li>
+  <li><a href="#example-1" class="d-flex align-center text-decoration-none text-body-1 px-4 py-2 text--secondary">Titre 1</a></li>
+  <li><a href="#example-2" class="d-flex align-center text-decoration-none text-body-1 px-4 py-2 text--secondary">Titre 2</a></li>
 </ul>
 `;


### PR DESCRIPTION
## Description

Le composant ContextualMenu ne gère pas les longs titres

## Playground

<details>

```vue
<template>
	<VSheet
		width="400"
		elevation="1"
		class="ma-4 py-4"
		rounded
	>
		<ContextualMenu
			v-model="current"
			:items="items"
		/>
		<br />
		<ContextualMenu
			v-model="current"
			:items="items2"
		/>
	</VSheet>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { MenuItem } from '@cnamts/vue-dot/src/patterns/ContextualMenu/types';

	@Component
	export default class ContextualMenuUsage extends Vue {
		current: string | null = null;

		items: MenuItem[] = [
			{
				text: 'Lorem ipsum dolor.',
				hash: '#doc-example-1'
			},
			{
				text: 'Lorem ipsum dolor.',
				hash: '#doc-example-2'
			},
			{
				text: 'Lorem ipsum dolor.',
				hash: '#doc-example-3'
			}
		];

		items2: MenuItem[] = [
			{
				text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.',
				hash: '#doc2-example-1'
			},
			{
				text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.',
				hash: '#doc2-example-2'
			},
			{
				text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.',
				hash: '#doc2-example-3'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
