### PR TITLE
fix build warning

### DIFF
--- a/packages/synapse-bridge/vite.config.ts
+++ b/packages/synapse-bridge/vite.config.ts
@@ -6,6 +6,52 @@ import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 import dts from 'vite-plugin-dts'
 import { visualizer } from 'rollup-plugin-visualizer'
 
+function generateVuetifyGlobals() {
+	const components = [
+		'VForm',
+		'VBtn',
+		'VIcon',
+		'VChip',
+		'VMenu',
+		'VRadioGroup',
+		'VRadio',
+		'VTable',
+		'VDataTable',
+		'VBtnToggle',
+		'VCheckbox',
+		'VSelect',
+		'VRating',
+		'VRangeSlider',
+		'VSnackbar',
+		'VTooltip',
+		'VTextField',
+		'VInput',
+		'VToolbar',
+		'VNavigationDrawer',
+		'VTabs',
+		'VLayout',
+		'VFooter',
+		'VAlert',
+		'VDivider',
+		'VSheet',
+		'VList',
+		'VGrid',
+		'VDialog',
+		'VCard',
+		'VSkeletonLoader',
+		'transitions',
+	];
+
+	const globals = {};
+
+	for (const component of components) {
+		globals[`vuetify/lib/components/${component}/index.mjs`] = component;
+	}
+	globals['vuetify/components/VSkeletonLoader'] = 'VSkeletonLoader';
+	globals['vuetify/lib/directives/index.mjs'] = 'vuetifyDirectives';
+
+	return globals;
+}
 export default defineConfig(({ mode }) => {
 	const config = {
 		plugins: [
@@ -39,12 +85,15 @@ export default defineConfig(({ mode }) => {
 			rollupOptions: {
 				external: [
 					'vue',
-					/vuetify/
+					/vuetify/,
 				],
 				output: {
 					globals: {
 						vue: 'Vue',
-						vuetify: 'Vuetify'
+						vuetify: 'Vuetify',
+						'vuetify/directives': 'vuetifyDirectives',
+						'vuetify/lib/directives': 'vuetifyDirectives',
+						...generateVuetifyGlobals(),
 					}
 				}
 			}


### PR DESCRIPTION
## Description

Au build erreur qui survient lors de l'utilisation de Rollup pour empaqueter l'application. Rollup ne peut pas déterminer automatiquement le nom global pour le module externe "vuetify/lib/components/VForm/index.mjs"...

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
// Copiez-collez le contenu de votre Playground.vue entier ici
```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
