### PR TITLE
Fix a typescript warning in LogoBrandSection

### DIFF
--- a/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
+++ b/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
@@ -70,7 +70,7 @@
 						:class="{ 'vd-compte-entreprise-title': isCompteEntreprise }"
 						class="vd-title text-caption text-md-subtitle-1 font-weight-medium"
 					>
-						<template v-if="isCompteEntreprise">
+						<template v-if="isCompteEntreprise && typeof service.title === 'object'">
 							{{ service.title.text }}
 							<span>{{ service.title.highlight }}</span>
 						</template>

--- a/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
+++ b/packages/vue-dot/src/elements/LogoBrandSection/LogoBrandSection.vue
@@ -70,7 +70,7 @@
 						:class="{ 'vd-compte-entreprise-title': isCompteEntreprise }"
 						class="vd-title text-caption text-md-subtitle-1 font-weight-medium"
 					>
-						<template v-if="isCompteEntreprise && typeof service.title === 'object'">
+						<template v-if="isCompteEntrepriseTitle(service.title)">
 							{{ service.title.text }}
 							<span>{{ service.title.highlight }}</span>
 						</template>
@@ -103,7 +103,7 @@
 	import { ThemeEnum } from '../../constants/enums/ThemeEnum';
 	import { Dimensions, Next } from '../../types';
 
-	import { LogoInfo, Service } from './types';
+	import { HighlightedTitle, LogoInfo, Service } from './types';
 	import { locales } from './locales';
 	import { secondaryLogoMapping } from './secondaryLogoMapping';
 	import { dividerDimensionsMapping } from './dividerDimensionsMapping';
@@ -314,6 +314,10 @@
 			}
 
 			return LogoSizeEnum.NORMAL;
+		}
+
+		isCompteEntrepriseTitle(_title: string | HighlightedTitle): _title is HighlightedTitle {
+			return this.isCompteEntreprise;
 		}
 	}
 </script>


### PR DESCRIPTION
## Description

Permettre a typescript de comprendre que le titre est de type `HighlightedTitle` quand le thème est de type compteEntreprise.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<LogoBrandSection
			theme="compte-entreprise"
		/>
	</PageContainer>
</template>

<script lang="ts">
	import Component from 'vue-class-component';
	import Vue from 'vue';

	@Component
	export default class FilePreviewUsage extends Vue {}
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
