### PR TITLE
➖bridge: Remove deprecated vsc extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
 	"recommendations": [
 		"Vue.volar",
-		"Vue.vscode-typescript-vue-plugin",
 		"editorconfig.editorconfig"
 	]
 }


### PR DESCRIPTION
## Description

L'extension `Vue.vscode-typescript-vue-plugin` est [déprécié](https://www.reddit.com/r/vuejs/comments/1b66msi/vscode_message_the_typescript_vue_plugin_volar/) et n'est plus nécessaire. Cette PR la supprime de la liste des extensions reconnandé sur le bridge.

## Type de changement

- Maintenance


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
