### PR TITLE
♻️ vue-dot: Use v-html for title in FormField

### DIFF
--- a/packages/form-builder/src/components/FormField/FormField.vue
+++ b/packages/form-builder/src/components/FormField/FormField.vue
@@ -5,7 +5,9 @@
 			class="text-body-1"
 			:class="{ 'mb-2': !field.tooltip }"
 		>
-			<span>{{ field.title }}</span>
+			<span
+				v-html="field.title"
+			/>
 
 			<VTooltip
 				v-if="field.tooltip"

--- a/packages/form-builder/src/components/FormField/FormField.vue
+++ b/packages/form-builder/src/components/FormField/FormField.vue
@@ -5,9 +5,7 @@
 			class="text-body-1"
 			:class="{ 'mb-2': !field.tooltip }"
 		>
-			<span
-				v-html="field.title"
-			/>
+			<span v-html="field.title" />
 
 			<VTooltip
 				v-if="field.tooltip"


### PR DESCRIPTION
## Description

Je dois mettre en place un traitement pour gérer les sauts de ligne lors de l'affichage des données dans les questionnaire.
Je suggère de traiter le texte du titre comme du html.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
// Copiez-collez le contenu de votre Playground.vue entier ici
<span
	v-html="field.title"
/>
```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
