### PR TITLE
🐛 vue-dot: Use input event instead of change for v-model in NirField

### DIFF
--- a/packages/docs/src/data/api/nir-field.ts
+++ b/packages/docs/src/data/api/nir-field.ts
@@ -37,8 +37,13 @@ export const api: Api = {
 		],
 		events: [
 			{
-				name: 'change',
+				name: 'input',
 				description: 'Événement émis lorsque la valeur est mise à jour.',
+				value: 'string'
+			},
+			{
+				name: 'change',
+				description: 'Événement émis lorsque tous les champs sont complétés.',
 				value: 'string'
 			}
 		]

--- a/packages/vue-dot/src/patterns/NirField/NirField.vue
+++ b/packages/vue-dot/src/patterns/NirField/NirField.vue
@@ -128,12 +128,17 @@
 		inheritAttrs: false,
 		model: {
 			prop: 'value',
-			event: 'change'
+			event: 'input'
 		},
 		watch: {
 			value: {
 				handler(value: string | null) {
 					if (!value) {
+						this.numberValue = null;
+						this.keyValue = null;
+						this.numberErrors = [];
+						this.keyErrors = [];
+
 						return;
 					}
 
@@ -144,12 +149,6 @@
 					if (this.value.length === FieldTypesEnum.DOUBLE) {
 						this.numberValue = value.slice(0, -KEY_LENGTH);
 						this.keyValue = value.slice(NUMBER_LENGTH, NUMBER_LENGTH + KEY_LENGTH);
-					}
-
-					this.validateNumberValue();
-
-					if (!this.isSingleField) {
-						this.validateKeyValue();
 					}
 				},
 				immediate: true
@@ -202,6 +201,7 @@
 
 		setNumberValue(event: InputFacadeEvent): void {
 			this.numberValue = event.target?.unmaskedValue ?? null;
+			this.emitInputEvent();
 		}
 
 		get keyFilled(): boolean {
@@ -262,6 +262,7 @@
 
 		setKeyValue(event: InputFacadeEvent): void {
 			this.keyValue = event.target?.unmaskedValue ?? null;
+			this.emitInputEvent();
 		}
 
 		get computedNumberValue(): string | null {
@@ -278,6 +279,13 @@
 			}
 
 			return this.numberValue as string + this.keyValue as string;
+		}
+
+		get rawInternalValue(): string | null {
+			const numberValue = this.numberValue ?? '';
+			const keyValue = this.keyValue ?? '';
+
+			return numberValue + keyValue;
 		}
 
 		get isSingleField(): boolean {
@@ -317,6 +325,10 @@
 			}
 
 			this.$emit('change', this.internalValue);
+		}
+
+		emitInputEvent(): void {
+			this.$emit('input', this.rawInternalValue);
 		}
 	}
 </script>


### PR DESCRIPTION
## Description

Fixes #3410

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<NirField
			v-model="nir"
			required
			outlined
		/>

		<VBtn @click="nir = ''">
			reset
		</VBtn>

		{{ nir }}
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {
		nir = '';
	}
</script>
```

</details>

## Type de changement

- Correction de bug
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
