### PR TITLE
🐛 vue-dot: Fix btn-href prop not working in ErrorPage

### DIFF
--- a/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
+++ b/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
@@ -102,7 +102,6 @@
 		locales = locales;
 		route: RawLocation | undefined = this.btnRoute;
 
-		// If btnHref is set, the props btnRoute is ignored
 		mounted() {
 			if (this.btnHref) {
 				this.route = undefined;

--- a/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
+++ b/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
@@ -29,8 +29,8 @@
 
 					<slot name="action">
 						<VBtn
-							v-if="!noBtn && btnText && btnRoute"
-							:to="btnRoute"
+							v-if="!noBtn && btnText && (route || btnHref)"
+							:to="route"
 							:href="btnHref"
 							color="primary"
 							exact
@@ -100,6 +100,14 @@
 	@Component
 	export default class MaintenancePage extends MixinsDeclaration {
 		locales = locales;
+		route: RawLocation | undefined = this.btnRoute;
+
+		// If btnHref is set, the props btnRoute is ignored
+		mounted() {
+			if (this.btnHref) {
+				this.route = undefined;
+			}
+		}
 
 		get mobileVersion(): boolean {
 			return this.$vuetify.breakpoint.xsOnly;


### PR DESCRIPTION
## Description


La props 'btnHref' est toujours overide par la valeur par défaut de la props 'btnRoute'. Cette PR a pour but de prendre en compte cette props quand elle est renseigné.


## Playground

<details>

```vue
<template>
	<PageContainer>
		<ErrorPage
			page-title="Error page"
			code="418"
			message="Something went wrong"
			btn-text="href link"
			btn-href="http://www.google.com"
		/>
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';
	import ErrorPage from '../src/templates/ErrorPage/index';

	@Component({
		components: {
			ErrorPage
		}
	})
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
