### PR TITLE
🐛 vue-dot: Fix reactivity issue in PeriodField

### DIFF
--- a/packages/vue-dot/src/patterns/PeriodField/PeriodField.vue
+++ b/packages/vue-dot/src/patterns/PeriodField/PeriodField.vue
@@ -92,12 +92,14 @@
 		get toPickerOptions(): Options {
 			const { to } = this.datePickerOptions;
 
-			to.textField = {
+			const textField = {
 				...to.textField,
 				errorMessages: this.errorMessages
 			};
 
-			return to;
+			return Object.assign({}, to, {
+				textField
+			});
 		}
 
 		async dateUpdated(): Promise<void> {


### PR DESCRIPTION
## Description

Un problème de réactivité empêchait l'erreur de s'afficher quand la date de fin est ultérieur à la date de début.

Lien vers la documentation sur laquelle je me suis basé pour cette PR :
https://v2.vuejs.org/v2/guide/reactivity#For-Objects

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<div>
		<PeriodField />
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {

	}
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
