### PR TITLE
🐛 vue-dot: Hide upload area when all files uploaded in UploadWorkFlow

### DIFF
--- a/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
@@ -21,6 +21,7 @@
 		/>
 
 		<FileUpload
+			v-if="showFileUpload"
 			ref="fileUpload"
 			v-bind="options.fileUpload"
 			v-model="uploadedFile"
@@ -116,6 +117,10 @@
 
 		get showFileList(): boolean {
 			return this.value.length > 0 || this.fileListItems?.length > 0;
+		}
+
+		get showFileUpload(): boolean {
+			return this.fileListItems?.some((item) => item.state !== 'success');
 		}
 
 		uploadInline(id: string): void {

--- a/packages/vue-dot/src/patterns/UploadWorkflow/tests/__snapshots__/UploadWorkflow.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/tests/__snapshots__/UploadWorkflow.spec.ts.snap
@@ -38,15 +38,8 @@ exports[`UploadWorkflow renders correctly 1`] = `
       </div>
     </div>
     <hr role="separator" aria-orientation="horizontal" class="v-divider v-divider--inset theme--light">
-  </div> <label class="vd-file-upload d-block pa-4 primary--text mt-6" style="width: 100%;"><input type="file" accept=".pdf,.jpg,.jpeg,.png" class="vd-file-upload-input"> <span class="vd-file-upload-placeholder"><span aria-hidden="true" class="v-icon notranslate theme--light primary--text" style="font-size: 40px; height: 40px; width: 40px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg" style="font-size: 40px; height: 40px; width: 40px;"><path d="M11 20H6.5Q4.22 20 2.61 18.43 1 16.85 1 14.58 1 12.63 2.17 11.1 3.35 9.57 5.25 9.15 5.88 6.85 7.75 5.43 9.63 4 12 4 14.93 4 16.96 6.04 19 8.07 19 11 20.73 11.2 21.86 12.5 23 13.78 23 15.5 23 17.38 21.69 18.69 20.38 20 18.5 20H13V12.85L14.6 14.4L16 13L12 9L8 13L9.4 14.4L11 12.85Z"></path></svg></span> <span class="mt-1 font-weight-medium black--text">
-					Placez votre fichier ici
-				</span> <span class="mb-2 grey--text">
-					Ou
-				</span> <span class="vd-file-upload-btn primary white--text text-uppercase py-2 px-4 elevation-2">
-					Choisir un fichier
-				</span> <span class="mt-4 text-body-2 font-weight-regular grey--text">
-					Taille max. : 10 Mo. Formats acceptés : PDF, JPG, JPEG, PNG
-				</span></span></label>
+  </div>
+  <!---->
   <div class="v-dialog__container vd-dialog-box" aria-modal="true">
     <!---->
   </div>
@@ -75,15 +68,8 @@ exports[`UploadWorkflow renders correctly with a single file 1`] = `
       </div>
     </div>
     <hr role="separator" aria-orientation="horizontal" class="v-divider v-divider--inset theme--light">
-  </div> <label class="vd-file-upload d-block pa-4 primary--text mt-6" style="width: 100%;"><input type="file" accept=".pdf,.jpg,.jpeg,.png" class="vd-file-upload-input"> <span class="vd-file-upload-placeholder"><span aria-hidden="true" class="v-icon notranslate theme--light primary--text" style="font-size: 40px; height: 40px; width: 40px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg" style="font-size: 40px; height: 40px; width: 40px;"><path d="M11 20H6.5Q4.22 20 2.61 18.43 1 16.85 1 14.58 1 12.63 2.17 11.1 3.35 9.57 5.25 9.15 5.88 6.85 7.75 5.43 9.63 4 12 4 14.93 4 16.96 6.04 19 8.07 19 11 20.73 11.2 21.86 12.5 23 13.78 23 15.5 23 17.38 21.69 18.69 20.38 20 18.5 20H13V12.85L14.6 14.4L16 13L12 9L8 13L9.4 14.4L11 12.85Z"></path></svg></span> <span class="mt-1 font-weight-medium black--text">
-					Placez votre fichier ici
-				</span> <span class="mb-2 grey--text">
-					Ou
-				</span> <span class="vd-file-upload-btn primary white--text text-uppercase py-2 px-4 elevation-2">
-					Choisir un fichier
-				</span> <span class="mt-4 text-body-2 font-weight-regular grey--text">
-					Taille max. : 10 Mo. Formats acceptés : PDF, JPG, JPEG, PNG
-				</span></span></label>
+  </div>
+  <!---->
   <div class="v-dialog__container vd-dialog-box" aria-modal="true">
     <!---->
   </div>


### PR DESCRIPTION
## Description

https://github.com/assurance-maladie-digital/design-system/issues/3287

## Playground

<details>

```vue
<template>
	<div>
		<UploadWorkflow
			v-model="selectedFiles"
			:file-list-items="fileListItems"
		/>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { FileListItem, SelectedFile } from '@cnamts/vue-dot/src/patterns/UploadWorkflow/types';

	@Component
	export default class UploadWorkflowUsage extends Vue {
		selectedFiles: SelectedFile[] = [];

		fileListItems: FileListItem[] = [
			{
				id: 'rib',
				title: 'RIB'
			},
			{
				id: 'idCard',
				title: 'Carte d’identité recto / verso'
			},
			{
				id: 'passport',
				title: 'Passeport'
			}
		];
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
