### PR TITLE
DatePicker : add no-icon prop

### DIFF
--- a/packages/docs/src/data/api/date-picker-bridge.ts
+++ b/packages/docs/src/data/api/date-picker-bridge.ts
@@ -28,6 +28,12 @@ export const api: Api = {
 				description: 'Masque l’icône avant le `VTextField`.'
 			},
 			{
+				name: 'no-icon',
+				type: 'boolean',
+				default: false,
+				description: 'Masque l’icône avant et après le `VTextField`.'
+			},
+			{
 				name: 'append-icon',
 				type: 'boolean',
 				default: false,

--- a/packages/docs/src/data/api/date-picker.ts
+++ b/packages/docs/src/data/api/date-picker.ts
@@ -28,6 +28,12 @@ export const api: Api = {
 				description: 'Masque l’icône avant le `VTextField`.'
 			},
 			{
+				name: 'no-icon',
+				type: 'boolean',
+				default: false,
+				description: 'Masque l’icône avant et après le `VTextField`.'
+			},
+			{
 				name: 'append-icon',
 				type: 'boolean',
 				default: false,

--- a/packages/docs/src/data/examples/date-picker/usage.vue
+++ b/packages/docs/src/data/examples/date-picker/usage.vue
@@ -20,6 +20,7 @@
 			booleans: [
 				'noCalendar',
 				'noPrependIcon',
+				'noIcon',
 				'appendIcon',
 				'textFieldActivator',
 				'showWeekends',

--- a/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
+++ b/packages/vue-dot/src/patterns/DatePicker/DatePicker.vue
@@ -131,6 +131,10 @@
 				type: Boolean,
 				default: false
 			},
+			noIcon: {
+				type: Boolean,
+				default: false
+			},
 			outlined: {
 				type: Boolean,
 				default: false
@@ -181,11 +185,11 @@
 		menu = false;
 
 		get showPrependIcon(): boolean {
-			return !this.noPrependIcon && !this.showAppendIcon;
+			return !this.noPrependIcon && !this.showAppendIcon && !this.noIcon;
 		}
 
 		get showAppendIcon(): boolean {
-			return this.appendIcon || this.outlined;
+			return this.appendIcon || this.outlined && !this.noIcon;
 		}
 
 		get menuOptions(): Options {
@@ -209,6 +213,10 @@
 			}
 
 			if (!this.showPrependIcon) {
+				textFieldClasses.push('vd-no-prepend-icon');
+			}
+
+			if (this.noIcon) {
 				textFieldClasses.push('vd-no-prepend-icon');
 			}
 


### PR DESCRIPTION
## Description

Ajout d'une prop permettant de masquer l'icone calendar en mode outlined

## Playground

<details>

```vue
<template>
	<div>
		<DatePicker
			v-model="birthdate"
			label="Date de naissance"
			birthdate
			no-icon
		/>

		<p
			v-if="birthdate"
			class="mt-4 mb-0"
		>
			Date saisie : {{ birthdate }}
		</p>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	@Component
	export default class DatePickerBirthdate extends Vue {
		birthdate: string | null = null;
	}
</script>

```

</details>

## Type de changement

- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
