### PR TITLE
Vue-dot : MaintenancePage / NotFound Page improve

### DIFF
--- a/packages/docs/src/data/examples/maintenance-page/usage.vue
+++ b/packages/docs/src/data/examples/maintenance-page/usage.vue
@@ -41,6 +41,20 @@
 
 		:deep(.v-card) {
 			padding: 24px !important;
+			margin: 0 !important;
+			box-shadow: none !important;
+			@media (min-width: 600px) {
+				.col-sm-6 {
+					flex: 0 0 100%;
+					max-width: 100%;
+				}
+				.order-sm-first {
+					order: 1 !important;
+				}
+				.text-sm-left {
+					text-align: center !important;
+				}
+			}
 		}
 	}
 </style>

--- a/packages/docs/src/data/examples/not-found-page/usage.vue
+++ b/packages/docs/src/data/examples/not-found-page/usage.vue
@@ -45,6 +45,20 @@
 
 		:deep(.v-card) {
 			padding: 24px !important;
+			margin: 0 !important;
+			box-shadow: none !important;
+			@media (min-width: 600px) {
+				.col-sm-6 {
+					flex: 0 0 100%;
+					max-width: 100%;
+				}
+				.order-sm-first {
+					order: 1 !important;
+				}
+				.text-sm-left {
+					text-align: center !important;
+				}
+			}
 		}
 	}
 </style>

--- a/packages/vue-dot/src/elements/PageContainer/PageContainer.vue
+++ b/packages/vue-dot/src/elements/PageContainer/PageContainer.vue
@@ -59,7 +59,7 @@
 
 			const spacing = spacingMapping[this.$vuetify.breakpoint.name];
 
-			return `py-10 ${spacing}`;
+			return `py-sm-10 ${spacing}`;
 		}
 
 		get containerSize(): number {

--- a/packages/vue-dot/src/elements/PageContainer/tests/__snapshots__/PageContainer.spec.ts.snap
+++ b/packages/vue-dot/src/elements/PageContainer/tests/__snapshots__/PageContainer.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PageContainer renders correctly 1`] = `
-<div class="vd-page-container d-flex justify-center py-10 px-8">
+<div class="vd-page-container d-flex justify-center py-sm-10 px-8">
   <vsheet-stub color="transparent" width="1440" tag="div"></vsheet-stub>
 </div>
 `;

--- a/packages/vue-dot/src/templates/MaintenancePage/MaintenancePage.vue
+++ b/packages/vue-dot/src/templates/MaintenancePage/MaintenancePage.vue
@@ -27,10 +27,11 @@
 					class="d-flex align-center justify-center"
 				>
 					<slot name="illustration">
-						<img
+						<VImg
 							:src="require('../../assets/images/maintenance.svg')"
-							alt=""
-						>
+							:alt="locales.pageTitle"
+							max-width="70%"
+						/>
 					</slot>
 				</VCol>
 			</VRow>

--- a/packages/vue-dot/src/templates/MaintenancePage/MaintenancePage.vue
+++ b/packages/vue-dot/src/templates/MaintenancePage/MaintenancePage.vue
@@ -1,6 +1,6 @@
 <template>
 	<PageContainer size="m">
-		<VCard class="pa-6 pa-sm-16">
+		<VCard class="pa-6">
 			<VRow class="mx-0">
 				<VCol
 					cols="12"

--- a/packages/vue-dot/src/templates/MaintenancePage/MaintenancePage.vue
+++ b/packages/vue-dot/src/templates/MaintenancePage/MaintenancePage.vue
@@ -1,6 +1,9 @@
 <template>
 	<PageContainer size="m">
-		<VCard class="pa-6">
+		<VCard
+			:elevation="isMobileVersion ? 0 : 2"
+			class="pa-6 pa-sm-16"
+		>
 			<VRow class="mx-0">
 				<VCol
 					cols="12"
@@ -57,5 +60,11 @@
 	const MixinsDeclaration = mixins(Props);
 
 	@Component
-	export default class MaintenancePage extends MixinsDeclaration {}
+	export default class MaintenancePage extends MixinsDeclaration {
+		locales = locales;
+
+		get isMobileVersion(): boolean {
+			return this.$vuetify.breakpoint.smAndDown;
+		}
+	}
 </script>

--- a/packages/vue-dot/src/templates/MaintenancePage/tests/__snapshots__/MaintenancePage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/MaintenancePage/tests/__snapshots__/MaintenancePage.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MaintenancePage renders correctly 1`] = `
 <pagecontainer-stub size="m" color="transparent">
-  <vcard-stub loaderheight="4" tag="div" class="pa-6 pa-sm-16">
+  <vcard-stub loaderheight="4" tag="div" elevation="2" class="pa-6 pa-sm-16">
     <vrow-stub tag="div" class="mx-0">
       <vcol-stub cols="12" sm="6" tag="div" class="order-last order-sm-first text-center text-sm-left">
         <h2 class="mb-2 font-weight-bold text-h5 mb-4">

--- a/packages/vue-dot/src/templates/MaintenancePage/tests/__snapshots__/MaintenancePage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/MaintenancePage/tests/__snapshots__/MaintenancePage.spec.ts.snap
@@ -12,7 +12,9 @@ exports[`MaintenancePage renders correctly 1`] = `
           L’application n’est pas disponible pour le moment, veuillez nous excuser pour la gêne occasionnée.
         </p>
       </vcol-stub>
