### PR TITLE
♿️vue-dot: make the error code visible for the screens readers

### DIFF
--- a/packages/docs/src/data/api/error-page.ts
+++ b/packages/docs/src/data/api/error-page.ts
@@ -22,6 +22,12 @@ export const api: Api = {
 				description: 'Le code HTTP de l’erreur.'
 			},
 			{
+				name: 'codeErrorText',
+				type: 'string',
+				default: `'Code d’erreur\xa0:'`,
+				description: 'Le texte à afficher avant le code d’erreur pour les liseuses d’écran.'
+			},
+			{
 				name: 'btn-text',
 				type: 'string',
 				default: `'Retour à l’accueil'`,

--- a/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
+++ b/packages/vue-dot/src/templates/ErrorPage/ErrorPage.vue
@@ -11,9 +11,9 @@
 					class="order-last order-sm-first text-center text-sm-left"
 				>
 					<div
-						aria-hidden="true"
 						class="vd-code font-weight-thin primary--text mb-4"
 					>
+						<span class="d-sr-only">{{ codeErrorText }}</span>
 						{{ code }}
 					</div>
 
@@ -79,6 +79,10 @@
 			btnText: {
 				type: String,
 				default: locales.btnText
+			},
+			codeErrorText: {
+				type: String,
+				default: locales.errorCodeText
 			},
 			btnRoute: {
 				type: [Array, Object, String] as PropType<RawLocation>,

--- a/packages/vue-dot/src/templates/ErrorPage/locales.ts
+++ b/packages/vue-dot/src/templates/ErrorPage/locales.ts
@@ -1,4 +1,5 @@
 export const locales = {
+	errorCodeText: 'Code d\'erreur\xa0: ',
 	supportIdMessage: 'Votre identifiant de support\xa0:',
 	btnText: 'Retour à l’accueil'
 };

--- a/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/ErrorPage/tests/__snapshots__/ErrorPage.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`ErrorPage renders correctly 1`] = `
   <vcard-stub loaderheight="4" tag="div" elevation="2" class="pa-6 pa-sm-16">
     <vrow-stub tag="div" class="max-width-none">
       <vcol-stub cols="12" sm="12" tag="div" class="order-last order-sm-first text-center text-sm-left">
-        <div aria-hidden="true" class="vd-code font-weight-thin primary--text mb-4">
+        <div class="vd-code font-weight-thin primary--text mb-4"><span class="d-sr-only">Code d'erreur&nbsp;: </span>
 
         </div>
         <h2 class="mb-2 font-weight-bold text-h5 mb-4">

--- a/packages/vue-dot/src/templates/MaintenancePage/tests/__snapshots__/MaintenancePage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/MaintenancePage/tests/__snapshots__/MaintenancePage.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MaintenancePage renders correctly 1`] = `<errorpage-stub pagetitle="Maintenance en cours" message="L’application n’est pas disponible pour le moment, veuillez nous excuser pour la gêne occasionnée." btntext="Retour à l’accueil" btnroute="[object Object]" nobtn="true"><img src="" alt="" width="170px" height="170px"></errorpage-stub>`;
+exports[`MaintenancePage renders correctly 1`] = `<errorpage-stub pagetitle="Maintenance en cours" message="L’application n’est pas disponible pour le moment, veuillez nous excuser pour la gêne occasionnée." btntext="Retour à l’accueil" codeerrortext="Code d'erreur&nbsp;: " btnroute="[object Object]" nobtn="true"><img src="" alt="" width="170px" height="170px"></errorpage-stub>`;

--- a/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
+++ b/packages/vue-dot/src/templates/NotFoundPage/tests/__snapshots__/NotFoundPage.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NotFoundPage renders correctly 1`] = `<errorpage-stub pagetitle="Page non trouvée" message="Cette page n’existe pas ou a été déplacée." code="404" btntext="Retour à l’accueil" btnroute="[object Object]"><img src="" alt="" width="170px" height="170px"></errorpage-stub>`;
+exports[`NotFoundPage renders correctly 1`] = `<errorpage-stub pagetitle="Page non trouvée" message="Cette page n’existe pas ou a été déplacée." code="404" btntext="Retour à l’accueil" codeerrortext="Code d'erreur&nbsp;: " btnroute="[object Object]"><img src="" alt="" width="170px" height="170px"></errorpage-stub>`;


### PR DESCRIPTION
## Description

Rendre le code d'erreure visible pour les screens readers

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<ErrorPage
	code="500"
	message="La page ne fonctionne pas correctement."
	page-title="Erreur serveur"
        codeErrorText="Error code : "
/>
```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
