### PR TITLE
vue-dot / doc : set outlined icons to VAlert

### DIFF
--- a/packages/docs/src/components/global/DocAlert.vue
+++ b/packages/docs/src/components/global/DocAlert.vue
@@ -2,6 +2,7 @@
 	<VAlert
 		v-bind="$attrs"
 		v-on="$listeners"
+		:icon="icon"
 		class="doc-alert w-100"
 	>
 		<slot />
@@ -12,10 +13,30 @@
 	import Vue from 'vue';
 	import Component from "vue-class-component";
 
+	import { IndexedObject } from '@cnamts/vue-dot/src/types';
+
+	import {
+		mdiCheckCircleOutline,
+		mdiAlertCircleOutline,
+		mdiInformationOutline,
+		mdiAlertOutline
+	} from '@mdi/js';
+
 	@Component({
 		inheritAttrs: false
 	})
-	export default class DocAlert extends Vue {}
+	export default class DocAlert extends Vue {
+		iconMapping: IndexedObject = {
+			success: mdiCheckCircleOutline,
+			error: mdiAlertCircleOutline,
+			info: mdiInformationOutline,
+			warning: mdiAlertOutline
+		};
+
+		get icon(): string | null {
+			return this.iconMapping[this.$attrs.type];
+		}
+	}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/vue-dot/src/patterns/RatingPicker/RatingPicker.vue
+++ b/packages/vue-dot/src/patterns/RatingPicker/RatingPicker.vue
@@ -15,6 +15,7 @@
 				:class="{ 'mb-0': !displayAdditionalContent }"
 				outlined
 				type="success"
+				:icon="checkIcon"
 				class="mt-4"
 			>
 				{{ locales.thanks }}
@@ -32,6 +33,8 @@
 	import EmotionPicker from './EmotionPicker';
 	import NumberPicker from './NumberPicker';
 	import StarsPicker from './StarsPicker';
+
+	import { mdiCheckCircleOutline } from '@mdi/js';
 
 	import { RATING_ENUM_VALUES, RatingEnum } from './RatingMixin';
 
@@ -92,6 +95,8 @@
 	})
 	export default class RatingPicker extends MixinsDeclaration {
 		locales = locales;
+
+		checkIcon = mdiCheckCircleOutline;
 
 		internalValue = -1;
 		displayAdditionalContent = false;


### PR DESCRIPTION
## Description

set outlined icons to VAlert like on the Figma 
https://www.figma.com/file/gKaLp1f8pMdaf1jcu2mX5R/DS-CNAM---WIP-Composants?type=design&node-id=308-8&mode=design&t=942naYx9BJgyNaHq-0

## Type de changement

- Correction de bug
- Documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
