### PR TITLE
🐛 vue-dot: Fix divider display in LogoBrandSection

### DIFF
--- a/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
+++ b/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
@@ -241,7 +241,7 @@
 		}
 
 		get showBrandContent(): boolean {
-			return Boolean(this.service.title || this.service.subTitle || this.$slots['brand-content']);
+			return Boolean(this.service.title || this.service.subTitle || this.$slots['brand-content'] || this.hasSecondaryLogo);
 		}
 
 		get showDivider(): boolean {


### PR DESCRIPTION
## Description

Show divider when secondaryLogo on LogoBrandSection.

## Playground

<details>

```vue
<template>
	<PageContainer>
		<HeaderBar theme="compte-ameli" />
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
