### PR TITLE
🐛 vue-dot Fix secondary content display in RatingPicker

### DIFF
--- a/packages/vue-dot/src/patterns/RatingPicker/RatingPicker.vue
+++ b/packages/vue-dot/src/patterns/RatingPicker/RatingPicker.vue
@@ -114,6 +114,10 @@
 			return undefined;
 		}
 
+		get hasAnswered(): boolean {
+			return this.value !== -1;
+		}
+
 		showAdditionalContent(value: number): void {
 			const starsUnsatisfied = this.type === RatingEnum.STARS && value <= 3;
 			const numberUnsatisfied = this.type === RatingEnum.NUMBER && value <= 7;


### PR DESCRIPTION
## Description

Il manquait la variable `hasAnswered` pour afficher le contenu secondaire.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
