### PR TITLE
vue-dot: Fix typo in error message

### DIFF
--- a/packages/vue-dot/src/patterns/NirField/locales.ts
+++ b/packages/vue-dot/src/patterns/NirField/locales.ts
@@ -5,6 +5,6 @@ export const locales = {
 	keyHint: '2 chiffres',
 	errorRequiredNumber: 'Le numéro de sécurité sociale est obligatoire',
 	errorRequiredKey: 'La clé de validation est obligatoire',
-	errorLengthNumber: (length: number): string => `La longueur du numéro de sécurité social doit être de ${length} caractères.`,
+	errorLengthNumber: (length: number): string => `La longueur du numéro de sécurité sociale doit être de ${length} caractères.`,
 	errorLengthKey: (length: number): string => `La longueur de la clé doit être de ${length} caractères.`
 };

--- a/packages/vue-dot/src/patterns/NirField/tests/__snapshots__/NirField.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/NirField/tests/__snapshots__/NirField.spec.ts.snap
@@ -37,7 +37,7 @@ exports[`NirField displays an error message when the fields are not totally fill
       </div>
       <div class="v-messages theme--light error--text" role="alert">
         <transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper">
-          <div class="v-messages__message">La longueur du numéro de sécurité social doit être de 13 caractères.</div>
+          <div class="v-messages__message">La longueur du numéro de sécurité sociale doit être de 13 caractères.</div>
           <div class="v-messages__message">La longueur de la clé doit être de 2 caractères.</div>
         </transition-group-stub>
       </div>


### PR DESCRIPTION
## Description

Fix d'une typo

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<VApp>
		<PageContainer>
			<NirField />
		</PageContainer>
	</VApp>
</template>

<script lang="ts">
	import { defineComponent } from 'vue';
	import PageContainer from '../src/elements/PageContainer/PageContainer.vue';
	import NirField from '../src/patterns/NirField';

	export default defineComponent({
		components: {
			PageContainer,
			NirField
		},
		data() {
			return {

			};
		}
	});
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
