### PR TITLE
🐛 vue-dot: Fix tooltip position in NirField

### DIFF
--- a/packages/vue-dot/src/patterns/NirField/NirField.vue
+++ b/packages/vue-dot/src/patterns/NirField/NirField.vue
@@ -341,6 +341,7 @@
 	.vd-key-field {
 		width: 84px;
 	}
+
 	// Don't allow resize for these elements
 	.vd-nir-field :deep(.v-input__append-inner),
 	.vd-number-field,
@@ -353,6 +354,7 @@
 		display: flex;
 		align-self: baseline;
 	}
+
 	:deep(.v-messages__message + .v-messages__message) {
 		margin-top: 4px;
 	}

--- a/packages/vue-dot/src/patterns/NirField/NirField.vue
+++ b/packages/vue-dot/src/patterns/NirField/NirField.vue
@@ -341,7 +341,6 @@
 	.vd-key-field {
 		width: 84px;
 	}
-
 	// Don't allow resize for these elements
 	.vd-nir-field :deep(.v-input__append-inner),
 	.vd-number-field,
@@ -350,6 +349,10 @@
 		flex: none;
 	}
 
+	.v-icon {
+		display: flex;
+		align-self: baseline;
+	}
 	:deep(.v-messages__message + .v-messages__message) {
 		margin-top: 4px;
 	}

--- a/packages/vue-dot/src/patterns/NirField/NirField.vue
+++ b/packages/vue-dot/src/patterns/NirField/NirField.vue
@@ -2,6 +2,8 @@
 	<div
 		:class="{
 			'vd-nir-field--outlined': $attrs.hasOwnProperty('outlined'),
+			'vd-nir-field--simple': isSingleField,
+			'vd-nir-field--double': !isSingleField
 		}"
 		class="vd-nir-field"
 	>
@@ -362,5 +364,9 @@
 	:deep(.v-input__slot) {
 		flex-wrap: wrap;
 		justify-content: flex-start;
+	}
+
+	.vd-nir-field--simple .vd-number-field {
+		margin-right: 0 !important;
 	}
 </style>

--- a/packages/vue-dot/src/patterns/NirField/tests/__snapshots__/NirField.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/NirField/tests/__snapshots__/NirField.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NirField displays an error message when the fields are not totally filled 1`] = `
-<div class="vd-nir-field">
+<div class="vd-nir-field vd-nir-field--double">
   <div class="v-input vd-nir-field__fields-wrapper v-input--has-state v-input--is-label-active v-input--is-dirty theme--light error--text">
     <div class="v-input__control">
       <div class="v-input__slot">
@@ -47,7 +47,7 @@ exports[`NirField displays an error message when the fields are not totally fill
 `;
 
 exports[`NirField renders correctly 1`] = `
-<div class="vd-nir-field">
+<div class="vd-nir-field vd-nir-field--double">
   <div class="v-input vd-nir-field__fields-wrapper v-input--is-label-active v-input--is-dirty theme--light">
     <div class="v-input__control">
       <div class="v-input__slot">
@@ -90,7 +90,7 @@ exports[`NirField renders correctly 1`] = `
 `;
 
 exports[`NirField renders correctly with 13 characters 1`] = `
-<div class="vd-nir-field">
+<div class="vd-nir-field vd-nir-field--simple">
   <div class="v-input vd-nir-field__fields-wrapper v-input--is-label-active v-input--is-dirty theme--light">
     <div class="v-input__control">
       <div class="v-input__slot">
@@ -120,7 +120,7 @@ exports[`NirField renders correctly with 13 characters 1`] = `
 `;
 
 exports[`NirField renders correctly with a tooltip 1`] = `
-<div class="vd-nir-field">
+<div class="vd-nir-field vd-nir-field--double">
   <div class="v-input vd-nir-field__fields-wrapper v-input--is-label-active v-input--is-dirty theme--light">
     <div class="v-input__control">
       <div class="v-input__slot">


### PR DESCRIPTION
## Description

Fix tooltip position on NireField

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<NirField outlined tooltip="jjh" />
	</PageContainer>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class Playground extends Vue {}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
