### PR TITLE
improve validDate rule ans set it by default

### DIFF
--- a/packages/synapse-bridge/src/patterns/DatePicker/tests/DatePicker.spec.ts
+++ b/packages/synapse-bridge/src/patterns/DatePicker/tests/DatePicker.spec.ts
@@ -157,7 +157,7 @@ describe('Computed', () => {
 			disabled: false,
 			hint: wrapper.vm.hint,
 			persistentHint: true,
-			rules: [],
+			rules: [wrapper.vm.validateDateFormat, ...wrapper.vm.rules],
 			errorMessages: [],
 		}
 

--- a/packages/synapse-bridge/src/rules/notAfterToday/index.ts
+++ b/packages/synapse-bridge/src/rules/notAfterToday/index.ts
@@ -4,7 +4,7 @@ import { ValidationRule, ValidationResult, ErrorMessages, Value } from '../types
 import { defaultErrorMessages } from './locales';
 import { TODAY } from '../../constants';
 
-function formatDateToDDMMYYYY(date: Date): string {
+export function formatDateToDDMMYYYY(date: Date): string {
 	const day = String(date.getDate()).padStart(2, '0');
 	const month = String(date.getMonth() + 1).padStart(2, '0');
 	const year = date.getFullYear();

--- a/packages/synapse-bridge/src/rules/notAfterToday/index.ts
+++ b/packages/synapse-bridge/src/rules/notAfterToday/index.ts
@@ -4,7 +4,7 @@ import { ValidationRule, ValidationResult, ErrorMessages, Value } from '../types
 import { defaultErrorMessages } from './locales';
 import { TODAY } from '../../constants';
 
-export function formatDateToDDMMYYYY(date: Date): string {
+export function formatDateToDDMMYYYYFn(date: Date): string {
 	const day = String(date.getDate()).padStart(2, '0');
 	const month = String(date.getMonth() + 1).padStart(2, '0');
 	const year = date.getFullYear();
@@ -17,7 +17,7 @@ export function notAfterTodayFn(errorMessages: ErrorMessages = defaultErrorMessa
 		if (!value) {
 			return true;
 		}
-		const formattedValue = typeof value === 'object' ? formatDateToDDMMYYYY(value) : value;
+		const formattedValue = typeof value === 'object' ? formatDateToDDMMYYYYFn(value) : value;
 		if (isDateAfter(TODAY, formattedValue)) {
 			return ruleMessage(errorMessages, 'default');
 		}

--- a/packages/synapse-bridge/src/rules/notAfterToday/tests/notAfterToday.spec.ts
+++ b/packages/synapse-bridge/src/rules/notAfterToday/tests/notAfterToday.spec.ts
@@ -2,7 +2,7 @@ import { notAfterTodayFn } from '@/rules/notAfterToday/index.ts'
 import dayjs from 'dayjs'
 import { defaultErrorMessages } from '@/rules/notAfterToday/locales'
 import { it, describe, expect } from 'vitest'
-import {formatDateToDDMMYYYY} from "@/rules/notBeforeToday";
+import {formatDateToDDMMYYYY} from '../'
 
 const DATE_FORMAT = 'DD/MM/YYYY'
 

--- a/packages/synapse-bridge/src/rules/notAfterToday/tests/notAfterToday.spec.ts
+++ b/packages/synapse-bridge/src/rules/notAfterToday/tests/notAfterToday.spec.ts
@@ -2,6 +2,7 @@ import { notAfterTodayFn } from '@/rules/notAfterToday/index.ts'
 import dayjs from 'dayjs'
 import { defaultErrorMessages } from '@/rules/notAfterToday/locales'
 import { it, describe, expect } from 'vitest'
+import {formatDateToDDMMYYYY} from "@/rules/notBeforeToday";
 
 const DATE_FORMAT = 'DD/MM/YYYY'
 
@@ -26,5 +27,10 @@ describe('notAfterTodayFn', () => {
 
 	it('returns true when value is today', () => {
 		expect(notAfterToday(today)).toBe(true)
+	})
+
+	it('returns date in DD/MM/YYYY format', () => {
+		const date = new Date('2021-01-01')
+		expect(formatDateToDDMMYYYY(date)).toBe('01/01/2021')
 	})
 })

--- a/packages/synapse-bridge/src/rules/notAfterToday/tests/notAfterToday.spec.ts
+++ b/packages/synapse-bridge/src/rules/notAfterToday/tests/notAfterToday.spec.ts
@@ -2,7 +2,7 @@ import { notAfterTodayFn } from '@/rules/notAfterToday/index.ts'
 import dayjs from 'dayjs'
 import { defaultErrorMessages } from '@/rules/notAfterToday/locales'
 import { it, describe, expect } from 'vitest'
-import {formatDateToDDMMYYYY} from '../'
+import {formatDateToDDMMYYYYFn} from '../'
 
 const DATE_FORMAT = 'DD/MM/YYYY'
 
@@ -31,6 +31,6 @@ describe('notAfterTodayFn', () => {
 
 	it('returns date in DD/MM/YYYY format', () => {
 		const date = new Date('2021-01-01')
-		expect(formatDateToDDMMYYYY(date)).toBe('01/01/2021')
+		expect(formatDateToDDMMYYYYFn(date)).toBe('01/01/2021')
 	})
 })

--- a/packages/synapse-bridge/src/rules/notBeforeToday/index.ts
+++ b/packages/synapse-bridge/src/rules/notBeforeToday/index.ts
@@ -11,7 +11,7 @@ import { defaultErrorMessages } from './locales'
 import { isDateBefore } from '../../functions/validation/isDateBefore'
 import { TODAY } from '../../constants'
 
-function formatDateToDDMMYYYY(date: Date): string {
+export function formatDateToDDMMYYYY(date: Date): string {
 	const day = String(date.getDate()).padStart(2, '0');
 	const month = String(date.getMonth() + 1).padStart(2, '0');
 	const year = date.getFullYear();

--- a/packages/synapse-bridge/src/rules/notBeforeToday/tests/notBeforeToday.spec.ts
+++ b/packages/synapse-bridge/src/rules/notBeforeToday/tests/notBeforeToday.spec.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 
-import { notBeforeToday, notBeforeTodayFn } from '../'
+import { notBeforeToday, notBeforeTodayFn, formatDateToDDMMYYYY } from '../'
 import { describe, it, expect } from 'vitest'
 
 const DATE_FORMAT = 'DD/MM/YYYY'
@@ -32,5 +32,10 @@ describe('notBeforeToday', () => {
 
 	it('returns true when value is today', () => {
 		expect(notBeforeToday(today)).toBe(true)
+	})
+
+	it('returns date in DD/MM/YYYY format', () => {
+		const date = new Date('2021-01-01')
+		expect(formatDateToDDMMYYYY(date)).toBe('01/01/2021')
 	})
 })


### PR DESCRIPTION
## Description

Si la date est invalide le message d'erreur s'affiche bien mais le submit n'est pas bloque

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<code>

```vue
<script setup lang="ts">
import {DatePicker, notAfterToday, required, notBeforeToday} from '@/main'
import {SubmitEventPromise} from "vuetify";
import { ref } from 'vue'

const date = ref(undefined)

async function submitForm(event: SubmitEventPromise): Promise<void> {
	const submitResult = await event
	if (submitResult.valid) {
		alert("valid")
	}
}
</script>

<template>
	<v-form
		@submit.prevent="submitForm"
	>
		<DatePicker v-model="date" :rules="[notAfterToday, required]" :warning-rules="[notBeforeToday]"  label="NotAfterToday"/>

		<button type="submit">Rechercher</button>
	</v-form>
</template>

```

</code>

