### PR TITLE
🔧 vue-dot: Fix VBtn large font-size

### DIFF
--- a/packages/vue-dot/src/styles/variables.scss
+++ b/packages/vue-dot/src/styles/variables.scss
@@ -75,7 +75,7 @@ $btn-font-sizes: (
 	'x-small': 0.625rem,
 	'small': 0.75rem,
 	'default': 1rem,
-	'large': 0.875rem,
+	'large': 1rem,
 	'x-large': 1.125rem
 );
 


### PR DESCRIPTION
## Description

La taille de la font des bouttons était plus petit que pour les bouttons de tailles medium.
Passage des bouton de taille large à 1rem pour être au même niveau que les bouttons de tailles medium

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue

<template>
	<PageContainer>
		<v-row
			align="center"
			justify="space-around"
		>
			<v-btn
				x-small
			>Extra small button</v-btn>
			<v-btn
				small
			>Small button</v-btn>
			<v-btn
				medium
			>Regular button</v-btn>
			<v-btn
				large
			>Large button</v-btn>
			<v-btn
				x-large
			>X-large button</v-btn>
		</v-row>
	</PageContainer>
</template>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
