### PR TITLE
blocking submit based on rules

### DIFF
--- a/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
@@ -28,6 +28,7 @@ interface DatePickerData {
 	calendarIcon: string
 	closeIcon: string
 	errorMessages: string[] | any
+	warningErrorMessages: string[] | any
 	birthdateFlow: DatePickerFlow
 	isCalOpen: boolean
 	lastTypeAddedDate: string
@@ -134,6 +135,7 @@ export default defineComponent({
 			calendarIcon: mdiCalendar,
 			closeIcon: mdiCloseCircle,
 			errorMessages: [] as string[],
+			warningErrorMessages: [] as string[],
 			birthdateFlow: ['year', 'month', 'calendar'],
 			isCalOpen: false,
 			lastTypeAddedDate: '',
@@ -166,9 +168,7 @@ export default defineComponent({
 
 		hasError() {
 			return (
-				this.errorMessages.includes(
-					"La date saisie n'est pas valide"
-				) ||
+				this.errorMessages.includes("La date saisie n'est pas valide") ||
 				this.errorMessages.includes('Une erreur est survenue') ||
 				this.errorMessages.includes(this.customErrorMessages)
 			)
@@ -481,18 +481,14 @@ export default defineComponent({
 		},
 
 		validate(value: any) {
-			const allRules = [
-				...(this.warningRules || []),
-				...(this.rules || []),
-			]
-			const ruleErrors = allRules
-				.map((rule: any) => rule(value))
-				.filter((result) => result !== true)
-			this.errorMessages = ruleErrors.length > 0 ? ruleErrors : []
-			// Check if the error prop is true
+			const applyRules = (rules: any[]) =>
+				rules.map(rule => rule(value)).filter(result => result !== true);
+
+			this.errorMessages = applyRules(this.rules || []);
+			this.warningErrorMessages = applyRules(this.warningRules || []);
+
 			if (this.error) {
-				// If it is, add an error message
-				this.errorMessages.push('Une erreur est survenue')
+				this.errorMessages.push('Une erreur est survenue');
 			}
 		},
 		buildTextFieldClasses() {
@@ -598,14 +594,14 @@ export default defineComponent({
 					:class="[
 						textFieldClasses,
 						{
-							'warning-style': errorMessages.length > 0,
+							'warning-style': warningErrorMessages.length > 0,
 							'error-style': hasError,
 							range: range,
 						},
 					]"
 					:clearable="clearable"
 					:disabled="disabled"
-					:error-messages="errorMessages"
+					:error-messages="[...errorMessages, ...warningErrorMessages]"
 					:hint="hint"
 					:label="label"
 					:persistent-hint="true"

--- a/packages/synapse-bridge/src/rules/notAfterToday/index.ts
+++ b/packages/synapse-bridge/src/rules/notAfterToday/index.ts
@@ -1,27 +1,28 @@
-import { ruleMessage } from '../../helpers/ruleMessage'
-import { isDateAfter } from '../../functions/validation/isDateAfter/index.ts'
-import {
-	ValidationRule,
-	ValidationResult,
-	ErrorMessages,
-	Value,
-} from '../types'
-import { defaultErrorMessages } from './locales'
-import { TODAY } from '../../constants'
+import { ruleMessage } from '../../helpers/ruleMessage';
+import { isDateAfter } from '../../functions/validation/isDateAfter/index.ts';
+import { ValidationRule, ValidationResult, ErrorMessages, Value } from '../types';
+import { defaultErrorMessages } from './locales';
+import { TODAY } from '../../constants';
 
-/** Check that the value is not after today (DD/MM/YYYY format) */
-export function notAfterTodayFn(
-	errorMessages: ErrorMessages = defaultErrorMessages
-): ValidationRule {
-	return (value: Value): ValidationResult => {
-		if (!value) {
-			return true
-		}
-
-		return (
-			!isDateAfter(TODAY, value) || ruleMessage(errorMessages, 'default')
-		)
-	}
+function formatDateToDDMMYYYY(date: Date): string {
+	const day = String(date.getDate()).padStart(2, '0');
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const year = date.getFullYear();
+	return `${day}/${month}/${year}`;
 }
 
-export const notAfterToday = notAfterTodayFn()
+/** Vérifie que la valeur n'est pas après aujourd'hui (format DD/MM/YYYY) */
+export function notAfterTodayFn(errorMessages: ErrorMessages = defaultErrorMessages): ValidationRule {
+	return (value: Value): ValidationResult => {
+		if (!value) {
+			return true;
+		}
+		const formattedValue = typeof value === 'object' ? formatDateToDDMMYYYY(value) : value;
+		if (isDateAfter(TODAY, formattedValue)) {
+			return ruleMessage(errorMessages, 'default');
+		}
+		return true;
+	};
+}
+
+export const notAfterToday = notAfterTodayFn();

--- a/packages/synapse-bridge/src/rules/notBeforeToday/index.ts
+++ b/packages/synapse-bridge/src/rules/notBeforeToday/index.ts
@@ -11,6 +11,12 @@ import { defaultErrorMessages } from './locales'
 import { isDateBefore } from '../../functions/validation/isDateBefore'
 import { TODAY } from '../../constants'
 
+function formatDateToDDMMYYYY(date: Date): string {
+	const day = String(date.getDate()).padStart(2, '0');
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const year = date.getFullYear();
+	return `${day}/${month}/${year}`;
+}
 /** Check that the value is not before today (DD/MM/YYYY format) */
 export function notBeforeTodayFn(
 	errorMessages: ErrorMessages = defaultErrorMessages
@@ -19,9 +25,12 @@ export function notBeforeTodayFn(
 		if (!value) {
 			return true
 		}
-		return (
-			!isDateBefore(TODAY, value) || ruleMessage(errorMessages, 'default')
-		)
+		const formattedValue = typeof value === 'object' ? formatDateToDDMMYYYY(value) : value;
+		if (isDateBefore(TODAY, formattedValue)) {
+			return ruleMessage(errorMessages, 'default');
+		}
+		return true;
+
 	}
 }
 


### PR DESCRIPTION
## Description

Les règles autres que required ou isDateValid passées dans la prop rules deviennent des warning-rules et ne bloquent plus la validation.

## Comment reproduire

Entrer dans la prop rules vos règles. Ces règles peuvent être l'une des règles mise à disposition par le DS ou une règle custom.
Si entrèes en même temps, la règle required fonctionnera normalement, les autres se transformant en warning-rules.

## Reproduction minimale
``` vue
<script setup lang="ts">
import {DatePicker, notAfterToday, required, notBeforeToday} from '@/main'
import {SubmitEventPromise} from "vuetify";
import { ref } from 'vue'

const date = ref(undefined)

async function submitForm(event: SubmitEventPromise): Promise<void> {
	const submitResult = await event
	if (submitResult.valid) {
		alert("valid")
	}
}
</script>

<template>
	<v-form
		@submit.prevent="submitForm"
	>
		<DatePicker v-model="date" :rules="[notAfterToday, required]" :warning-rules="[notBeforeToday]"  label="NotAfterToday"/>

		<button type="submit">Rechercher</button>
	</v-form>
</template>
```
## Comportement attendu

Les règles effectues leurs vérifications et bloquent la validation du formulaire.

