### PR TITLE
datePicker : add persistent hint for accessibility

### DIFF
--- a/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -105,7 +105,13 @@ exports[`FormBuilder renders correctly 1`] = `
             <div class="v-text-field__details">
               <div class="v-messages theme--light">
                 <transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper">
-                  <div class="v-messages__message">Format JJ/MM/AAAA</div>
+                  <div class="v-messages__message">
+                    <!---->
+                    <!---->
+                    <div class="messages">
+                      Format JJ/MM/AAAA
+                    </div>
+                  </div>
                 </transition-group-stub>
               </div>
             </div>
@@ -132,7 +138,13 @@ exports[`FormBuilder renders correctly 1`] = `
               <div class="v-text-field__details">
                 <div class="v-messages theme--light">
                   <transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper">
-                    <div class="v-messages__message">Format JJ/MM/AAAA</div>
+                    <div class="v-messages__message">
+                      <!---->
+                      <!---->
+                      <div class="messages">
+                        Format JJ/MM/AAAA
+                      </div>
+                    </div>
                   </transition-group-stub>
                 </div>
               </div>
@@ -154,7 +166,13 @@ exports[`FormBuilder renders correctly 1`] = `
               <div class="v-text-field__details">
                 <div class="v-messages theme--light">
                   <transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper">
-                    <div class="v-messages__message">Format JJ/MM/AAAA</div>
+                    <div class="v-messages__message">
+                      <!---->
+                      <!---->
+                      <div class="messages">
+                        Format JJ/MM/AAAA
+                      </div>
+                    </div>
                   </transition-group-stub>
                 </div>
               </div>

--- a/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
@@ -25,6 +25,17 @@
 				@change="dateFormatted = $event"
 				v-on="listeners"
 			>
+				<template #message>
+					<div v-if="successMessages.length">
+						{{ successMessages[0] }}
+					</div>
+					<div v-if="errorMessages">
+						{{ errorMessages[0] }}
+					</div>
+					<div class="messages">
+						{{ textFieldOptions.hint }}
+					</div>
+				</template>
 				<template #prepend>
 					<VBtn
 						v-show="showPrependIcon"
@@ -286,5 +297,9 @@
 	// @see https://github.com/assurance-maladie-digital/design-system/issues/907
 	.vd-no-prepend-icon :deep() .v-input__prepend-outer {
 		margin: 0 !important;
+	}
+	.messages {
+		color: rgba(0, 0, 0, 0.6);
+		margin-top: 5px;
 	}
 </style>

--- a/packages/vue-dot/src/patterns/DatePicker/tests/__snapshots__/DatePicker.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/DatePicker/tests/__snapshots__/DatePicker.spec.ts.snap
@@ -12,7 +12,13 @@ exports[`DatePicker renders correctly 1`] = `
       <div class="v-text-field__details">
         <div class="v-messages theme--light">
           <transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper">
-            <div class="v-messages__message">Format JJ/MM/AAAA</div>
+            <div class="v-messages__message">
+              <!---->
+              <!---->
+              <div class="messages">
+                Format JJ/MM/AAAA
+              </div>
+            </div>
           </transition-group-stub>
         </div>
       </div>


### PR DESCRIPTION
## Description

Add hint in messages (accessibility)

## Playground

<details>

```vue
<template>
	<div>
		<DatePicker
			v-model="date"
			date-format="DD-MM-YYYY"
			hint="Format JJ-MM-AAAA"
			date-format-return="DD/MM/YYYY"
			outlined
		/>
		<p
			v-if="date"
			class="mt-4 mb-0"
		>
			Date saisie : {{ date }}
		</p>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class DatePickerFormat extends Vue {
		date: string | null = null;
	}
</script>
```

</details>

## Type de changement

- Nouvelle fonctionnalité

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
