### PR TITLE
vue-dot: fix v-alert size in rating picker

### DIFF
--- a/packages/vue-dot/src/patterns/RatingPicker/RatingPicker.vue
+++ b/packages/vue-dot/src/patterns/RatingPicker/RatingPicker.vue
@@ -139,3 +139,11 @@
 		}
 	}
 </script>
+
+<style lang="scss" scoped>
+:deep(.v-alert__wrapper > .v-icon) {
+	width: auto !important;
+	height: auto !important;
+	background: none !important;
+}
+</style>


### PR DESCRIPTION
## Description

Le v-alert du rating picker est trop gros.

Avant :
![Capture d’écran 2023-06-21 à 12 30 11](https://github.com/assurance-maladie-digital/design-system/assets/1822420/2cf9c3e2-d25d-43b3-8841-fdcffc744a67)

Après :
![Capture d’écran 2023-06-21 à 12 29 32](https://github.com/assurance-maladie-digital/design-system/assets/1822420/7f8cb3cd-61df-4db6-b3e8-71fc9248232a)

## Type de changement

- Maintenance

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
