### PR TITLE
🐛 docs: Fix layout shift when search is opened

### DIFF
--- a/packages/docs/src/components/DocSearch.vue
+++ b/packages/docs/src/components/DocSearch.vue
@@ -125,8 +125,4 @@
 	.DocSearch-Help a {
 		display: inline-block;
 	}
-
-	html:has(> .DocSearch--active) {
-		overflow: hidden;
-	}
 </style>


### PR DESCRIPTION
## Description

La scrollbar disparaît lorsque la recherche est ouverte ce qui crée un layout shift.

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] ~~J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne~~
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
