### PR TITLE
add noIcon props in datepicker

### DIFF
--- a/packages/synapse-bridge/CHANGELOG.md
+++ b/packages/synapse-bridge/CHANGELOG.md
@@ -1,12 +1,12 @@
 #### v3.0.0
 
-- Fix AlertWrapper background [`#3692`](https://github.com/assurance-maladie-digital/design-system/pull/3692)
-- Fix DatePicker's issues with validation  [`#3688`](https://github.com/assurance-maladie-digital/design-system/pull/3688)
-- NirField: add labels props [`#3689`](https://github.com/assurance-maladie-digital/design-system/pull/3689)
-- improve validDate rule ans set it by default to DatePicker [`#3681`](https://github.com/assurance-maladie-digital/design-system/pull/3681)
-- DatePicker: block submit based on rules [`#3677`](https://github.com/assurance-maladie-digital/design-system/pull/3677)
-- Fix buttons style [`#3667`](https://github.com/assurance-maladie-digital/design-system/pull/3667)
-- DatePicker refactor delete [`#3670`](https://github.com/assurance-maladie-digital/design-system/pull/3670)
+-   Fix AlertWrapper background [`#3692`](https://github.com/assurance-maladie-digital/design-system/pull/3692)
+-   Fix DatePicker's issues with validation [`#3688`](https://github.com/assurance-maladie-digital/design-system/pull/3688)
+-   NirField: add labels props [`#3689`](https://github.com/assurance-maladie-digital/design-system/pull/3689)
+-   improve validDate rule ans set it by default to DatePicker [`#3681`](https://github.com/assurance-maladie-digital/design-system/pull/3681)
+-   DatePicker: block submit based on rules [`#3677`](https://github.com/assurance-maladie-digital/design-system/pull/3677)
+-   Fix buttons style [`#3667`](https://github.com/assurance-maladie-digital/design-system/pull/3667)
+-   DatePicker refactor delete [`#3670`](https://github.com/assurance-maladie-digital/design-system/pull/3670)
 
 #### v1.4.10-alpha.0
 

--- a/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
@@ -197,7 +197,7 @@ export default defineComponent({
 			return this.determineVariant()
 		},
 		prependIconValue() {
-			if (!this.appendIcon && !this.noPrependIcon) {
+			if (!this.appendIcon && !this.noPrependIcon && !this.noIcon) {
 				return this.calendarIcon
 			}
 			return undefined
@@ -736,7 +736,7 @@ export default defineComponent({
 						</VIcon>
 					</template>
 
-					<template #prepend v-if="!outlined && prependIconValue">
+					<template #prepend v-if="!outlined && prependIconValue && !noIcon">
 						<VIcon
 							@click="handleIconClick"
 							tabindex="-1"

--- a/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/synapse-bridge/src/patterns/DatePicker/DatePicker.vue
@@ -64,6 +64,10 @@ export default defineComponent({
 			type: Boolean as PropType<boolean>,
 			default: false,
 		},
+		noIcon: {
+			type: Boolean as PropType<boolean>,
+			default: false,
+		},
 		disabled: {
 			type: Boolean as PropType<boolean>,
 			default: false,
@@ -354,7 +358,8 @@ export default defineComponent({
 			if (
 				(!this.isCalOpen &&
 					!this.noPrependIcon &&
-					!this.textFieldActivator) ||
+					!this.textFieldActivator &&
+					!this.noIcon) ||
 				this.noCalendar
 			) {
 				datePicker.closeMenu()
@@ -588,6 +593,10 @@ export default defineComponent({
 				textFieldClasses.push('vd-no-prepend-icon')
 			}
 
+			if (this.noIcon) {
+				textFieldClasses.push('vd-no-prepend-icon')
+			}
+
 			if (this.appendIcon) {
 				textFieldClasses.push('vd-append-icon')
 			}
@@ -718,6 +727,7 @@ export default defineComponent({
 						v-if="outlined || (appendIcon && calendarIcon)"
 					>
 						<VIcon
+							v-if="!noIcon"
 							@click="handleIconClick"
 							tabindex="-1"
 							aria-hidden="true"

--- a/packages/synapse-bridge/src/patterns/DatePicker/tests/DatePicker.spec.ts
+++ b/packages/synapse-bridge/src/patterns/DatePicker/tests/DatePicker.spec.ts
@@ -66,6 +66,32 @@ describe('DatePicker', () => {
 		expect(wrapper.vm.prependIconValue).toBeUndefined()
 	})
 
+	it('returns undefined when appendIcon or noIcon is false', () => {
+		const wrapper = shallowMount(DatePicker, {
+			propsData: {
+				noPrependIcon: true,
+				noIcon: false,
+			},
+		})
+
+		expect(wrapper.vm.prependIconValue).toBeUndefined()
+		wrapper.setProps({ noPrependIcon: false, noIcon: true })
+		expect(wrapper.vm.prependIconValue).toBeUndefined()
+	})
+
+	it('returns undefined when appendIcon or noIcon is true', () => {
+		const wrapper = shallowMount(DatePicker, {
+			propsData: {
+				noPrependIcon: false,
+				noIcon: true,
+			},
+		})
+
+		expect(wrapper.vm.prependIconValue).toBeUndefined()
+		wrapper.setProps({ noPrependIcon: true, noIcon: true })
+		expect(wrapper.vm.prependIconValue).toBeUndefined()
+	})
+
 	it('returns correct date when day slot is called', () => {
 		const wrapper = shallowMount(DatePicker, {
 			propsData: {


### PR DESCRIPTION
## Description

<!--
<template>
	<PageContainer>
		<v-row>
			<v-col cols="12" md="6">
				Date: {{ date }} Date pre definie: {{ dateDefinie }}
				<h3 class="mt-4">No icon</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					no-icon
					outlined
				/>
				<h3>Basique Outlined</h3>
				<date-picker
					v-model="date1"
					label="Date"
					:hint="defaultHint"
					outlined
					clearable
				/>
				<h3>Basique with change event</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					@change="handleDateChange"
				/>
				<h3>Basique</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					clearable
				/>
				<h3>Clearable</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					clearable
					outlined
					append-icon
				/>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					clearable
				/>

				<h3>Required</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					:rules="validRules"
				/>

				<h3>Not After Today</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					:warning-rules="notAfterTodayRules"
				/>

				<h3>Not Before Today</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					:warning-rules="notBeforeTodayRules"
				/>

				<h3>Warning Rules</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					:warning-rules="warningRules"
					outlined
				/>
				<h3 class="mt-4">No-prepend-icon</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					no-prepend-icon
				/>

				<h3 class="mt-4">No icon</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					no-icon
					outlined
				/>
			</v-col>
			<v-col cols="12" md="6">
				<h3 class="mt-4">Append-icon</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					append-icon
				/>

				<h3>No Calendar</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					no-calendar
				/>

				<h3>TextField Activator</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					text-field-activator
				/>

				<h3 class="mt-4">Show weekends</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					show-weekends
				/>

				<h3 class="mt-4">Disabled</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					disabled
				/>

				<h3 class="mt-4">Outlined</h3>
				<date-picker
					v-model="date"
					label="Date"
					:hint="defaultHint"
					outlined
				/>

				<h3 class="mt-4">Birthdate</h3>
				<date-picker
					v-model="date"
					birthdate
					label="Date d'anniversaire"
					:hint="defaultHint"
				/>

				<h3 class="mt-4">Range</h3>
				<div>
					{{ dateRange }}
					<date-picker v-model="dateRange" range clearable outlined />
				</div>

				<h3 class="mt-4">DateFormat</h3>
				{{ dateToFormat }}
				<date-picker
					v-model="dateToFormat"
					label="Date"
					hint="JJ-MM-YYYY"
					dateFormat="DD-MM-YYYY"
				/>
				<h3 class="mt-4">DateFormatReturn</h3>
				{{ dateFormatReturn }}
				<date-picker
					v-model="dateFormatReturn"
					label="Date"
					:hint="defaultHint"
					dateFormatReturn="DD/MM/YY"
				/>
			</v-col>
		</v-row>
	</PageContainer>
</template>

<script lang="ts">
import DatePicker from '@/patterns/DatePicker/DatePicker.vue'
import { required } from '@/rules/required/index.ts'
import { notAfterToday } from '@/rules/notAfterToday/index.ts'
import { notBeforeToday } from '@/rules/notBeforeToday/index.ts'
import PageContainer from '@/elements/PageContainer/PageContainer.vue'
import dayjs from 'dayjs'
export default {
	emits: ['change'],
	components: {
		DatePicker,
		PageContainer,
	},
	data() {
		return {
			date: dayjs().format('DD/MM/YYYY'),
			date1: dayjs().add(2, 'day').format('DD/MM/YYYY'),
			dateRange: [
				dayjs().format('DD/MM/YYYY'),
				dayjs().add(12, 'day').format('DD/MM/YYYY'),
			],
			startDate: null,
			endDate: null,
			dateDefinie: dayjs().format('DD/MM/YYYY'),
			dateToFormat: dayjs().format('DD/MM/YYYY'),
			dateFormatReturn: dayjs().format('DD/MM/YYYY'),
			validRules: [required],
			notAfterTodayRules: [notAfterToday],
			notBeforeTodayRules: [notBeforeToday],
			defaultHint: 'Format JJ/MM/YYYY',
			warningRules: [notAfterToday, notBeforeToday],
		}
	},
	mounted() {
		const date = dayjs().add(8, 'day').format('DD/MM/YYYY')
		const date1 = dayjs().add(10, 'day').format('DD/MM/YYYY')
		const startDate = dayjs().add(18, 'day').format('DD/MM/YYYY')
		const endDate = dayjs().add(21, 'day').format('DD/MM/YYYY')

		this.dateRange = [date, date1]

		setTimeout(() => {
			this.date = date
		}, 4000)
		setTimeout(() => {
			this.date1 = date1
		}, 4000)
		setTimeout(() => {
			this.dateRange = [startDate, endDate]
		}, 5000)
	},
	methods: {
		notAfterToday,
		handleDateChange(value: any) {
			console.log('Date changed to ' + value)
		},
	},
}
</script>

-->

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
// Copiez-collez le contenu de votre Playground.vue entier ici
```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
