### PR TITLE
DialogBox: fix aria

### DIFF
--- a/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
+++ b/packages/vue-dot/src/elements/DialogBox/DialogBox.vue
@@ -11,7 +11,7 @@
 		<VCard
 			v-bind="options.card"
 			ref="dialogContent"
-			aria-describedby="dialogContent"
+			aria-labelledby="dialogContent"
 		>
 			<VCardTitle v-bind="options.cardTitle">
 				<slot name="title">

--- a/packages/vue-dot/src/elements/DialogBox/tests/__snapshots__/DialogBox.spec.ts.snap
+++ b/packages/vue-dot/src/elements/DialogBox/tests/__snapshots__/DialogBox.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`DialogBox renders correctly 1`] = `
 <vdialog-stub contentclass="" opendelay="0" closedelay="0" openonclick="true" origin="center center" retainfocus="true" transition="dialog-transition" width="800px" aria-modal="true" class="vd-dialog-box">
-  <vcard-stub loaderheight="4" tag="div" aria-describedby="dialogContent" class="pa-6">
+  <vcard-stub loaderheight="4" tag="div" aria-labelledby="dialogContent" class="pa-6">
     <vcardtitle-stub tag="div" class="d-flex align-start flex-nowrap pa-0 mb-6">
       <!---->
       <vspacer-stub tag="div"></vspacer-stub>


### PR DESCRIPTION
## Description

Add aria-labelledby on component 

## Playground

<details>

```vue
<template>
	<div>
		<VBtn
			color="primary"
			@click="dialog = true"
		>
			Afficher le composant
		</VBtn>

		<DialogBox
			v-model="dialog"
			:width="dialogWidth"
			title="Enregistrement"
			@cancel="dialog = false"
			@confirm="dialog = false"
		>
			<p>Souhaitez-vous procéder à l’enregistrement ?</p>
		</DialogBox>
	</div>
</template>

<script lang="ts">
	import Vue from 'vue';
	import Component from 'vue-class-component';

	import { tokens } from '@cnamts/design-tokens';

	@Component
	export default class DialogBoxWidth extends Vue {
		dialog = false;

		dialogWidth = tokens.dialogWidth.dialogSmall;
	}
</script>
```

</details>

## Type de changement

- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
