### PR TITLE
💄vue-dot: Fix VAlert font size

### DIFF
--- a/packages/vue-dot/dev/App.vue
+++ b/packages/vue-dot/dev/App.vue
@@ -33,7 +33,6 @@
 
 <style lang="scss">
 	@import '@cnamts/design-tokens/dist/tokens';
-	@import '../src/styles/index.scss';
 
 	/* Default, global styles */
 	* {

--- a/packages/vue-dot/src/styles/variables.scss
+++ b/packages/vue-dot/src/styles/variables.scss
@@ -1,4 +1,4 @@
-// @see https://vuetifyjs.com/en/features/sass-variables/
+// @see https://v2.vuetifyjs.com/en/features/sass-variables/
 $body-font-family: 'Source Sans 3', 'Source Sans Pro', sans-serif;
 $heading-font-family: 'Mic 32 New', 'Source Sans 3', 'Source Sans Pro', sans-serif;
 
@@ -82,3 +82,5 @@ $btn-font-sizes: (
 $btn-letter-spacing: 0.005em;
 $btn-font-weight: 600;
 $btn-text-transform: none;
+
+$alert-font-size: map-get( map-get($headings, 'body-1'), 'size');

--- a/packages/vue-dot/src/styles/variables.scss
+++ b/packages/vue-dot/src/styles/variables.scss
@@ -83,4 +83,4 @@ $btn-letter-spacing: 0.005em;
 $btn-font-weight: 600;
 $btn-text-transform: none;
 
-$alert-font-size: map-get( $headings, 'body-1', 'size');
+$alert-font-size: map-get($headings, 'body-1', 'size');

--- a/packages/vue-dot/src/styles/variables.scss
+++ b/packages/vue-dot/src/styles/variables.scss
@@ -83,4 +83,4 @@ $btn-letter-spacing: 0.005em;
 $btn-font-weight: 600;
 $btn-text-transform: none;
 
-$alert-font-size: map-get( map-get($headings, 'body-1'), 'size');
+$alert-font-size: map-get( $headings, 'body-1', 'size');

--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -109,6 +109,10 @@
 	font-size: 1rem !important;
 }
 
+.v-alert {
+	font-size: 1.125rem;
+}
+
 // Fix VDataTable pagination on IE
 // @see https://github.com/vuetifyjs/vuetify/issues/9185
 .v-data-footer__select {

--- a/packages/vue-dot/src/styles/vuetify.scss
+++ b/packages/vue-dot/src/styles/vuetify.scss
@@ -109,10 +109,6 @@
 	font-size: 1rem !important;
 }
 
-.v-alert {
-	font-size: 1.125rem;
-}
-
 // Fix VDataTable pagination on IE
 // @see https://github.com/vuetifyjs/vuetify/issues/9185
 .v-data-footer__select {


### PR DESCRIPTION
## Description

Utilisation de la font en taille 18px '1.125rem' pour les Alertes pour coller avec la charte figma

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<AlertWrapper>
			Lorem ipsum dolor, sit amet consectetur adipisicing elit. Asperiores inventore, reiciendis obcaecati voluptates repellat ut cumque dolor dolore possimus alias mollitia ex iusto sit cupiditate delectus quis ipsum fuga quibusdam?
		</AlertWrapper>
	</PageContainer>
</template>

<script lang="ts">
import { defineComponent } from "vue";

export default defineComponent({
	components: {
	}
});
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Maintenance

## Checklist


- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
