### PR TITLE
🐛 vue-dot: Fix VOverlay color when not active

### DIFF
--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -101,7 +101,7 @@
 	}
 
 	// Fix overlay color
-	.v-overlay {
+	.v-overlay.v-overlay--active {
 		background-color: rgba(33, 33, 33, .48);
 	}
 }


### PR DESCRIPTION
## Description

Update : la regression vient de l'utilisation de v-overlay au sein d'un composant plus précisément. On affiche un overlay blanc au chargement. Sinon, il se basait sur le fait que cela soit transparent par défaut. Or, le changement de valeur par défaut, fait que l'overlay s'affiche même si le composant n'est pas affiché

## Playground

<details>

```vue
<template>
	<PageContainer>
		<VBtn
			color="error"
			@click="overlay = !overlay"
		>
			Show Overlay
		</VBtn>
		<VOverlay :value="overlay" />
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		overlay = false;
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
