### PR TITLE
add custom message on error

### DIFF
--- a/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
@@ -379,7 +379,7 @@ export default defineComponent({
 						this.$emit('update:model-value', this.indexedThis[historyKey]);
 					} else {
 						// If the date format or the date is not valid, add an error message
-						this.errorMessages.push(this.customErrorMessages || 'La date saisie n\'est pas valide');
+						this.errorMessages.push(this.customErrorMessages.length > 0 ? this.customErrorMessages :  'La date saisie n\'est pas valide');
 					}
 				} else {
 					// If the date format is 'DD/MM/YY', emit an update event with the formatted date
@@ -454,9 +454,6 @@ export default defineComponent({
 
 <template>
 	<div class="vd-date-picker">
-		{{ errorMessages }}
-		{{ customErrorMessages }}
-		{{ hasError }}
 		<!--	doc:	https://vue3datepicker.com-->
 		<VueDatePicker
 			v-model="date"

--- a/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
@@ -98,6 +98,10 @@ export default defineComponent({
 			type: String as PropType<string>,
 			default: 'DD/MM/YYYY',
 		},
+		customErrorMessages: {
+			type: Array as PropType<Array<string>>,
+			default: () => [],
+		},
 	},
 	data(): DatePickerData {
 		return {
@@ -138,7 +142,9 @@ export default defineComponent({
 		},
 
 		hasError() {
-			return this.errorMessages.includes('La date saisie n\'est pas valide') || this.errorMessages.includes('Une erreur est survenue');
+			return this.errorMessages.includes('La date saisie n\'est pas valide') ||
+					this.errorMessages.includes('Une erreur est survenue')||
+				    this.errorMessages.includes(this.customErrorMessages);
 		},
 		textFieldClasses() {
 			const textFieldClasses = this.buildTextFieldClasses();
@@ -373,7 +379,7 @@ export default defineComponent({
 						this.$emit('update:model-value', this.indexedThis[historyKey]);
 					} else {
 						// If the date format or the date is not valid, add an error message
-						this.errorMessages.push('La date saisie n\'est pas valide');
+						this.errorMessages.push(this.customErrorMessages || 'La date saisie n\'est pas valide');
 					}
 				} else {
 					// If the date format is 'DD/MM/YY', emit an update event with the formatted date
@@ -448,6 +454,9 @@ export default defineComponent({
 
 <template>
 	<div class="vd-date-picker">
+		{{ errorMessages }}
+		{{ customErrorMessages }}
+		{{ hasError }}
 		<!--	doc:	https://vue3datepicker.com-->
 		<VueDatePicker
 			v-model="date"


### PR DESCRIPTION
## Description

Selon la documentation de Vuetify, il faut utiliser error-messages pour personnaliser le message d'erreur, mais cela ne fonctionne pas. À la place, j'ai dû indiquer cette propriété 'textField': { 'errorMessages': '' }. (sans le tiret)

Solution proposee: Ajout d'une props customErrorMessages

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<v-row>
			<v-col cols="12" md="6">
				<h3>Required</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					:rules="validRules"
					:customErrorMessages="['Votre message d erreur personnalisé ici']"				/>
			</v-col>
		</v-row>
	</PageContainer>
</template>

<script lang="ts">
import DatePicker from "@/patterns/DatePicker/DatePicker.vue";
import { required } from "@/rules/required/index.ts";
import PageContainer from "@/elements/PageContainer/PageContainer.vue";

export default {
	emits: ['change'],
	components: {
		DatePicker,
		PageContainer
	},
	data() {
		return {
			date: null,
			validRules: [required],
			defaultHint: "Format JJ/MM/YYYY",
			customMessages: 'Ohhohohoho'
		};
	},
};
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Mon code suit le style de code du projet
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
