### PR TITLE
🐛 vue-dot: Fix field types in RangeField

### DIFF
--- a/packages/vue-dot/src/patterns/RangeField/RangeField.vue
+++ b/packages/vue-dot/src/patterns/RangeField/RangeField.vue
@@ -9,7 +9,8 @@
 				:value="minValue"
 				:label="locales.minLabel"
 				:outlined="outlined"
-				@input="updateMinValue"
+				type="number"
+				@change="updateMinValue"
 			/>
 
 			<VTextField
@@ -17,7 +18,8 @@
 				:value="maxValue"
 				:label="locales.maxLabel"
 				:outlined="outlined"
-				@input="updateMaxValue"
+				type="number"
+				@change="updateMaxValue"
 			/>
 		</div>
 
@@ -64,7 +66,7 @@
 				default: 0
 			},
 			value: {
-				type: String,
+				type: Array as () => number[] | undefined,
 				default: undefined
 			},
 			outlined: {
@@ -117,12 +119,12 @@
 			return this.$vuetify.breakpoint.xs;
 		}
 
-		updateMinValue(value: number): void {
-			this.updateRange(RangeEnum.MIN, value);
+		updateMinValue(value: string): void {
+			this.updateRange(RangeEnum.MIN, Number(value));
 		}
 
-		updateMaxValue(value: number): void {
-			this.updateRange(RangeEnum.MAX, value);
+		updateMaxValue(value: string): void {
+			this.updateRange(RangeEnum.MAX, Number(value));
 		}
 
 		updateRange(index: RangeEnum, value: number): void {
@@ -149,3 +151,21 @@
 		}
 	}
 </script>
+
+<style scoped>
+	/* Hide the arrows on the fields */
+
+	/* Chrome like browsers */
+	::v-deep .v-text-field input[type=number]::-webkit-outer-spin-button,
+	::v-deep .v-text-field input[type=number]::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+
+	/* Firefox */
+	::v-deep .v-text-field input[type=number] {
+		appearance: textfield;
+		-moz-appearance: textfield;
+	}
+
+</style>

--- a/packages/vue-dot/src/patterns/RangeField/RangeField.vue
+++ b/packages/vue-dot/src/patterns/RangeField/RangeField.vue
@@ -5,20 +5,22 @@
 			class="d-flex flex-wrap max-width-none ma-n3"
 		>
 			<VTextField
+				v-facade="mask"
 				v-bind="options.textField"
 				:value="minValue"
 				:label="locales.minLabel"
 				:outlined="outlined"
-				type="number"
+				inputmode="numeric"
 				@change="updateMinValue"
 			/>
 
 			<VTextField
+				v-facade="mask"
 				v-bind="options.textField"
 				:value="maxValue"
 				:label="locales.maxLabel"
 				:outlined="outlined"
-				type="number"
+				inputmode="numeric"
 				@change="updateMaxValue"
 			/>
 		</div>
@@ -95,6 +97,10 @@
 						return;
 					}
 
+					if (isNaN(value[RangeEnum.MIN]) || isNaN(value[RangeEnum.MAX])) {
+						return;
+					}
+
 					this.rangeValue = value;
 				},
 				immediate: true,
@@ -104,6 +110,8 @@
 	})
 	export default class RangeField extends MixinsDeclaration {
 		locales = locales;
+
+		mask = '-?#*';
 
 		rangeValue: number[] = [];
 
@@ -151,21 +159,3 @@
 		}
 	}
 </script>
-
-<style scoped>
-	/* Hide the arrows on the fields */
-
-	/* Chrome like browsers */
-	::v-deep .v-text-field input[type=number]::-webkit-outer-spin-button,
-	::v-deep .v-text-field input[type=number]::-webkit-inner-spin-button {
-		-webkit-appearance: none;
-		margin: 0;
-	}
-
-	/* Firefox */
-	::v-deep .v-text-field input[type=number] {
-		appearance: textfield;
-		-moz-appearance: textfield;
-	}
-
-</style>

--- a/packages/vue-dot/src/patterns/RangeField/tests/__snapshots__/RangeField.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/RangeField/tests/__snapshots__/RangeField.spec.ts.snap
@@ -6,14 +6,14 @@ exports[`RangeField renders correctly 1`] = `
     <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field ma-3">
       <div class="v-input__control">
         <div class="v-input__slot">
-          <div class="v-text-field__slot"><label for="input-2" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur min</label><input id="input-2" type="text"></div>
+          <div class="v-text-field__slot"><label for="input-2" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur min</label><input id="input-2" type="number"></div>
         </div>
       </div>
     </div>
     <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field ma-3">
       <div class="v-input__control">
         <div class="v-input__slot">
-          <div class="v-text-field__slot"><label for="input-3" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur max</label><input id="input-3" type="text"></div>
+          <div class="v-text-field__slot"><label for="input-3" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur max</label><input id="input-3" type="number"></div>
         </div>
       </div>
     </div>

--- a/packages/vue-dot/src/patterns/RangeField/tests/__snapshots__/RangeField.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/RangeField/tests/__snapshots__/RangeField.spec.ts.snap
@@ -6,14 +6,14 @@ exports[`RangeField renders correctly 1`] = `
     <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field ma-3">
       <div class="v-input__control">
         <div class="v-input__slot">
-          <div class="v-text-field__slot"><label for="input-2" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur min</label><input id="input-2" type="number"></div>
+          <div class="v-text-field__slot"><label for="input-2" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur min</label><input inputmode="numeric" id="input-2" type="text"></div>
         </div>
       </div>
     </div>
     <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field ma-3">
       <div class="v-input__control">
         <div class="v-input__slot">
-          <div class="v-text-field__slot"><label for="input-3" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur max</label><input id="input-3" type="number"></div>
+          <div class="v-text-field__slot"><label for="input-3" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Valeur max</label><input inputmode="numeric" id="input-3" type="text"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fix de l'issue https://github.com/assurance-maladie-digital/design-system/issues/3273

## Description

Fix des problème de typage, du bug en cas d'utilisation de caractère non numérique dans les champs et du problème de modification de champs min quand la valeure minimal est définie sur un chiffre suppérieur à 0.

## Playground


<details>

```vue
<template>
	<PageContainer>
		<RangeField
			v-model="rangeValue"
			:min="20"
			:max="100"
		/>
	</PageContainer>
</template>

<script lang="ts">

	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component({
		watch: {
			rangeValue: {
				handler: 'testUpdate',
				deep: true
			}
		}
	})
	export default class Playground extends Vue {
		rangeValue = [50, 80];

		testUpdate(e: unknown): void {
			console.log(e);
		}
	}
</script>

```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
