### PR TITLE
DialogBox : Problème vocalisation modal avec titre

### DIFF
--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -5,15 +5,16 @@
 		:width="width"
 		:persistent="persistent"
 		aria-modal="true"
-		:aria-labelledby="title ? title : 'dialog-title'"
-		role="dialog"
 		class="vd-dialog-box"
 	>
 		<VCard
 			v-bind="options.card"
 			ref="dialogContent"
 		>
-			<VCardTitle v-bind="options.cardTitle">
+			<VCardTitle
+				v-bind="options.cardTitle"
+				:aria-labelledby="title ? title : 'dialog-title'"
+			>
 				<slot name="title">
 					<h2
 						v-if="title"
@@ -126,6 +127,7 @@
 			}
 		}
 	})
+
 	export default class DialogBox extends MixinsDeclaration {
 		$refs!: Refs<{
 			dialogContent: Vue;

--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -5,6 +5,8 @@
 		:width="width"
 		:persistent="persistent"
 		aria-modal="true"
+		:aria-labelledby="title ? title : 'dialog-title'"
+		role="dialog"
 		class="vd-dialog-box"
 	>
 		<VCard
@@ -15,6 +17,7 @@
 				<slot name="title">
 					<h2
 						v-if="title"
+						:id="title ? title : 'dialog-title'"
 						class="text-h6 font-weight-bold"
 					>
 						{{ title }}

--- a/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
+++ b/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
@@ -8,14 +8,19 @@ import DialogBox from '../DialogBox.vue';
 let wrapper: Wrapper<Vue>;
 
 describe('DialogBox', () => {
-	it('renders correctly', async() => {
+	it('renders correctly', () => {
+		wrapper = mountComponent(DialogBox);
+
+		expect(wrapper).toMatchSnapshot();
+	});
+
+	it('renders correctly title content', () => {
 		wrapper = mountComponent(DialogBox, {
 			propsData: {
 				title: 'Test Dialog'
 			}
 		});
 
-		// test the title
 		expect(wrapper.find('h2').text()).toBe('Test Dialog');
 	});
 });

--- a/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
+++ b/packages/vue-dot/src/elements/DialogBox/tests/DialogBox.spec.ts
@@ -8,9 +8,14 @@ import DialogBox from '../DialogBox.vue';
 let wrapper: Wrapper<Vue>;
 
 describe('DialogBox', () => {
-	it('renders correctly', () => {
-		wrapper = mountComponent(DialogBox);
+	it('renders correctly', async() => {
+		wrapper = mountComponent(DialogBox, {
+			propsData: {
+				title: 'Test Dialog'
+			}
+		});
 
-		expect(wrapper).toMatchSnapshot();
+		// test the title
+		expect(wrapper.find('h2').text()).toBe('Test Dialog');
 	});
 });

--- a/packages/vue-dot/src/elements/DialogBox/tests/__snapshots__/DialogBox.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DialogBox/tests/__snapshots__/DialogBox.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`DialogBox renders correctly 1`] = `
 <vdialog-stub contentclass="" opendelay="0" closedelay="0" openonclick="true" origin="center center" retainfocus="true" transition="dialog-transition" width="800px" aria-modal="true" class="vd-dialog-box">
   <vcard-stub loaderheight="4" tag="div" class="pa-6">
-    <vcardtitle-stub tag="div" class="d-flex align-start flex-nowrap pa-0 mb-6">
+    <vcardtitle-stub tag="div" aria-labelledby="dialog-title" class="d-flex align-start flex-nowrap pa-0 mb-6">
       <!---->
       <vspacer-stub tag="div"></vspacer-stub>
       <vbtn-stub height="32px" width="32px" tag="button" activeclass="" icon="true" type="button" aria-label="Fermer la boîte de dialogue" class="mt-n2 mr-n2 ml-4">


### PR DESCRIPTION
## Description

Les composants DialogBox ne respectent pas la notice AcceDeWeb https://www.accede-web.com/notices/interface-riche/fenetres-modales/. Lorsqu'une modal a un titre, il faut utiliser aria-labelledby comme décrit dans la notice.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<div>
		<VBtn
			color="primary"
			@click="dialog = true"
		>
			Afficher le composant
		</VBtn>

		<DialogBox
			v-model="dialog"
			title="Enregistrement"
			cancel-btn-text="Retour"
			confirm-btn-text="Enregistrer"
			@cancel="dialog = false"
			@confirm="dialog = false"
		>
			<p>Souhaitez-vous procéder à l’enregistrement ?</p>
		</DialogBox>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class DialogBoxBtnText extends Vue {
		dialog = false;
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