-      <vcol-stub cols="12" sm="6" tag="div" class="d-flex align-center justify-center"><img src="" alt=""></vcol-stub>
+      <vcol-stub cols="12" sm="6" tag="div" class="d-flex align-center justify-center">
+        <vimg-stub maxwidth="70%" alt="Maintenance en cours" options="[object Object]" position="center center" src="" transition="fade-transition"></vimg-stub>
+      </vcol-stub>
     </vrow-stub>
   </vcard-stub>
 </pagecontainer-stub>

--- a/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
+++ b/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
@@ -1,6 +1,9 @@
 <template>
 	<PageContainer size="m">
-		<VCard class="pa-6 pa-sm-16">
+		<VCard
+			class="pa-6"
+			elevation="2"
+		>
 			<VRow class="mx-0">
 				<VCol
 					cols="12"

--- a/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
+++ b/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
@@ -7,8 +7,8 @@
 			<VRow class="mx-0">
 				<VCol
 					cols="12"
-					md="6"
-					class="order-last order-md-first text-center text-md-left"
+					sm="6"
+					class="order-last order-sm-first text-center text-sm-left"
 				>
 					<div
 						aria-hidden="true"
@@ -42,14 +42,15 @@
 
 				<VCol
 					cols="12"
-					md="6"
+					sm="6"
 					class="d-flex align-center justify-center"
 				>
 					<slot name="illustration">
-						<img
+						<VImg
 							:src="require('../../assets/images/not-found.svg')"
-							alt=""
-						>
+							:alt="locales.pageTitle"
+							max-width="70%"
+						/>
 					</slot>
 				</VCol>
 			</VRow>

--- a/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
+++ b/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
@@ -1,8 +1,8 @@
 <template>
 	<PageContainer size="m">
 		<VCard
-			class="pa-6"
-			elevation="2"
+			:elevation="isMobileVersion ? 0 : 2"
+			class="pa-6 pa-sm-16"
 		>
 			<VRow class="mx-0">
 				<VCol
@@ -96,6 +96,10 @@
 	@Component
 	export default class NotFoundPage extends MixinsDeclaration {
 		locales = locales;
+
+		get isMobileVersion(): boolean {
+			return this.$vuetify.breakpoint.smAndDown;
+		}
 
 		/**
 		 * Support ID is a number added by our firewall if a rule is violated

--- a/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`NotFoundPage renders correctly 1`] = `
 <pagecontainer-stub size="m" color="transparent">
   <vcard-stub loaderheight="4" tag="div" elevation="2" class="pa-6 pa-sm-16">
     <vrow-stub tag="div" class="mx-0">
-      <vcol-stub cols="12" md="6" tag="div" class="order-last order-md-first text-center text-md-left">
+      <vcol-stub cols="12" sm="6" tag="div" class="order-last order-sm-first text-center text-sm-left">
         <div aria-hidden="true" class="vd-code font-weight-thin primary--text mb-4">
           404
         </div>
@@ -19,7 +19,9 @@ exports[`NotFoundPage renders correctly 1`] = `
           Retour à l’accueil
         </vbtn-stub>
       </vcol-stub>
-      <vcol-stub cols="12" md="6" tag="div" class="d-flex align-center justify-center"><img src="" alt=""></vcol-stub>
+      <vcol-stub cols="12" sm="6" tag="div" class="d-flex align-center justify-center">
+        <vimg-stub maxwidth="70%" alt="Page non trouvée" options="[object Object]" position="center center" src="" transition="fade-transition"></vimg-stub>
+      </vcol-stub>
     </vrow-stub>
   </vcard-stub>
 </pagecontainer-stub>

--- a/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`NotFoundPage renders correctly 1`] = `
 <pagecontainer-stub size="m" color="transparent">
-  <vcard-stub loaderheight="4" tag="div" class="pa-6 pa-sm-16">
+  <vcard-stub loaderheight="4" tag="div" elevation="2" class="pa-6 pa-sm-16">
     <vrow-stub tag="div" class="mx-0">
       <vcol-stub cols="12" md="6" tag="div" class="order-last order-md-first text-center text-md-left">
         <div aria-hidden="true" class="vd-code font-weight-thin primary--text mb-4">


### PR DESCRIPTION
## Description

Amélioration de l'affichage des templates MaintenancePage et NotFoundPage en mobile.
[#2866](https://github.com/assurance-maladie-digital/design-system/issues/2866)

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<MaintenancePage />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class MaintenancePage extends Vue {}
</script>
```

</details>

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
