### PR TITLE
🐛 vue-dot: Fix input event order in DatePicker

### DIFF
--- a/packages/vue-dot/src/mixins/filterable/index.ts
+++ b/packages/vue-dot/src/mixins/filterable/index.ts
@@ -172,8 +172,9 @@ export class Filterable extends Props {
 	resetAllFilters(): void {
 		this.filters.forEach(filter => {
 			this.$set(filter, 'value', undefined);
-			this.updateValue();
 		});
+
+		this.updateValue();
 	}
 
 	updateValue(): void {

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/dateLogic.ts
@@ -154,10 +154,12 @@ export class DateLogic extends MixinsDeclaration {
 		this.textFieldDate = value;
 	}
 
-	saveFromCalendar(): void {
+	async saveFromCalendar(): Promise<void> {
 		this.$refs.menu.save(this.date);
 
 		this.setTextFieldModel();
+
+		await this.$nextTick();
 
 		// Trigger validation when the calendar is clicked since
 		// the input loose focus and fires textFieldBlur
@@ -167,6 +169,8 @@ export class DateLogic extends MixinsDeclaration {
 			// Validate the VTextField since no blur event is emitted
 			this.validateVuetify();
 		}
+
+		await this.$nextTick();
 
 		this.emitChangeEvent();
 	}

--- a/packages/vue-dot/src/patterns/DatePicker/mixins/tests/dateLogic.spec.ts
+++ b/packages/vue-dot/src/patterns/DatePicker/mixins/tests/dateLogic.spec.ts
@@ -29,7 +29,7 @@ interface TestComponent extends Vue {
 	textFieldDate: string;
 	errorMessages: string[];
 	saveFromTextField: () => void;
-	saveFromCalendar: () => void;
+	saveFromCalendar: () => Promise<void>;
 	saveFromPasted: (event: ClipboardEvent) => void;
 	parseTextFieldDate: (date: string) => string;
 	textFieldBlur: () => void;
@@ -171,27 +171,27 @@ describe('DateLogic', () => {
 	});
 
 	// saveFromCalendar
-	it('emits change event when called', () => {
+	it('emits change event when called', async () => {
 		const wrapper = createWrapper();
 
-		wrapper.vm.saveFromCalendar();
+		await wrapper.vm.saveFromCalendar();
 
 		expect(wrapper.emitted('change')).toBeTruthy();
 	});
 
-	it('validates the VTextField when validateOnBlur is true', () => {
+	it('validates the VTextField when validateOnBlur is true', async () => {
 		const wrapper = createWrapper(undefined, {
 			textField: {
 				validateOnBlur: true
 			}
 		});
 
-		wrapper.vm.saveFromCalendar();
+		await wrapper.vm.saveFromCalendar();
 
 		expect(wrapper.emitted('change')).toBeTruthy();
 	});
 
-	it('does not set hasFocused if it is undefined', () => {
+	it('does not set hasFocused if it is undefined', async () => {
 		const wrapper = createWrapper(undefined, {
 			textField: {
 				validateOnBlur: true
@@ -200,7 +200,7 @@ describe('DateLogic', () => {
 
 		delete wrapper.vm.$refs.input.hasFocused;
 
-		wrapper.vm.saveFromCalendar();
+		await wrapper.vm.saveFromCalendar();
 
 		expect(wrapper.emitted('change')).toBeTruthy();
 	});


### PR DESCRIPTION
## Description

Fixes #3233

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<div>
		<FiltersSideBar
			v-model="filters"
			@update:value="updateFilters"
		>
			<template #birthdate="{ on, attrs }">
				<DatePicker
					v-bind="attrs"
					birthdate
					outlined
					date-format="DD/MM/YYYY"
					hint="Format JJ/MM/AAAA"
					date-format-return="YYYY MM DD"
					v-on="on"
				/>
			</template>

			<template #studiesdate="{ on, attrs }">
				<DatePicker
					v-bind="attrs"
					outlined
					date-format="DD/MM/YYYY"
					hint="Format JJ/MM/AAAA"
					date-format-return="YYYY MM DD"
					v-on="on"
				/>
			</template>
		</FiltersSideBar>

		<DatePicker
			outlined
			date-format="DD/MM/YYYY"
			hint="Format JJ/MM/AAAA"
			date-format-return="YYYY MM DD"
			@input="log($event)"
		/>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		filters = [
			{
				name: 'birthdate',
				title: 'Date de naissance'
			},
			{
				name: 'studiesdate',
				title: 'Date d\'ODD'
			}
		];

		updateFilters(): void {
			console.log(this.filters);
		}

		log(value: string): void {
			console.log(value);
		}
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] ~~J'ai apporté les modifications correspondantes à la documentation~~
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
