### PR TITLE
vue-dot: Remove unused dense property from HeaderNavigationBar config

### DIFF
--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/config.ts
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/config.ts
@@ -1,7 +1,6 @@
 export const config = {
 	sheet: {
 		height: '48px',
-		dense: true,
 		dark: true
 	},
 	innerSheet: {

--- a/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/__snapshots__/HeaderNavigationBar.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/HeaderBar/HeaderNavigationBar/tests/__snapshots__/HeaderNavigationBar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HeaderNavigationBar renders correctly 1`] = `
-<vsheet-stub color="#0a347b" height="48px" dark="true" tag="div" dense="true" class="vd-navigation-bar d-flex align-center justify-center px-14">
+<vsheet-stub color="#0a347b" height="48px" dark="true" tag="div" class="vd-navigation-bar d-flex align-center justify-center px-14">
   <vsheet-stub color="transparent" tag="div" class="d-flex align-center">
     <vtabs-stub activeclass="" backgroundcolor="transparent" nexticon="$next" optional="true" previcon="$prev" slidersize="2"></vtabs-stub>
   </vsheet-stub>


### PR DESCRIPTION
## Description

Suppression de l'utilisationde la propriété 'dense' qui n'existe pas sur le composant VSheet

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<HeaderBar :navigation-items="navigationItems" />
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { NavigationItem } from '@cnamts/vue-dot/src/patterns/HeaderBar/types';

	@Component
	export default class HeaderBarNavigationBar extends Vue {
		navigationItems: NavigationItem[] = [
			{
				label: 'Accueil'
			},
			{
				label: 'Mes projets'
			},
			{
				label: 'Mes outils'
			}
		];
	}
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
