### PR TITLE
vue-dot: add external link option on NotFoundPage

### DIFF
--- a/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
+++ b/packages/vue-dot/src/templates/NotFoundPage/NotFoundPage.vue
@@ -29,7 +29,8 @@
 					</p>
 
 					<VBtn
-						:to="btnRoute"
+						:to="btnUrl ? null : btnRoute"
+						:href="btnUrl ? btnUrl : null"
 						color="primary"
 						exact
 					>
@@ -84,6 +85,10 @@
 			btnRoute: {
 				type: [Array, Object, String] as PropType<RawLocation>,
 				default: () => ({ name: 'home' })
+			},
+			btnUrl: {
+				type: String,
+				default: null
 			}
 		}
 	});


### PR DESCRIPTION
## Description

On a le besoin de pouvoir mettre un lien externe sur le bouton de Retour du template NotFoundPage.
En effet, lors de cohabitation du compte legacy/refonte, l'accueil est sur la partie legacy (et non sur la partie vue)

## Playground

<details>

```vue
<template>
	<div>
		<NotFoundPage btn-url="http://www.google.fr" />
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { NavigationItem } from '@cnamts/vue-dot/src/patterns/HeaderBar/types';

	@Component
	export default class Playground extends Vue {
		navigationItems: NavigationItem[] = [
			{
				label: 'Accueil'
			},
			{
				label: 'Mes projets'
			},
			{
				label: 'Mes outils'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Mon code suit le style de code du projet
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
