### PR TITLE
refactor: Improve focus handling in SelectBtnField component

### DIFF
--- a/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
+++ b/packages/form-builder/src/components/FormBuilder/tests/__snapshots__/FormBuilder.spec.ts.snap
@@ -395,15 +395,14 @@ exports[`FormBuilder renders correctly 1`] = `
       <!---->
       <div>
         <div class="vd-select-btn-field" type="choiceButton">
-          <div class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle" role="listbox"><button type="button" value="1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Oui
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="0" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Non
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button></div>
+          <ul class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle">
+            <li class="vd-select-list-item"><button type="button" value="1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Oui
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="0" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Non
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+          </ul>
           <p class="v-messages px-3 mt-2 mb-0 theme--light">
             Vous pourrez choisir le moyen de contact
           </p>
@@ -418,23 +417,20 @@ exports[`FormBuilder renders correctly 1`] = `
       <!---->
       <div>
         <div class="vd-select-btn-field vd-form-input" type="choiceButton">
-          <div class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column" role="listbox"><button type="button" value="test1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Multiple 1
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="22" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Multiple 2
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="33" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Seul 1
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="44" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Seul 2
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button></div>
+          <ul class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column">
+            <li class="vd-select-list-item"><button type="button" value="test1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Multiple 1
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="22" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Multiple 2
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="33" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Seul 1
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="44" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Seul 2
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+          </ul>
           <!---->
         </div>
         <!---->
@@ -447,15 +443,14 @@ exports[`FormBuilder renders correctly 1`] = `
       <!---->
       <div>
         <div class="vd-select-btn-field vd-form-input" type="choiceButton">
-          <div class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column" role="listbox"><button type="button" value="1" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Texte qui permet de tester sur plusieurs lignes
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="2" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Texte 2
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button></div>
+          <ul class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column">
+            <li class="vd-select-list-item"><button type="button" value="1" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" aria-label="Sélectionné"><span class="v-btn__content"><span class="text-body-1">
+					Texte qui permet de tester sur plusieurs lignes
+				</span> <span class="spacer"></span> <span role="img" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="2" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Texte 2
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+          </ul>
           <!---->
         </div>
         <!---->
@@ -468,23 +463,20 @@ exports[`FormBuilder renders correctly 1`] = `
       <!---->
       <div>
         <div class="vd-select-btn-field vd-form-input" type="choiceButton" outlined="true">
-          <div class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column" aria-label="Classic field" role="listbox"><button type="button" value="0" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" role="option"><span class="v-btn__content"><span class="text-body-1">
-				S
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="1" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" role="option"><span class="v-btn__content"><span class="text-body-1">
-				M
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="2" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				L
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="3" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				XL
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button></div>
+          <ul class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column" aria-label="Classic field">
+            <li class="vd-select-list-item"><button type="button" value="0" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" aria-label="Sélectionné"><span class="v-btn__content"><span class="text-body-1">
+					S
+				</span> <span class="spacer"></span> <span role="img" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="1" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" aria-label="Sélectionné"><span class="v-btn__content"><span class="text-body-1">
+					M
+				</span> <span class="spacer"></span> <span role="img" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="2" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					L
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="3" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					XL
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+          </ul>
           <!---->
         </div>
         <div class="v-input vd-form-input v-input--is-label-active v-input--is-dirty v-input--dense theme--dark v-text-field v-text-field--enclosed v-text-field--outlined v-text-field--placeholder">
