### PR TITLE
vue-dot: fix notfound page on ipad

### DIFF
--- a/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
+++ b/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
@@ -4,8 +4,8 @@
 			<VRow class="mx-0">
 				<VCol
 					cols="12"
-					md="6"
-					class="order-last order-md-first text-center text-md-left"
+					sm="6"
+					class="order-last order-sm-first text-center text-sm-left"
 				>
 					<div
 						aria-hidden="true"
@@ -39,7 +39,7 @@
 
 				<VCol
 					cols="12"
-					md="6"
+					sm="6"
 					class="d-flex align-center justify-center"
 				>
 					<slot name="illustration">

--- a/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`NotFoundPage renders correctly 1`] = `
 <pagecontainer-stub size="m" color="transparent">
   <vcard-stub loaderheight="4" tag="div" class="pa-6 pa-sm-16">
     <vrow-stub tag="div" class="mx-0">
-      <vcol-stub cols="12" md="6" tag="div" class="order-last order-md-first text-center text-md-left">
+      <vcol-stub cols="12" sm="6" tag="div" class="order-last order-sm-first text-center text-sm-left">
         <div aria-hidden="true" class="vd-code font-weight-thin primary--text mb-4">
           404
         </div>
@@ -19,7 +19,7 @@ exports[`NotFoundPage renders correctly 1`] = `
           Retour à l’accueil
         </vbtn-stub>
       </vcol-stub>
-      <vcol-stub cols="12" md="6" tag="div" class="d-flex align-center justify-center"><img src="" alt=""></vcol-stub>
+      <vcol-stub cols="12" sm="6" tag="div" class="d-flex align-center justify-center"><img src="" alt=""></vcol-stub>
     </vrow-stub>
   </vcard-stub>
 </pagecontainer-stub>


### PR DESCRIPTION
## Description

Corriger l'affiche du composant NotFoundPage en mode tablette.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<div>
		<NotFoundPage />
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
