### PR TITLE
Improve handling of NirField values

### DIFF
--- a/packages/vue-dot/src/patterns/NirField/NirField.vue
+++ b/packages/vue-dot/src/patterns/NirField/NirField.vue
@@ -135,7 +135,8 @@
 		watch: {
 			value: {
 				handler(value: string | null) {
-					if (!value) {
+
+					if (!value && !this.keyValue) {
 						this.numberValue = null;
 						this.keyValue = null;
 						this.numberErrors = [];
@@ -144,14 +145,14 @@
 						return;
 					}
 
-					if (this.value.length >= FieldTypesEnum.SINGLE) {
+					if (this.nirLength === FieldTypesEnum.SINGLE) {
 						this.numberValue = value;
+
+						return;
 					}
 
-					if (this.value.length === FieldTypesEnum.DOUBLE) {
-						this.numberValue = value.slice(0, -KEY_LENGTH);
-						this.keyValue = value.slice(NUMBER_LENGTH, NUMBER_LENGTH + KEY_LENGTH);
-					}
+					this.numberValue = value?.slice(0, NUMBER_LENGTH) ?? '';
+					this.keyValue = this.keyValue ?? value?.slice(NUMBER_LENGTH, NUMBER_LENGTH + KEY_LENGTH) ?? '';
 				},
 				immediate: true
 			}
@@ -286,6 +287,13 @@
 		get rawInternalValue(): string | null {
 			const numberValue = this.numberValue ?? '';
 			const keyValue = this.keyValue ?? '';
+
+			if (
+				!this.isSingleField
+				&& numberValue.length < NUMBER_LENGTH
+			) {
+				return numberValue;
+			}
 
 			return numberValue + keyValue;
 		}


### PR DESCRIPTION
## Description

fix the issue when the user delete somme number in the first field when the second field is not empty

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<PageContainer>
		<NirField
			v-model="value"
			label="NIR"
			placeholder="Enter your NIR"
		/>

		{{ value }}
	</PageContainer>
</template>

<script lang="ts">
	import NirField from '../src/patterns/NirField';
	import { defineComponent } from 'vue';

	export default defineComponent({
		name: 'ThePlayground',
		components: {
			NirField
		},
		data() {
			return {
				value: '',
				value2: ''
			};
		},
		mounted() {
			setTimeout(() => {
				this.value = '123456789012345';
			}, 3000);
		}
	});
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
