### PR TITLE
Fix du mode libre du composant upload Workflow

### DIFF
--- a/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/UploadWorkflow.vue
@@ -108,11 +108,11 @@
 				return this.sectionTitle;
 			}
 
-			if (!this.internalFileListItems.length) {
+			if (this.freeMode) {
 				return locales.importTitle;
 			}
 
-			return locales.title(this.internalFileListItems.length > 1);
+			return locales.title(this.internalFileListItems.length > 1 && !this.freeMode);
 		}
 
 		get showFileList(): boolean {
@@ -120,6 +120,10 @@
 		}
 
 		get showFileUpload(): boolean {
+			if (!this.fileListItems) {
+				return true;
+			}
+
 			return this.fileListItems?.some((item) => item.state !== 'success');
 		}
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
@@ -14,6 +14,7 @@ interface TestComponent extends Vue {
 	updateFileModel<T>(id: string, key: string, value: T): void;
 
 	setFileInList: () => void;
+	setInternalModel: () => void;
 	resetFile: (index: number) => void;
 	dialogConfirm: () => void;
 	uploadedFile: File | null;
@@ -56,7 +57,7 @@ const testFile = {
 } as File;
 
 /** Create the wrapper */
-function createWrapper(fileListItems = fileList, showFilePreview = false) {
+function createWrapper(fileListItems: null | FileListItem[] = fileList , showFilePreview = false) {
 	const component = Vue.component('TestComponent', {
 		mixins: [
 			UploadWorkflowCore
@@ -154,7 +155,8 @@ describe('EventsFileFired', () => {
 	});
 
 	it('deletes an item from the list in unrestricted mode', () => {
-		const wrapper = createWrapper([]) as Wrapper<TestComponent>;
+		const wrapper = createWrapper(null) as Wrapper<TestComponent>;
+
 		wrapper.vm.resetFile(0);
 
 		expect(wrapper.vm.fileList).toEqual([]);
@@ -237,8 +239,7 @@ describe('EventsFileFired', () => {
 	});
 
 	it('skips the dialog and add the file in the list in unrestricted mode', () => {
-		const wrapper = createWrapper([]) as Wrapper<TestComponent>;
-		wrapper.vm.freeMode = true;
+		const wrapper = createWrapper(null) as Wrapper<TestComponent>;
 		wrapper.vm.uploadedFile = testFile;
 		wrapper.vm.fileSelected();
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/tests/uploadWorkflowCore.spec.ts
@@ -20,6 +20,7 @@ interface TestComponent extends Vue {
 	fileList: FileListItem[];
 	error: boolean;
 	dialog: boolean;
+	freeMode: boolean;
 	inlineSelect: boolean;
 	selectedItem: string;
 	internalFileListItems: FileListItem[] | null;
@@ -237,6 +238,7 @@ describe('EventsFileFired', () => {
 
 	it('skips the dialog and add the file in the list in unrestricted mode', () => {
 		const wrapper = createWrapper([]) as Wrapper<TestComponent>;
+		wrapper.vm.freeMode = true;
 		wrapper.vm.uploadedFile = testFile;
 		wrapper.vm.fileSelected();
 

--- a/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/mixins/uploadWorkflowCore.ts
@@ -60,6 +60,9 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 
 	internalFileListItems = [] as FileListItem[];
 
+	// Is there a predefined list of files to upload using fileListItems or value(deprecated)
+	freeMode = false;
+
 	get singleMode(): boolean {
 		return this.internalFileListItems.length === 1;
 	}
@@ -83,6 +86,7 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 		this.internalFileListItems = this.fileListItems ?? this.value;
 
 		if (this.fileListItems === null && !this.value.length) {
+			this.freeMode = true;
 			this.resetInternalModel();
 		}
 
@@ -115,7 +119,7 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 	}
 
 	resetFile(index: number): void {
-		if (!this.internalFileListItems.length) {
+		if (this.freeMode) {
 			this.$delete(this.fileList, index);
 		} else {
 			this.updateFileModel(index, 'state', 'initial');
@@ -172,8 +176,9 @@ export class UploadWorkflowCore extends MixinsDeclaration {
 			return;
 		}
 
-		if (!this.internalFileListItems.length && this.uploadedFile) {
+		if (this.freeMode && this.uploadedFile) {
 			this.fileList.push(this.uploadedFile);
+			this.updateFileModel(this.fileList.length - 1, 'state', 'success');
 			this.emitChangeEvent();
 
 			return;

--- a/packages/vue-dot/src/patterns/UploadWorkflow/tests/__snapshots__/UploadWorkflow.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/UploadWorkflow/tests/__snapshots__/UploadWorkflow.spec.ts.snap
@@ -38,8 +38,15 @@ exports[`UploadWorkflow renders correctly 1`] = `
       </div>
     </div>
     <hr role="separator" aria-orientation="horizontal" class="v-divider v-divider--inset theme--light">
-  </div>
-  <!---->
+  </div> <label class="vd-file-upload d-block pa-4 primary--text mt-6" style="width: 100%;"><input type="file" accept=".pdf,.jpg,.jpeg,.png" class="vd-file-upload-input"> <span class="vd-file-upload-placeholder"><span aria-hidden="true" class="v-icon notranslate theme--light primary--text" style="font-size: 40px; height: 40px; width: 40px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg" style="font-size: 40px; height: 40px; width: 40px;"><path d="M11 20H6.5Q4.22 20 2.61 18.43 1 16.85 1 14.58 1 12.63 2.17 11.1 3.35 9.57 5.25 9.15 5.88 6.85 7.75 5.43 9.63 4 12 4 14.93 4 16.96 6.04 19 8.07 19 11 20.73 11.2 21.86 12.5 23 13.78 23 15.5 23 17.38 21.69 18.69 20.38 20 18.5 20H13V12.85L14.6 14.4L16 13L12 9L8 13L9.4 14.4L11 12.85Z"></path></svg></span> <span class="mt-1 font-weight-medium black--text">
+					Placez votre fichier ici
+				</span> <span class="mb-2 grey--text">
+					Ou
+				</span> <span class="vd-file-upload-btn primary white--text text-uppercase py-2 px-4 elevation-2">
+					Choisir un fichier
+				</span> <span class="mt-4 text-body-2 font-weight-regular grey--text">
+					Taille max. : 10 Mo. Formats acceptés : PDF, JPG, JPEG, PNG
+				</span></span></label>
   <div class="v-dialog__container vd-dialog-box" aria-modal="true">
     <!---->
   </div>
@@ -68,8 +75,15 @@ exports[`UploadWorkflow renders correctly with a single file 1`] = `
       </div>
     </div>
     <hr role="separator" aria-orientation="horizontal" class="v-divider v-divider--inset theme--light">
-  </div>
-  <!---->
+  </div> <label class="vd-file-upload d-block pa-4 primary--text mt-6" style="width: 100%;"><input type="file" accept=".pdf,.jpg,.jpeg,.png" class="vd-file-upload-input"> <span class="vd-file-upload-placeholder"><span aria-hidden="true" class="v-icon notranslate theme--light primary--text" style="font-size: 40px; height: 40px; width: 40px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg" style="font-size: 40px; height: 40px; width: 40px;"><path d="M11 20H6.5Q4.22 20 2.61 18.43 1 16.85 1 14.58 1 12.63 2.17 11.1 3.35 9.57 5.25 9.15 5.88 6.85 7.75 5.43 9.63 4 12 4 14.93 4 16.96 6.04 19 8.07 19 11 20.73 11.2 21.86 12.5 23 13.78 23 15.5 23 17.38 21.69 18.69 20.38 20 18.5 20H13V12.85L14.6 14.4L16 13L12 9L8 13L9.4 14.4L11 12.85Z"></path></svg></span> <span class="mt-1 font-weight-medium black--text">
+					Placez votre fichier ici
+				</span> <span class="mb-2 grey--text">
+					Ou
+				</span> <span class="vd-file-upload-btn primary white--text text-uppercase py-2 px-4 elevation-2">
+					Choisir un fichier
+				</span> <span class="mt-4 text-body-2 font-weight-regular grey--text">
+					Taille max. : 10 Mo. Formats acceptés : PDF, JPG, JPEG, PNG
+				</span></span></label>
   <div class="v-dialog__container vd-dialog-box" aria-modal="true">
     <!---->
   </div>


### PR DESCRIPTION
## Description

Le mode libre plantais lors de l'upload de plusieurs fichiers

```Error in v-on handler: "TypeError: setting getter-only property "name""```

solution proposé: utilisation d'une variable pour détecter le mode libre qui n'est pas mis à jours lors de l'upload d'un fichier.

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<UploadWorkflow v-model="files" />
</template>
<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class UploadWorkflowUnrestricted extends Vue {
		files: File[] = [];
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
