### PR TITLE
Update boostrapColors.ts to use type import

### DIFF
--- a/packages/design-tokens/src/boostrapColors.ts
+++ b/packages/design-tokens/src/boostrapColors.ts
@@ -1,4 +1,4 @@
-import { PaletteBootstrap } from './types';
+import type { PaletteBootstrap } from './types';
 
 export const paletteBootstrap: PaletteBootstrap = {
 	amBlue: {


### PR DESCRIPTION
## Description

En essayant de faire plaisir au SonarQube je me retrouve a devoir enlever une option
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/ffd7df21-eaf6-480e-a8a6-f4207d7d2af5"> que j'avais mise par rapport a cette lib il me semble


## Type de changement
- Maintenance

## Checklist


- [ ] Ma Pull Request pointe vers la bonne branche
- [x] Mon code suit le style de code du projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai apporté les modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
- [ ] J'ai mis à jour le fichier Changelog