@@ -563,15 +555,14 @@ exports[`FormBuilder renders correctly 1`] = `
       </p>
       <div>
         <div class="vd-select-btn-field" outlined="true" type="choiceButton">
-          <div class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle" role="listbox"><button type="button" value="oui" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Oui
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button><button type="button" value="non" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Non
-			</span>
-              <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-            </button></div>
+          <ul class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle">
+            <li class="vd-select-list-item"><button type="button" value="oui" class="v-btn white--text v-btn--active v-btn--has-bg theme--light elevation-0 v-size--default primary" style="height: auto; min-height: 40px;" aria-selected="true" aria-label="Sélectionné"><span class="v-btn__content"><span class="text-body-1">
+					Oui
+				</span> <span class="spacer"></span> <span role="img" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: visible;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+            <li class="vd-select-list-item"><button type="button" value="non" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Non
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+          </ul>
           <!---->
         </div>
         <transition-stub name="expand-transition">

--- a/packages/form-builder/src/components/FormField/fields/tests/__snapshots__/ChoiceField.spec.ts.snap
+++ b/packages/form-builder/src/components/FormField/fields/tests/__snapshots__/ChoiceField.spec.ts.snap
@@ -45,19 +45,17 @@ exports[`ChoiceField renders the other field when the corresponding choice is se
 exports[`ChoiceField renders with multiple error messages 1`] = `
 <div>
   <div class="vd-select-btn-field vd-form-input" type="choiceButton">
-    <div class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column" role="listbox"><button type="button" value="0" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				S
-			</span>
-        <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-      </button><button type="button" value="1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				M
-			</span>
-        <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-      </button><button type="button" value="autre" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Autre
-			</span>
-        <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-      </button></div>
+    <ul class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column">
+      <li class="vd-select-list-item"><button type="button" value="0" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					S
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+      <li class="vd-select-list-item"><button type="button" value="1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					M
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+      <li class="vd-select-list-item"><button type="button" value="autre" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Autre
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+    </ul>
     <p class="v-messages error--text px-3 mt-2 mb-0 theme--light">
       Erreur 1
     </p>
@@ -72,19 +70,17 @@ exports[`ChoiceField renders with multiple error messages 1`] = `
 exports[`ChoiceField renders with single error message 1`] = `
 <div>
   <div class="vd-select-btn-field vd-form-input" type="choiceButton">
-    <div class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column" role="listbox"><button type="button" value="0" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				S
-			</span>
-        <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-      </button><button type="button" value="1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				M
-			</span>
-        <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-      </button><button type="button" value="autre" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" role="option"><span class="v-btn__content"><span class="text-body-1">
-				Autre
-			</span>
-        <div class="spacer"></div> <span aria-hidden="true" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span>
-      </button></div>
+    <ul class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text v-item-group theme--light v-btn-toggle flex-column">
+      <li class="vd-select-list-item"><button type="button" value="0" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					S
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+      <li class="vd-select-list-item"><button type="button" value="1" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					M
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+      <li class="vd-select-list-item"><button type="button" value="autre" class="v-btn v-btn--outlined theme--light elevation-0 v-size--default primary--text" style="height: auto; min-height: 40px;" aria-label=""><span class="v-btn__content"><span class="text-body-1">
+					Autre
+				</span> <span class="spacer"></span> <span aria-hidden="true" role="img" hidden="hidden" aria-label="Sélectionné" class="v-icon notranslate theme--light white--text flex-shrink-0 ml-1" style="visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg></span></span></button></li>
+    </ul>
     <p class="v-messages error--text px-3 mt-2 mb-0 theme--light">
       Erreur
     </p>

--- a/packages/vue-dot/src/patterns/SelectBtnField/SelectBtnField.vue
+++ b/packages/vue-dot/src/patterns/SelectBtnField/SelectBtnField.vue
@@ -5,40 +5,51 @@
 	>
 		<VBtnToggle
 			v-bind="options.btnToggle"
+			tag="ul"
 			:value="internalValue"
 			:multiple="multiple"
-			:class="{ 'flex-column': !inline }"
 			:aria-label="label"
-			role="listbox"
 			class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text"
+			:class="{ 'flex-column': !inline }"
 		>
-			<VBtn
+			<li
 				v-for="(item, index) in filteredItems"
-				v-bind="options.btn"
 				:key="index"
-				:value="item.value"
-				:outlined="!isSelected(item.value)"
-				:elevation="0"
-				:color="error ? 'error' : 'primary'"
-				:class="{ 'error--text': error }"
-				:aria-selected="isSelected(item.value)"
-				role="option"
-				:aria-readonly="readonly"
-				@click="toggleItem(item)"
+				class="vd-select-list-item"
 			>
-				<span class="text-body-1">
-					{{ item.text }}
-				</span>
-
-				<VSpacer v-bind="options.spacer" />
-
-				<VIcon
-					v-bind="options.icon"
-					:style="getIconStyles(item)"
+				<VBtn
+					v-bind="options.btn"
+					:value="item.value"
+					:outlined="!isSelected(item.value)"
+					:elevation="0"
+					:color="error ? 'error' : 'primary'"
+					:class="{ 'error--text': error }"
+					:aria-selected="isSelected(item.value)"
+					:aria-label="isSelected(item.value)? 'Sélectionné' : ''"
+					:aria-readonly="readonly"
+					@click="toggleItem(item)"
 				>
-					{{ checkIcon }}
-				</VIcon>
-			</VBtn>
+					<span class="text-body-1">
+						{{ item.text }}
+					</span>
+
+					<VSpacer
+						v-bind="options.spacer"
+						tag="span"
+					/>
+
+					<VIcon
+						v-bind="options.icon"
+						:style="getIconStyles(item)"
+						role="img"
+						:hidden="!isSelected(item.value)"
+						:aria-hidden="!isSelected(item.value)"
+						aria-label="Sélectionné"
+					>
+						{{ checkIcon }}
+					</VIcon>
+				</VBtn>
+			</li>
 		</VBtnToggle>
 
 		<template v-if="errorMessages">
@@ -227,15 +238,6 @@
 	.vd-select-btn-field-toggle {
 		background: none !important;
 
-		&.flex-column .v-btn {
-			border-radius: 4px !important;
-			border-width: 1px !important;
-
-			+ .v-btn {
-				margin-top: 8px;
-			}
-		}
-
 		.v-btn {
 			background: #fff;
 
@@ -246,6 +248,27 @@
 			:deep(.v-btn__content) {
 				flex-shrink: 1 !important;
 			}
+
+			:deep(.v-icon__svg) {
+				height: 1.5rem;
+				width: 1.5rem;
+			}
+		}
+
+		&.flex-column {
+			.v-btn {
+				border-radius: 4px !important;
+				border-width: 1px !important;
+			}
+
+			.vd-select-list-item + .vd-select-list-item .v-btn {
+				margin-top: 8px;
+			}
+		}
+
+		.vd-select-list-item {
+			all: unset;
+			display: contents;
 		}
 
 		&.theme--dark {

--- a/packages/vue-dot/src/patterns/SelectBtnField/tests/__snapshots__/SelectBtnField.spec.ts.snap
+++ b/packages/vue-dot/src/patterns/SelectBtnField/tests/__snapshots__/SelectBtnField.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`SelectBtnField renders correctly 1`] = `
 <div class="vd-select-btn-field vd-form-input">
