### PR TITLE
fix nierfield for the Corsican departments

### DIFF
--- a/packages/synapse-bridge/src/patterns/NirField/NirField.vue
+++ b/packages/synapse-bridge/src/patterns/NirField/NirField.vue
@@ -179,6 +179,7 @@ export default defineComponent({
 	methods: {
 		changeNumberValue(): void {
 			this.$emit("update:modelValue", this.keyValue ? this.maskaNumberValue.unmasked + this.keyValue : this.maskaNumberValue.unmasked);
+			this.validateNumberValue();
 		},
 
 		changeKeyValue(): void {
@@ -198,7 +199,13 @@ export default defineComponent({
 				this.numberRules
 					.map(rule => rule(this.maskaNumberValue.unmasked))
 					.filter((error): error is string => typeof error === 'string');
-			//this.$emit('update:modelValue', this.maskaNumberValue.unmasked);
+
+			// Add custom validation for 'A' or 'B' (For the Corsican departments)
+			const seventhChar = this.maskaNumberValue.unmasked.charAt(5);
+			const eighthChar = this.maskaNumberValue.unmasked.charAt(6);
+			if ((eighthChar === 'A' || eighthChar === 'B') && seventhChar !== '1' && seventhChar !== '2') {
+				this.numberErrors.push(this.locales.errorCorsican);
+			}
 		},
 
 		/**

--- a/packages/synapse-bridge/src/patterns/NirField/locales.ts
+++ b/packages/synapse-bridge/src/patterns/NirField/locales.ts
@@ -6,5 +6,6 @@ export const locales = {
 	errorRequiredNumber: 'Le numéro de sécurité sociale est obligatoire',
 	errorRequiredKey: 'La clé de validation est obligatoire',
 	errorLengthNumber: (length: number): string => `La longueur du numéro de sécurité sociale doit être de ${length} caractères.`,
-	errorLengthKey: (length: number): string => `La longueur de la clé doit être de ${length} caractères.`
+	errorLengthKey: (length: number): string => `La longueur de la clé doit être de ${length} caractères.`,
+	errorCorsican: 'Le chiffre précédant A ou B doit être 1 ou 2.'
 } as const;


### PR DESCRIPTION
Description

Les caracteres autres que A et B sont possible sans erreur , et comme il est n'est pas possible de passer des rules custom c'est bloquant
Comment reproduire

Dans un NirField entrer : "1 23 44 7D 898 765"
Le champ se valide
Comportement attendu

Le champ devrait être en erreur

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue

<template>
	<div>
		<NirField v-model="nirValue" @update:model-value='newValue'/>
		{{ nirValue }}

		<NirField v-model="nirValue2" @update:model-value='newValue' :nir-length='13'/>
		{{ nirValue2 }}
	</div>
</template>

<script lang="ts" setup>
import { ref } from 'vue';
import NirField from '../src/patterns/NirField';

const nirValue = ref('');
const nirValue2 = ref('');

setTimeout(() => {
	nirValue.value = '12345678901234k';
	nirValue2.value = '123456A222224';
}, 1000);
function newValue(value: string) {
	console.log('newValue', value);
}
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Mon code suit le style de code du projet
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
