### PR TITLE
🐛 vue-dot: Fix additional info color in UserMenuBtn

### DIFF
--- a/packages/vue-dot/src/elements/UserMenuBtn/UserMenuBtn.vue
+++ b/packages/vue-dot/src/elements/UserMenuBtn/UserMenuBtn.vue
@@ -30,7 +30,7 @@
 							{{ fullName }}
 						</span>
 
-						<span class="grey--text text--darken-2">
+						<span class="grey--text font-weight-medium">
 							{{ additionalInformation }}
 						</span>
 					</span>


### PR DESCRIPTION
## Description

https://github.com/assurance-maladie-digital/design-system/issues/3391

![Capture d’écran 2024-02-19 à 10 38 01](https://github.com/assurance-maladie-digital/design-system/assets/1822420/74d7d592-76cb-43f0-93b0-aae399617603)

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<UserMenuBtn
		additional-information="Information supplémentaire"
		full-name="Virginie Beauchesne"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class UploadWorkflowUsage extends Vue {

	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