-  <vbtntoggle-stub valuecomparator="[Function]" activeclass="v-item--active" tag="div" role="listbox" class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text flex-column"></vbtntoggle-stub>
+  <vbtntoggle-stub valuecomparator="[Function]" activeclass="v-item--active" tag="ul" class="vd-select-btn-field-toggle d-flex overflow-y-auto primary--text flex-column"></vbtntoggle-stub>
   <!---->
 </div>
 `;


### PR DESCRIPTION
## Description

- [x] Supprimer l'attribut aria-hidden="true" sur le span et le SVG
- [x] Lorsque le bouton n'est pas sélectionné, ajouter un attribut hidden sur le SPAN et le SVG pour masquer réellement ces éléments à tous
- [x] Changer les balises DIV en balises SPAN pour celles qui sont imbriquées dans une balise BUTTON
- [x] Ajouter un attribut aria-label="Sélectionné" au niveau de la balise
- [x] Ajouter des balises de liste non ordonnée pour identifier les éléments de réponses
- [x] Faire en sorte que le picto "check" grandisse en zoom texte seulement, 200% minimum.
- [x] Supprimer l'attribut role="option" et role="listbox"

## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<template>
	<SelectBtnField
		v-model="value"
		:items="items"
		label="Moyen de contact"
	/>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { SelectBtnItem } from '@cnamts/vue-dot/src/patterns/SelectBtnField/types';

	@Component
	export default class SelectBtnFieldUsage extends Vue {
		value: string[] = [];

		items: SelectBtnItem[] = [
			{
				text: 'Email',
				value: 'email'
			},
			{
				text: 'Courrier',
				value: 'courrier'
			},
			{
				text: 'SMS',
				value: 'sms'
			}
		];
	}
</script>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
