### PR TITLE
retirer la validation de la clé en mode sinple

### DIFF
--- a/packages/synapse-bridge/src/patterns/NirField/NirField.vue
+++ b/packages/synapse-bridge/src/patterns/NirField/NirField.vue
@@ -101,8 +101,6 @@ export default defineComponent({
 
 			numberErrors: [] as string[],
 			keyErrors: [] as string[],
-
-			isSingleField: false,
 		}
 	},
 	watch: {
@@ -126,14 +124,16 @@ export default defineComponent({
 				this.keyValue = newValue.slice(NUMBER_LENGTH, DOUBLE_FIELD)
 
 				this.validateNumberValue(this.numberValue)
-				this.validateKeyValue(this.keyValue)
+				if (!this.isSingleField) {
+					this.validateKeyValue(this.keyValue)
+				}
 			},
 		},
 	},
-	created(): void {
-		this.isSingleField = this.nirLength === SINGLE_FIELD
-	},
 	computed: {
+		isSingleField(): boolean {
+			return this.nirLength === SINGLE_FIELD
+		},
 		textFieldOptions() {
 			return deepMerge(config, this.$attrs)
 		},
@@ -159,6 +159,9 @@ export default defineComponent({
 		 * Generate the validation rules for the key field
 		 */
 		keyRules(): ValidationRule[] {
+			if (this.isSingleField) {
+				return []
+			}
 			let rules = [
 				exactLength(KEY_LENGTH, true, {
 					default: locales.errorLengthKey,

--- a/packages/synapse-bridge/src/patterns/NirField/tests/NirField.spec.ts
+++ b/packages/synapse-bridge/src/patterns/NirField/tests/NirField.spec.ts
@@ -574,4 +574,22 @@ describe('NirField', () => {
 		expect(wrapper.text()).toContain(locales.errorRequiredNumber)
 		expect(wrapper.text()).toContain(locales.errorRequiredKey)
 	})
+
+	it('do not validate the key field in single field mode', async () => {
+		const wrapper = mount(NirField, {
+			global: {
+				plugins: [vuetify],
+			},
+			propsData: {
+				modelValue: '1234567890123',
+				nirLength: 13,
+				required: true,
+			},
+		})
+
+		await wrapper.setProps({ modelValue: '' })
+
+		expect(wrapper.text()).toContain(locales.errorRequiredNumber)
+		expect(wrapper.text()).not.toContain(locales.errorRequiredKey)
+	});
 })


### PR DESCRIPTION
## Description



## Playground

<!-- Copiez-collez votre playground pour tester vos changements -->

<details>

```vue
<script setup lang="ts">

import NirField from '@/patterns/NirField/NirField.vue';

import { ref } from 'vue';

const nir = ref('1234567890123');


</script>

<template>
  <div>
	<NirField
	  v-model="nir"
	  :required="true"
	  :nir-length="13"
	/>
  </div>
</template>

<style lang="scss" scoped></style>

```

</details>

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
