### PR TITLE
🐛 vue-dot: Fix word wrap in DialogBox

### DIFF
--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -205,5 +205,7 @@
 <style lang="scss" scoped>
 	.v-card__title > * {
 		line-height: 1em;
+		word-break: break-word;
+		text-wrap: balance;
 	}
 </style>


### PR DESCRIPTION
## Description

Evite les cassure de mots dans le titre des composant DialogBox

## Playground


<details>

```vue
<template>
	<PageContainer>
		<DialogBox v-model="open"
			title="Lorem ipsum dolor sit, amet consectetur adipisicing elit. Eum sapientegfdsgsdfhgshs quod temporibus aliquam laboriosam.
		">
			Lorem ipsum dolor sit amet, consectetur adipisicing elit.
		</DialogBox>
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component({
		components: {}
	})
	export default class FilePreviewUsage extends Vue {
		log = (e: string): void => {
			console.log(e);
		};

		open = true;
	}
</script>
```

</details>

## Type de changement


- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
